### PR TITLE
Add single line diagram JavaFX demo connected to network store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,4 @@
-/network-store-client/target/
-/network-store-integration-test/target/
-/network-store-model/target/
-/network-store-server/target/
-/target/
+target/
 
 # IntelliJ
 /.idea

--- a/network-store-demo/pom.xml
+++ b/network-store-demo/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2020, RTE (http://www.rte-france.com)
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.powsybl</groupId>
+        <artifactId>powsybl-network-store</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>powsybl-network-store-demo</artifactId>
+    <name>Network store demo</name>
+    <description>Network store demo using single line diagram JavaFX demo tool</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-single-line-diagram-view-app</artifactId>
+            <version>${powsybl-single-line-diagram.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-network-store-client</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/network-store-demo/src/main/java/com/powsybl/network/store/demo/ClientSingleLineDiagramViewer.java
+++ b/network-store-demo/src/main/java/com/powsybl/network/store/demo/ClientSingleLineDiagramViewer.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.network.store.demo;
+
+import com.powsybl.iidm.network.Network;
+import com.powsybl.network.store.client.NetworkStoreService;
+import com.powsybl.sld.view.app.AbstractSingleLineDiagramViewer;
+import javafx.geometry.Insets;
+import javafx.scene.Node;
+import javafx.scene.control.ComboBox;
+import javafx.scene.layout.BorderPane;
+import javafx.stage.Stage;
+
+import java.util.ArrayList;
+import java.util.UUID;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+public class ClientSingleLineDiagramViewer extends AbstractSingleLineDiagramViewer {
+
+    private NetworkStoreService service;
+
+    private final ComboBox<UUID> comboBoxIds = new ComboBox<>();
+
+    @Override
+    public void init() {
+        service = new NetworkStoreService("http://localhost:" + 8080 + "/");
+    }
+
+    @Override
+    public void start(Stage primaryStage) {
+        super.start(primaryStage);
+
+        BorderPane.setMargin(comboBoxIds, new Insets(3, 3, 3, 3));
+        comboBoxIds.setMaxWidth(Double.MAX_VALUE);
+        comboBoxIds.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) -> loadNetwork(newValue));
+        comboBoxIds.getItems().setAll(new ArrayList<>(service.getNetworkIds().keySet()));
+        if (!comboBoxIds.getItems().isEmpty()) {
+            comboBoxIds.getSelectionModel().select(0);
+        }
+    }
+
+    @Override
+    public void stop() throws Exception {
+        super.stop();
+        service.close();
+    }
+
+    protected Node createCasePane(Stage primaryStage) {
+        return comboBoxIds;
+    }
+
+    private void loadNetwork(UUID uuid) {
+        Network network = service.getNetwork(uuid);
+        setNetwork(network);
+    }
+
+    public static void main(String[] args) {
+        launch(args);
+    }
+}

--- a/network-store-demo/src/main/resources/logback.xml
+++ b/network-store-demo/src/main/resources/logback.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <Pattern>%d{yyyy-MM-dd_HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</Pattern>
+        </encoder>
+    </appender>
+
+    <logger name="com.powsybl.network.store.client.RestNetworkStoreClient" level="DEBUG" additivity="false">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,16 @@
                 <module>network-store-client</module>
             </modules>
         </profile>
+        <profile>
+            <id>demo</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <modules>
+                <module>network-store-demo</module>
+            </modules>
+        </profile>
+
     </profiles>
 
 </project>


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
feature


**What is the new behavior (if this is a feature change)?**
A customized version of single line diagram JavaFX demo connected to network store server. 


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
