### PR TITLE
Implement HVDC converter station to HVDC line link

### DIFF
--- a/network-store-client/src/main/java/com/powsybl/network/store/client/AbstractHvdcConverterStationImpl.java
+++ b/network-store-client/src/main/java/com/powsybl/network/store/client/AbstractHvdcConverterStationImpl.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.network.store.client;
+
+import com.powsybl.iidm.network.ConnectableType;
+import com.powsybl.iidm.network.HvdcConverterStation;
+import com.powsybl.iidm.network.HvdcLine;
+import com.powsybl.network.store.model.InjectionAttributes;
+import com.powsybl.network.store.model.Resource;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+public abstract class AbstractHvdcConverterStationImpl<I extends HvdcConverterStation<I>, D extends InjectionAttributes> extends AbstractInjectionImpl<I, D> {
+
+    protected AbstractHvdcConverterStationImpl(NetworkObjectIndex index, Resource<D> resource) {
+        super(index, resource);
+    }
+
+    public ConnectableType getType() {
+        return ConnectableType.HVDC_CONVERTER_STATION;
+    }
+
+    public HvdcLine getHvdcLine() {
+        // TODO: to optimize later on, this won't work with a lot of HVDC lines
+        return index.getHvdcLines()
+                .stream()
+                .filter(hvdcLine -> hvdcLine.getConverterStation1().getId().equals(getId())
+                        || hvdcLine.getConverterStation2().getId().equals(getId()))
+                .findFirst()
+                .orElseThrow(IllegalStateException::new);
+    }
+}

--- a/network-store-client/src/main/java/com/powsybl/network/store/client/HvdcLineImpl.java
+++ b/network-store-client/src/main/java/com/powsybl/network/store/client/HvdcLineImpl.java
@@ -24,14 +24,22 @@ public class HvdcLineImpl extends AbstractIdentifiableImpl<HvdcLine, HvdcLineAtt
         return new HvdcLineImpl(index, resource);
     }
 
+    private HvdcConverterStation<?> getConverterStation(String id) {
+        HvdcConverterStation<?> converterStation = index.getVscConverterStation(id).orElse(null);
+        if (converterStation == null) {
+            converterStation = index.getLccConverterStation(id).orElseThrow(IllegalStateException::new);
+        }
+        return converterStation;
+    }
+
     @Override
     public HvdcConverterStation<?> getConverterStation1() {
-        return index.getVscConverterStation(resource.getAttributes().getConverterStationId1()).orElseThrow(AssertionError::new); // TODO LCC
+        return  getConverterStation(resource.getAttributes().getConverterStationId1());
     }
 
     @Override
     public HvdcConverterStation<?> getConverterStation2() {
-        return index.getVscConverterStation(resource.getAttributes().getConverterStationId2()).orElseThrow(AssertionError::new); // TODO LCC
+        return  getConverterStation(resource.getAttributes().getConverterStationId2());
     }
 
     @Override

--- a/network-store-client/src/main/java/com/powsybl/network/store/client/LccConverterStationImpl.java
+++ b/network-store-client/src/main/java/com/powsybl/network/store/client/LccConverterStationImpl.java
@@ -6,8 +6,6 @@
  */
 package com.powsybl.network.store.client;
 
-import com.powsybl.iidm.network.ConnectableType;
-import com.powsybl.iidm.network.HvdcLine;
 import com.powsybl.iidm.network.LccConverterStation;
 import com.powsybl.network.store.model.LccConverterStationAttributes;
 import com.powsybl.network.store.model.Resource;
@@ -15,7 +13,7 @@ import com.powsybl.network.store.model.Resource;
 /**
  * @author Nicolas Noir <nicolas.noir at rte-france.com>
  */
-public class LccConverterStationImpl extends AbstractInjectionImpl<LccConverterStation, LccConverterStationAttributes> implements LccConverterStation {
+public class LccConverterStationImpl extends AbstractHvdcConverterStationImpl<LccConverterStation, LccConverterStationAttributes> implements LccConverterStation {
 
     public LccConverterStationImpl(NetworkObjectIndex index, Resource<LccConverterStationAttributes> resource) {
         super(index, resource);
@@ -28,16 +26,6 @@ public class LccConverterStationImpl extends AbstractInjectionImpl<LccConverterS
     @Override
     protected LccConverterStation getInjection() {
         return this;
-    }
-
-    @Override
-    public ConnectableType getType() {
-        return ConnectableType.HVDC_CONVERTER_STATION;
-    }
-
-    @Override
-    public HvdcLine getHvdcLine() {
-        throw new UnsupportedOperationException("TODO");
     }
 
     @Override

--- a/network-store-client/src/main/java/com/powsybl/network/store/client/VscConverterStationImpl.java
+++ b/network-store-client/src/main/java/com/powsybl/network/store/client/VscConverterStationImpl.java
@@ -13,7 +13,7 @@ import com.powsybl.network.store.model.*;
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
-public class VscConverterStationImpl extends AbstractInjectionImpl<VscConverterStation, VscConverterStationAttributes> implements VscConverterStation, ReactiveLimitsOwner {
+public class VscConverterStationImpl extends AbstractHvdcConverterStationImpl<VscConverterStation, VscConverterStationAttributes> implements VscConverterStation, ReactiveLimitsOwner {
 
     public VscConverterStationImpl(NetworkObjectIndex index, Resource<VscConverterStationAttributes> resource) {
         super(index, resource);
@@ -26,16 +26,6 @@ public class VscConverterStationImpl extends AbstractInjectionImpl<VscConverterS
     @Override
     protected VscConverterStation getInjection() {
         return this;
-    }
-
-    @Override
-    public ConnectableType getType() {
-        return ConnectableType.HVDC_CONVERTER_STATION;
-    }
-
-    @Override
-    public HvdcLine getHvdcLine() {
-        throw new UnsupportedOperationException("TODO");
     }
 
     @Override

--- a/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreIT.java
+++ b/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreIT.java
@@ -369,6 +369,8 @@ public class NetworkStoreIT {
             assertEquals(390, hvdcLine.getMaxP(), 0.1);
             assertEquals("VSC1", hvdcLine.getConverterStation1().getId());
             assertEquals("VSC2", hvdcLine.getConverterStation2().getId());
+            assertEquals("HVDC1", hvdcLine.getConverterStation1().getHvdcLine().getId());
+            assertEquals("HVDC1", hvdcLine.getConverterStation2().getHvdcLine().getId());
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
HvdcConverterStation.getHvdcLine is not implemented.



**What is the new behavior (if this is a feature change)?**
HvdcConverterStation.getHvdcLine is implemented.



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
