### PR TITLE
Correction of an error when retrieving a VscConverterStation by id fr…

### DIFF
--- a/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStorageTestCaseFactory.java
+++ b/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStorageTestCaseFactory.java
@@ -99,8 +99,8 @@ public final class NetworkStorageTestCaseFactory {
                 .setActivePowerSetpoint(330)
                 .setNominalV(335)
                 .setMaxP(390)
-                .setConverterStationId1("id536")
-                .setConverterStationId2("id1089")
+                .setConverterStationId1("VSC1")
+                .setConverterStationId2("VSC2")
                 .add();
         vscConverterStation1.getTerminal().setP(445);
         vscConverterStation1.getTerminal().setQ(325);

--- a/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreIT.java
+++ b/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreIT.java
@@ -325,8 +325,8 @@ public class NetworkStoreIT {
             assertEquals(hvdcLine.getActivePowerSetpoint(), 330, 0.1);
             assertEquals(hvdcLine.getNominalV(), 335, 0.1);
             assertEquals(hvdcLine.getMaxP(), 390, 0.1);
-            //assertEquals(hvdcLine.getConverterStation1(), "id536");
-            //assertEquals(hvdcLine.getConverterStation2(), "id1089");
+            assertEquals(hvdcLine.getConverterStation1().getId(), "VSC1");
+            assertEquals(hvdcLine.getConverterStation2().getId(), "VSC2");
         }
     }
 

--- a/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreRepository.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreRepository.java
@@ -992,9 +992,9 @@ public class NetworkStoreRepository {
                             .reactivePowerSetPoint(row.getDouble(6))
                             .voltageSetPoint(row.getDouble(7))
                             .reactiveLimits(minMaxReactiveLimitsAttributes != null ? minMaxReactiveLimitsAttributes : reactiveCapabilityCurveAttributes)
-                            .p(row.getDouble(9))
-                            .q(row.getDouble(10))
-                            .position(row.get(11, ConnectablePositionAttributes.class))
+                            .p(row.getDouble(10))
+                            .q(row.getDouble(11))
+                            .position(row.get(12, ConnectablePositionAttributes.class))
                             .build())
                     .build());
         }


### PR DESCRIPTION
…om repository

Signed-off-by: NOIR Nicolas ext <nicolas.noir@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
This PR fixes a bug when retrieving a VscConverterStation by Id from the storage repository


**What is the current behavior?** *(You can also link to an open issue here)*
When getting a VscConverterStation from storage repository (by using the getVscConverterStation(String Id) method on the client side), the following exception is thrown:
com.datastax.driver.core.exceptions.CodecNotFoundException: Codec not found for requested operation: [iidm.reactivecapabilitycurve <-> java.lang.Double]

This is due to an incorrect mapping of the Cassandra query result.  


**What is the new behavior (if this is a feature change)?**


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
