### PR TITLE
Corrections of cgmes import bugs

### DIFF
--- a/network-store-client/src/main/java/com/powsybl/network/store/client/VoltageLevelImpl.java
+++ b/network-store-client/src/main/java/com/powsybl/network/store/client/VoltageLevelImpl.java
@@ -380,6 +380,9 @@ public class VoltageLevelImpl extends AbstractIdentifiableImpl<VoltageLevel, Vol
         for (VscConverterStation station : getVscConverterStations()) {
             visitor.visitHvdcConverterStation(station);
         }
+        for (LccConverterStation station : index.getLccConverterStations(resource.getId())) {
+            visitor.visitHvdcConverterStation(station);
+        }
         for (TwoWindingsTransformer twt : index.getTwoWindingsTransformers(resource.getId())) {
             visitor.visitTwoWindingsTransformer(twt, twt.getSide(twt.getTerminal(resource.getId())));
         }

--- a/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreRepository.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreRepository.java
@@ -2002,9 +2002,11 @@ public class NetworkStoreRepository {
     }
 
     public List<Resource<TwoWindingsTransformerAttributes>> getVoltageLevelTwoWindingsTransformers(UUID networkUuid, String voltageLevelId) {
-        return ImmutableList.<Resource<TwoWindingsTransformerAttributes>>builder()
-                .addAll(getVoltageLevelTwoWindingsTransformers(networkUuid, Branch.Side.ONE, voltageLevelId))
-                .addAll(getVoltageLevelTwoWindingsTransformers(networkUuid, Branch.Side.TWO, voltageLevelId))
+        return ImmutableList.<Resource<TwoWindingsTransformerAttributes>>builder().addAll(
+                ImmutableSet.<Resource<TwoWindingsTransformerAttributes>>builder()
+                        .addAll(getVoltageLevelTwoWindingsTransformers(networkUuid, Branch.Side.ONE, voltageLevelId))
+                        .addAll(getVoltageLevelTwoWindingsTransformers(networkUuid, Branch.Side.TWO, voltageLevelId))
+                        .build())
                 .build();
     }
 
@@ -2430,10 +2432,12 @@ public class NetworkStoreRepository {
     }
 
     public List<Resource<ThreeWindingsTransformerAttributes>> getVoltageLevelThreeWindingsTransformers(UUID networkUuid, String voltageLevelId) {
-        return ImmutableList.<Resource<ThreeWindingsTransformerAttributes>>builder()
-                .addAll(getVoltageLevelThreeWindingsTransformers(networkUuid, ThreeWindingsTransformer.Side.ONE, voltageLevelId))
-                .addAll(getVoltageLevelThreeWindingsTransformers(networkUuid, ThreeWindingsTransformer.Side.TWO, voltageLevelId))
-                .addAll(getVoltageLevelThreeWindingsTransformers(networkUuid, ThreeWindingsTransformer.Side.THREE, voltageLevelId))
+        return ImmutableList.<Resource<ThreeWindingsTransformerAttributes>>builder().addAll(
+                ImmutableSet.<Resource<ThreeWindingsTransformerAttributes>>builder()
+                        .addAll(getVoltageLevelThreeWindingsTransformers(networkUuid, ThreeWindingsTransformer.Side.ONE, voltageLevelId))
+                        .addAll(getVoltageLevelThreeWindingsTransformers(networkUuid, ThreeWindingsTransformer.Side.TWO, voltageLevelId))
+                        .addAll(getVoltageLevelThreeWindingsTransformers(networkUuid, ThreeWindingsTransformer.Side.THREE, voltageLevelId))
+                        .build())
                 .build();
     }
 

--- a/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreRepository.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreRepository.java
@@ -8,6 +8,7 @@ package com.powsybl.network.store.server;
 
 import com.datastax.driver.core.*;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.powsybl.iidm.network.*;
 import com.powsybl.network.store.model.*;
@@ -16,10 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
 import javax.annotation.PostConstruct;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 
 import static com.datastax.driver.core.querybuilder.QueryBuilder.*;
 import static com.powsybl.network.store.server.CassandraConstants.KEYSPACE_IIDM;
@@ -1980,10 +1978,10 @@ public class NetworkStoreRepository {
                             .position2(row.get(17, ConnectablePositionAttributes.class))
                             .phaseTapChangerAttributes(row.get(18, PhaseTapChangerAttributes.class))
                             .ratioTapChangerAttributes(row.get(19, RatioTapChangerAttributes.class))
-                            .bus1(row.getString(21))
-                            .bus2(row.getString(22))
-                            .connectableBus1(row.getString(23))
-                            .connectableBus2(row.getString(24))
+                            .bus1(row.getString(20))
+                            .bus2(row.getString(21))
+                            .connectableBus1(row.getString(22))
+                            .connectableBus2(row.getString(23))
                             .build())
                     .build());
         }
@@ -2618,9 +2616,11 @@ public class NetworkStoreRepository {
     }
 
     public List<Resource<LineAttributes>> getVoltageLevelLines(UUID networkUuid, String voltageLevelId) {
-        return ImmutableList.<Resource<LineAttributes>>builder()
+        return ImmutableList.<Resource<LineAttributes>>builder().addAll(
+                ImmutableSet.<Resource<LineAttributes>>builder()
                 .addAll(getVoltageLevelLines(networkUuid, Branch.Side.ONE, voltageLevelId))
                 .addAll(getVoltageLevelLines(networkUuid, Branch.Side.TWO, voltageLevelId))
+                .build())
                 .build();
     }
 

--- a/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreRepository.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreRepository.java
@@ -420,6 +420,7 @@ public class NetworkStoreRepository {
         batch.add(delete().from("switch").where(eq("networkUuid", uuid)));
         batch.add(delete().from("generator").where(eq("networkUuid", uuid)));
         batch.add(delete().from("load").where(eq("networkUuid", uuid)));
+        batch.add(delete().from("shuntcompensator").where(eq("networkUuid", uuid)));
         batch.add(delete().from("staticVarCompensator").where(eq("networkUuid", uuid)));
         batch.add(delete().from("vscConverterStation").where(eq("networkUuid", uuid)));
         batch.add(delete().from("lccConverterStation").where(eq("networkUuid", uuid)));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
This PR introduces various bug fixes discovered when trying to import and visualize a CGMES network:
Corrections of retrieval of lines, two and three windings transformers by voltage level, which used to return the same line (or transformer) twice in the returned list when the line (or transformer) had two of its extremities on the same voltage level. This caused the creation of an erroneous graph when visualizing the network in the single line diagram viewer.
Correction of the retrieval of twoWindingsTransformers by voltageLevel (error in the rows indexes)
ShuntCompensators are now removed when a network is deleted from the database.
Correction of the creations of the various elements of the network in database (some values were set to null in Cassandra insertion requests, which caused the creation of a lot of tombstones by Cassandra. The null values are now unset)



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
