### PR TITLE
Remove 3wt flush

### DIFF
--- a/network-store-client/src/main/java/com/powsybl/network/store/client/BufferedRestNetworkStoreClient.java
+++ b/network-store-client/src/main/java/com/powsybl/network/store/client/BufferedRestNetworkStoreClient.java
@@ -183,7 +183,6 @@ public class BufferedRestNetworkStoreClient implements NetworkStoreClient {
 
     @Override
     public List<Resource<ThreeWindingsTransformerAttributes>> getVoltageLevelThreeWindingsTransformers(UUID networkUuid, String voltageLevelId) {
-        flush();
         return client.getVoltageLevelThreeWindingsTransformers(networkUuid, voltageLevelId);
     }
 
@@ -306,19 +305,16 @@ public class BufferedRestNetworkStoreClient implements NetworkStoreClient {
 
     @Override
     public List<Resource<ThreeWindingsTransformerAttributes>> getThreeWindingsTransformers(UUID networkUuid) {
-        flush();
         return client.getThreeWindingsTransformers(networkUuid);
     }
 
     @Override
     public Optional<Resource<ThreeWindingsTransformerAttributes>> getThreeWindingsTransformer(UUID networkUuid, String threeWindingsTransformerId) {
-        flush();
         return client.getThreeWindingsTransformer(networkUuid, threeWindingsTransformerId);
     }
 
     @Override
     public int getThreeWindingsTransformerCount(UUID networkUuid) {
-        flush();
         return client.getThreeWindingsTransformerCount(networkUuid);
     }
 


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
When getting 3 windings transformers from `BufferedRestNetworkStoreClient` already created resources are flushed.


**What is the new behavior (if this is a feature change)?**
flush have been removed (like for the other equipments)


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
