### PR TITLE
Fix the multiple switches retrieval requests

### DIFF
--- a/network-store-client/src/main/java/com/powsybl/network/store/client/NodeBreakerViewImpl.java
+++ b/network-store-client/src/main/java/com/powsybl/network/store/client/NodeBreakerViewImpl.java
@@ -74,9 +74,7 @@ public class NodeBreakerViewImpl implements VoltageLevel.NodeBreakerView {
 
     @Override
     public BusbarSection getBusbarSection(String id) {
-        return getBusbarSectionStream()
-                .filter(busbarSection -> busbarSection.getId().equals(id))
-                .findFirst()
+        return index.getBusbarSection(id)
                 .orElse(null);
     }
 
@@ -127,9 +125,7 @@ public class NodeBreakerViewImpl implements VoltageLevel.NodeBreakerView {
     }
 
     public Switch getSwitch(String id) {
-        return getSwitchStream()
-                .filter(sw -> sw.getId().equals(id))
-                .findFirst()
+        return index.getSwitch(id)
                 .orElse(null);
     }
 


### PR DESCRIPTION
This fix doesn't fully solve the issue, since that instead of retrieving all switches each time we need to get a single switch (which was the cause of the issue), it only ensures that only the needed switch is retrieved (and not all).

Signed-off-by: NOIR Nicolas ext <nicolas.noir@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
#57 


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
