### PR TITLE
Remove Groovy dependency from network store client by moving tools to…

### DIFF
--- a/network-store-client/pom.xml
+++ b/network-store-client/pom.xml
@@ -55,11 +55,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy</artifactId>
-            <version>${groovy.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.jgrapht</groupId>
             <artifactId>jgrapht-core</artifactId>
         </dependency>

--- a/network-store-integration-test/pom.xml
+++ b/network-store-integration-test/pom.xml
@@ -60,6 +60,12 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-network-store-tools</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>com.powsybl</groupId>
@@ -104,6 +110,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.google.jimfs</groupId>
+            <artifactId>jimfs</artifactId>
+            <version>${jimfs.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
@@ -111,6 +122,13 @@
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-tools</artifactId>
+            <version>${powsybl-core.version}</version>
+            <type>test-jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/network-store-integration-test/pom.xml
+++ b/network-store-integration-test/pom.xml
@@ -64,7 +64,6 @@
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-network-store-tools</artifactId>
             <version>${project.version}</version>
-            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/network-store-integration-test/pom.xml
+++ b/network-store-integration-test/pom.xml
@@ -60,11 +60,6 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.powsybl</groupId>
-            <artifactId>powsybl-network-store-tools</artifactId>
-            <version>${project.version}</version>
-        </dependency>
 
         <dependency>
             <groupId>com.powsybl</groupId>
@@ -87,6 +82,11 @@
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-network-store-server</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-network-store-tools</artifactId>
             <version>${project.version}</version>
         </dependency>
 

--- a/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreToolsIT.java
+++ b/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreToolsIT.java
@@ -29,7 +29,6 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Map;

--- a/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreToolsIT.java
+++ b/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreToolsIT.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.network.store.integration;
+
+import com.github.nosan.embedded.cassandra.api.connection.CqlSessionCassandraConnection;
+import com.github.nosan.embedded.cassandra.api.cql.CqlDataSet;
+import com.github.nosan.embedded.cassandra.spring.test.EmbeddedCassandra;
+import com.powsybl.network.store.client.NetworkStoreService;
+import com.powsybl.network.store.server.CassandraConfig;
+import com.powsybl.network.store.server.EmbeddedCassandraFactoryConfig;
+import com.powsybl.network.store.server.NetworkStoreApplication;
+import com.powsybl.network.store.tools.NetworkStoreDeleteTool;
+import com.powsybl.network.store.tools.NetworkStoreImportTool;
+import com.powsybl.network.store.tools.NetworkStoreListTool;
+import com.powsybl.network.store.tools.NetworkStoreScriptTool;
+import com.powsybl.tools.AbstractToolTest;
+import com.powsybl.tools.Tool;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Supplier;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ContextConfiguration(classes = {NetworkStoreApplication.class, CassandraConfig.class, NetworkStoreService.class,
+        EmbeddedCassandraFactoryConfig.class, CqlCassandraConnectionTestFactory.class})
+@EmbeddedCassandra(scripts = {"classpath:create_keyspace.cql", "classpath:iidm.cql"})
+public class NetworkStoreToolsIT extends AbstractToolTest {
+
+    @LocalServerPort
+    private int randomServerPort;
+
+    @Autowired
+    private CqlSessionCassandraConnection cqlSessionCassandraConnection;
+
+    private String getBaseUrl() {
+        return "http://localhost:" + randomServerPort + "/";
+    }
+
+    @Before
+    public void setup() throws Exception {
+        super.setUp();
+        CqlDataSet.ofClasspaths("truncate.cql").forEachStatement(cqlSessionCassandraConnection::execute);
+    }
+
+    @Override
+    protected Iterable<Tool> getTools() {
+        Supplier<NetworkStoreService> networkStoreServiceSupplier = () -> new NetworkStoreService(getBaseUrl());
+        return Arrays.asList(new NetworkStoreDeleteTool(networkStoreServiceSupplier),
+                             new NetworkStoreImportTool(networkStoreServiceSupplier),
+                             new NetworkStoreListTool(networkStoreServiceSupplier),
+                             new NetworkStoreScriptTool(networkStoreServiceSupplier));
+    }
+
+    @Override
+    public void assertCommand() {
+        try {
+            // import a xiidm file
+            Files.copy(getClass().getResourceAsStream("/test.xiidm"), fileSystem.getPath("/work/test.xiidm"));
+            assertCommand(new String[] {"network-store-import", "--input-file", "/work/test.xiidm"},
+                          0,
+                          "Importing file '/work/test.xiidm'...",
+                          "");
+
+            // get network UUID
+            UUID networkUuid;
+            try (NetworkStoreService networkStoreService = new NetworkStoreService(getBaseUrl())) {
+                Map<UUID, String> networkIds = networkStoreService.getNetworkIds();
+                assertEquals(1, networkIds.size());
+                networkUuid = networkIds.entrySet().iterator().next().getKey();
+            }
+
+            // list networks
+            assertCommand(new String[] {"network-store-list"},
+                          0,
+                          networkUuid + " : sim1",
+                          "");
+
+            // apply groovy script
+            Files.copy(getClass().getResourceAsStream("/test.groovy"), fileSystem.getPath("/work/test.groovy"));
+            assertCommand(new String[] {"network-store-script", "--network-uuid",  networkUuid.toString(), "--script-file", "/work/test.groovy"},
+                          0,
+                          "Applying '/work/test.groovy' on " + networkUuid + "..." + System.lineSeparator() + "id: sim1",
+                          "");
+
+            // delete network
+            assertCommand(new String[] {"network-store-delete", "--network-uuid",  networkUuid.toString()},
+                          0,
+                          "Deleting " + networkUuid + "...",
+                          "");
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreToolsIT.java
+++ b/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreToolsIT.java
@@ -67,13 +67,15 @@ public class NetworkStoreToolsIT extends AbstractToolTest {
 
     @Before
     public void setup() throws Exception {
-        super.setUp();
-        CqlDataSet.ofClasspaths("truncate.cql").forEachStatement(cqlSessionCassandraConnection::execute);
         Supplier<NetworkStoreService> networkStoreServiceSupplier = () -> new NetworkStoreService(getBaseUrl());
         deleteTool = new NetworkStoreDeleteTool(networkStoreServiceSupplier);
         importTool = new NetworkStoreImportTool(networkStoreServiceSupplier);
         listTool = new NetworkStoreListTool(networkStoreServiceSupplier);
         scriptTool = new NetworkStoreScriptTool(networkStoreServiceSupplier);
+
+        super.setUp();
+
+        CqlDataSet.ofClasspaths("truncate.cql").forEachStatement(cqlSessionCassandraConnection::execute);
     }
 
     @Override

--- a/network-store-integration-test/src/test/resources/test.groovy
+++ b/network-store-integration-test/src/test/resources/test.groovy
@@ -1,0 +1,1 @@
+print('id: ' + network.id)

--- a/network-store-tools/pom.xml
+++ b/network-store-tools/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2019, RTE (http://www.rte-france.com)
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>powsybl-network-store</artifactId>
+        <groupId>com.powsybl</groupId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>powsybl-network-store-tools</artifactId>
+    <name>Network store tools</name>
+
+    <dependencies>
+        <!-- compile scope -->
+        <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-iidm-converter-api</artifactId>
+            <version>${powsybl-core.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-tools</artifactId>
+            <version>${powsybl-core.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-network-store-client</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy</artifactId>
+            <version>${groovy.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/network-store-tools/src/main/java/com/powsybl/network/store/tools/NetworkStoreDeleteTool.java
+++ b/network-store-tools/src/main/java/com/powsybl/network/store/tools/NetworkStoreDeleteTool.java
@@ -17,7 +17,9 @@ import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 
+import java.util.Objects;
 import java.util.UUID;
+import java.util.function.Supplier;
 
 /**
  *
@@ -27,6 +29,16 @@ import java.util.UUID;
 public class NetworkStoreDeleteTool implements Tool {
 
     private static final String NETWORK_UUID = "network-uuid";
+
+    private final Supplier<NetworkStoreService> networkStoreServiceSupplier;
+
+    public NetworkStoreDeleteTool() {
+        this(() -> NetworkStoreService.create(NetworkStoreConfig.load()));
+    }
+
+    public NetworkStoreDeleteTool(Supplier<NetworkStoreService> networkStoreServiceSupplier) {
+        this.networkStoreServiceSupplier = Objects.requireNonNull(networkStoreServiceSupplier);
+    }
 
     @Override
     public Command getCommand() {
@@ -72,7 +84,9 @@ public class NetworkStoreDeleteTool implements Tool {
         ToolOptions toolOptions = new ToolOptions(line, context);
         UUID networkUuid = toolOptions.getValue(NETWORK_UUID).map(UUID::fromString).orElseThrow(() -> new IllegalArgumentException("Network ID is missing"));
 
-        try (NetworkStoreService service = NetworkStoreService.create(NetworkStoreConfig.load())) {
+        try (NetworkStoreService service = networkStoreServiceSupplier.get()) {
+            context.getOutputStream().println("Deleting " + networkUuid + "...");
+
             service.deleteNetwork(networkUuid);
         }
     }

--- a/network-store-tools/src/main/java/com/powsybl/network/store/tools/NetworkStoreListTool.java
+++ b/network-store-tools/src/main/java/com/powsybl/network/store/tools/NetworkStoreListTool.java
@@ -15,12 +15,25 @@ import com.powsybl.tools.ToolRunningContext;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
 
+import java.util.Objects;
+import java.util.function.Supplier;
+
 /**
  *
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 @AutoService(Tool.class)
 public class NetworkStoreListTool implements Tool {
+
+    private final Supplier<NetworkStoreService> networkStoreServiceSupplier;
+
+    public NetworkStoreListTool() {
+        this(() -> NetworkStoreService.create(NetworkStoreConfig.load()));
+    }
+
+    public NetworkStoreListTool(Supplier<NetworkStoreService> networkStoreServiceSupplier) {
+        this.networkStoreServiceSupplier = Objects.requireNonNull(networkStoreServiceSupplier);
+    }
 
     @Override
     public Command getCommand() {
@@ -55,7 +68,7 @@ public class NetworkStoreListTool implements Tool {
 
     @Override
     public void run(CommandLine line, ToolRunningContext context) {
-        try (NetworkStoreService service = NetworkStoreService.create(NetworkStoreConfig.load())) {
+        try (NetworkStoreService service = networkStoreServiceSupplier.get()) {
             service.getNetworkIds().forEach((key, value) -> context.getOutputStream().println(key + " : " + value));
         }
     }

--- a/network-store-tools/src/main/java/com/powsybl/network/store/tools/NetworkStoreListTool.java
+++ b/network-store-tools/src/main/java/com/powsybl/network/store/tools/NetworkStoreListTool.java
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package com.powsybl.network.store.client.tools;
+package com.powsybl.network.store.tools;
 
 import com.google.auto.service.AutoService;
 import com.powsybl.network.store.client.NetworkStoreConfig;

--- a/network-store-tools/src/main/java/com/powsybl/network/store/tools/NetworkStoreScriptTool.java
+++ b/network-store-tools/src/main/java/com/powsybl/network/store/tools/NetworkStoreScriptTool.java
@@ -27,7 +27,9 @@ import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Objects;
 import java.util.UUID;
+import java.util.function.Supplier;
 
 /**
  *
@@ -38,6 +40,16 @@ public class NetworkStoreScriptTool implements Tool {
 
     private static final String SCRIPT_FILE = "script-file";
     private static final String NETWORK_UUID = "network-uuid";
+
+    private final Supplier<NetworkStoreService> networkStoreServiceSupplier;
+
+    public NetworkStoreScriptTool() {
+        this(() -> NetworkStoreService.create(NetworkStoreConfig.load()));
+    }
+
+    public NetworkStoreScriptTool(Supplier<NetworkStoreService> networkStoreServiceSupplier) {
+        this.networkStoreServiceSupplier = Objects.requireNonNull(networkStoreServiceSupplier);
+    }
 
     @Override
     public Command getCommand() {
@@ -104,7 +116,7 @@ public class NetworkStoreScriptTool implements Tool {
         UUID networkUuid = toolOptions.getValue(NETWORK_UUID).map(UUID::fromString).orElseThrow(() -> new IllegalArgumentException("Network UUID is missing"));
         Path scriptFile = toolOptions.getPath(SCRIPT_FILE).orElseThrow(() -> new IllegalArgumentException("Script file is missing"));
 
-        try (NetworkStoreService service = NetworkStoreService.create(NetworkStoreConfig.load())) {
+        try (NetworkStoreService service = networkStoreServiceSupplier.get()) {
             Network network = service.getNetwork(networkUuid);
             if (scriptFile.toString().endsWith(".groovy")) {
                 context.getOutputStream().println("Applying '" + scriptFile + "' on " + networkUuid + "...");

--- a/network-store-tools/src/main/java/com/powsybl/network/store/tools/NetworkStoreScriptTool.java
+++ b/network-store-tools/src/main/java/com/powsybl/network/store/tools/NetworkStoreScriptTool.java
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package com.powsybl.network.store.client.tools;
+package com.powsybl.network.store.tools;
 
 import com.google.auto.service.AutoService;
 import com.powsybl.iidm.network.Network;

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
         <guava.version>28.2-jre</guava.version>
         <jgrapht.version>1.0.1</jgrapht.version>
         <jodatime.version>2.10.5</jodatime.version>
+        <jimfs.version>1.1</jimfs.version>
         <junit.version>4.12</junit.version>
         <lombok.version>1.18.10</lombok.version>
         <metricscore.version>3.2.6</metricscore.version>

--- a/pom.xml
+++ b/pom.xml
@@ -77,10 +77,11 @@
     </properties>
 
     <modules>
-        <module>network-store-server</module>
-        <module>network-store-model</module>
         <module>network-store-client</module>
         <module>network-store-integration-test</module>
+        <module>network-store-model</module>
+        <module>network-store-server</module>
+        <module>network-store-tools</module>
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
… another Maven module

Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
feature


**What is the current behavior?** *(You can also link to an open issue here)*
Network store client library depends on Groovy runtime because of tools (to apply a script to a network). The problem is that users of this client library very rarely need these tools and Groovy runtime is fat.
Furthermore embedding Groovy runtime in Java 11 cause lots of reflection warning especially on Spring boot services.

```bash
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.codehaus.groovy.vmplugin.v7.Java7$1 (file:/home/jamgotchiangeo/.m2/repository/org/codehaus/groovy/groovy/2.5.7/groovy-2.5.7.jar) to constructor java.lang.invoke.MethodHandles$Lookup(java.lang.Class,int)
WARNING: Please consider reporting this to the maintainers of org.codehaus.groovy.vmplugin.v7.Java7$1
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```

**What is the new behavior (if this is a feature change)?**
Tools have been moved to another artifact and can be added optionally.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
