### PR TITLE
Fix network object index

### DIFF
--- a/network-store-client/src/main/java/com/powsybl/network/store/client/NetworkObjectIndex.java
+++ b/network-store-client/src/main/java/com/powsybl/network/store/client/NetworkObjectIndex.java
@@ -109,9 +109,12 @@ public class NetworkObjectIndex {
                                                                                                           Function<Resource<U>, V> objectCreator) {
         V obj = (V) objectsById.get(id);
         if (obj == null) {
-            return resourceSupplier.get().map(objectCreator);
+            obj = resourceSupplier.get().map(objectCreator).orElse(null);
+            if (obj != null) {
+                objectsById.put(id, obj);
+            }
         }
-        return Optional.of(obj);
+        return Optional.ofNullable(obj);
     }
 
     private <T extends Identifiable<T>, U extends IdentifiableAttributes> T create(Map<String, T> objectsById,


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
When we get a single object from network (like network.getGenerator('A')), not the same instance is returned.


**What is the new behavior (if this is a feature change)?**
Same instance of the network object is returned to allow identity comparison.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
