### PR TITLE
Fix switch kind in case of bus/breaker topo

### DIFF
--- a/network-store-client/src/main/java/com/powsybl/network/store/client/SwitchAdderBusBreakerImpl.java
+++ b/network-store-client/src/main/java/com/powsybl/network/store/client/SwitchAdderBusBreakerImpl.java
@@ -7,6 +7,7 @@
 package com.powsybl.network.store.client;
 
 import com.powsybl.iidm.network.Switch;
+import com.powsybl.iidm.network.SwitchKind;
 import com.powsybl.iidm.network.VoltageLevel;
 import com.powsybl.network.store.model.Resource;
 import com.powsybl.network.store.model.SwitchAttributes;
@@ -89,6 +90,7 @@ class SwitchAdderBusBreakerImpl implements VoltageLevel.BusBreakerView.SwitchAdd
                         .name(name)
                         .bus1(bus1)
                         .bus2(bus2)
+                        .kind(SwitchKind.BREAKER)
                         .open(open)
                         .fictitious(fictitious)
                         .build())


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
In case of bus/breaker topology, switch kind is not set.


**What is the new behavior (if this is a feature change)?**
In case of bus/breaker topology, switch kind is set.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
