### PR TITLE
Fix Cassandra tombstone issue

### DIFF
--- a/network-store-client/src/main/java/com/powsybl/network/store/client/AbstractTopology.java
+++ b/network-store-client/src/main/java/com/powsybl/network/store/client/AbstractTopology.java
@@ -319,10 +319,12 @@ public abstract class AbstractTopology<T> {
     }
 
     private CalculationResult getCalculatedBusAttributesList(NetworkObjectIndex index, Resource<VoltageLevelAttributes> voltageLevelResource) {
-        List<CalculatedBusAttributes> calculatedBusAttributesList = voltageLevelResource.getAttributes().getCalculatedBuses();
-        Map<T, Integer> nodeOrBusToCalculatedBusNum = getNodeOrBusToCalculatedBusNum(voltageLevelResource);
-
-        if (calculatedBusAttributesList == null || nodeOrBusToCalculatedBusNum == null) {
+        List<CalculatedBusAttributes> calculatedBusAttributesList;
+        Map<T, Integer> nodeOrBusToCalculatedBusNum;
+        if (voltageLevelResource.getAttributes().isCalculatedBusesValid()) {
+            calculatedBusAttributesList = voltageLevelResource.getAttributes().getCalculatedBuses();
+            nodeOrBusToCalculatedBusNum = getNodeOrBusToCalculatedBusNum(voltageLevelResource);
+        } else {
             calculatedBusAttributesList = findConnectedVerticesList(index, voltageLevelResource, AbstractTopology::busViewBusValidator)
                     .stream()
                     .map(connectedVertices -> new CalculatedBusAttributes(connectedVertices, null, null, Double.NaN, Double.NaN))
@@ -339,9 +341,11 @@ public abstract class AbstractTopology<T> {
                 }
             }
             setNodeOrBusToCalculatedBusNum(voltageLevelResource, nodeOrBusToCalculatedBusNum);
+
+            voltageLevelResource.getAttributes().setCalculatedBusesValid(true);
         }
 
-        return new CalculationResult(calculatedBusAttributesList, nodeOrBusToCalculatedBusNum);
+        return new CalculationResult<>(calculatedBusAttributesList, nodeOrBusToCalculatedBusNum);
     }
 
     public Map<String, Bus> calculateBuses(NetworkObjectIndex index, Resource<VoltageLevelAttributes> voltageLevelResource) {

--- a/network-store-client/src/main/java/com/powsybl/network/store/client/VoltageLevelImpl.java
+++ b/network-store-client/src/main/java/com/powsybl/network/store/client/VoltageLevelImpl.java
@@ -45,9 +45,7 @@ public class VoltageLevelImpl extends AbstractIdentifiableImpl<VoltageLevel, Vol
     }
 
     void invalidateCalculatedBuses() {
-        resource.getAttributes().setCalculatedBuses(null);
-        resource.getAttributes().setNodeToCalculatedBus(null);
-        resource.getAttributes().setBusToCalculatedBus(null);
+        resource.getAttributes().setCalculatedBusesValid(false);
         getNetwork().invalidateComponents();
     }
 

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/ActivePowerControlAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/ActivePowerControlAttributes.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.network.store.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.annotations.ApiModel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -20,6 +21,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @ApiModel("Active power control attributes")
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ActivePowerControlAttributes {
 
     private boolean participate;

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/BusAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/BusAttributes.java
@@ -6,7 +6,6 @@
  */
 package com.powsybl.network.store.model;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
@@ -26,15 +25,12 @@ import java.util.Map;
 @ApiModel("Bus attributes")
 public class BusAttributes implements IdentifiableAttributes {
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Bus name")
     private String name;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("fictitious")
     private boolean fictitious;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Properties")
     private Map<String, String> properties;
 }

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/BusbarSectionAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/BusbarSectionAttributes.java
@@ -7,7 +7,6 @@
 package com.powsybl.network.store.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.google.common.collect.ImmutableSet;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -32,15 +31,12 @@ public class BusbarSectionAttributes implements IdentifiableAttributes, RelatedV
     @ApiModelProperty("Voltage level ID")
     private String voltageLevelId;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Busbar section name")
     private String name;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Busbar section fictitious")
     private boolean fictitious;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Properties")
     private Map<String, String> properties;
 

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/BusbarSectionPositionAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/BusbarSectionPositionAttributes.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.network.store.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.annotations.ApiModel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -19,6 +20,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @ApiModel("Busbar section position attributes")
 public class BusbarSectionPositionAttributes {
 

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/CalculatedBusAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/CalculatedBusAttributes.java
@@ -21,17 +21,16 @@ import java.util.Set;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @ApiModel("CalculatedBus")
 public class CalculatedBusAttributes {
 
     @ApiModelProperty("Set of connected node/bus")
     private Set<Vertex> vertices;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Connected component number")
     private Integer connectedComponentNumber;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Synchronous component number")
     private Integer synchronousComponentNumber;
 

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/ConfiguredBusAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/ConfiguredBusAttributes.java
@@ -7,15 +7,10 @@
 package com.powsybl.network.store.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.google.common.collect.ImmutableSet;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 import java.util.Map;
 import java.util.Set;
@@ -32,31 +27,24 @@ import java.util.Set;
 @ApiModel("ConfiguredBus attributes")
 public class ConfiguredBusAttributes extends AbstractAttributes implements IdentifiableAttributes, RelatedVoltageLevelsAttributes {
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Bus id")
     private String id;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Bus name")
     private String name;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Bus fictitious")
     private boolean fictitious;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("voltage level id")
     private String voltageLevelId;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("bus voltage magnitude in Kv")
     private double v;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("voltage angle of the bus in degree")
     private double angle;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Properties")
     private Map<String, String> properties;
 

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/ConnectablePositionAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/ConnectablePositionAttributes.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.network.store.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.annotations.ApiModel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -19,6 +20,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @ApiModel("Connectable position attributes")
 public class ConnectablePositionAttributes {
 

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/CurrentLimitsAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/CurrentLimitsAttributes.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.network.store.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
@@ -22,6 +23,7 @@ import java.util.TreeMap;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @ApiModel("Current limits attributes")
 public class CurrentLimitsAttributes {
 

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/DanglingLineAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/DanglingLineAttributes.java
@@ -6,14 +6,9 @@
  */
 package com.powsybl.network.store.model;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 import java.util.Map;
 
@@ -31,15 +26,12 @@ public class DanglingLineAttributes extends AbstractAttributes implements Inject
     @ApiModelProperty("Voltage level ID")
     private String voltageLevelId;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Dangling line name")
     private String name;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("fictitious")
     private boolean fictitious;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Properties")
     private Map<String, String> properties;
 

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/GeneratorAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/GeneratorAttributes.java
@@ -6,15 +6,10 @@
  */
 package com.powsybl.network.store.model;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.powsybl.iidm.network.EnergySource;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 import java.util.Map;
 
@@ -32,15 +27,12 @@ public class GeneratorAttributes extends AbstractAttributes implements Injection
     @ApiModelProperty("Voltage level ID")
     private String voltageLevelId;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Generator name")
     private String name;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Generator fictitious")
     private boolean fictitious;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Properties")
     private Map<String, String> properties;
 

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/HvdcLineAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/HvdcLineAttributes.java
@@ -6,15 +6,10 @@
  */
 package com.powsybl.network.store.model;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.powsybl.iidm.network.HvdcLine;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 import java.util.Map;
 
@@ -29,15 +24,12 @@ import java.util.Map;
 @ApiModel("HVDC line attributes")
 public class HvdcLineAttributes extends AbstractAttributes implements IdentifiableAttributes {
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("HVDC line name")
     private String name;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("fictitious")
     private boolean fictitious;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Properties")
     private Map<String, String> properties;
 

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/IdentifiableAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/IdentifiableAttributes.java
@@ -6,11 +6,14 @@
  */
 package com.powsybl.network.store.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import java.util.Map;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public interface IdentifiableAttributes {
 
     String getName();

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/LccConverterStationAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/LccConverterStationAttributes.java
@@ -6,14 +6,9 @@
  */
 package com.powsybl.network.store.model;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 import java.util.Map;
 
@@ -31,19 +26,15 @@ public class LccConverterStationAttributes extends AbstractAttributes implements
     @ApiModelProperty("Voltage level ID")
     private String voltageLevelId;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("LCC converter station name")
     private String name;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("fictitious")
     private boolean fictitious;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Properties")
     private Map<String, String> properties;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Connection node in node/breaker topology")
     private Integer node;
 
@@ -53,23 +44,18 @@ public class LccConverterStationAttributes extends AbstractAttributes implements
     @ApiModelProperty("Possible connection bus in bus/breaker topology")
     private String connectableBus;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Power factor")
     private float powerFactor;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Loss factor")
     private float lossFactor;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Active power in MW")
     private double p;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Reactive power in MW")
     private double q;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Connectable position (for substation diagram)")
     private ConnectablePositionAttributes position;
 

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/LegAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/LegAttributes.java
@@ -21,6 +21,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @ApiModel("Three windings transformer leg attributes")
 public class LegAttributes implements TapChangerParentAttributes {
 
@@ -54,11 +55,9 @@ public class LegAttributes implements TapChangerParentAttributes {
     @ApiModelProperty("Leg number")
     private int legNumber;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("PhaseTapChangerAttributes")
     private PhaseTapChangerAttributes phaseTapChangerAttributes;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("RatioTapChangerAttributes")
     private RatioTapChangerAttributes ratioTapChangerAttributes;
 

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/LineAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/LineAttributes.java
@@ -6,14 +6,9 @@
  */
 package com.powsybl.network.store.model;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 import java.util.Map;
 
@@ -34,32 +29,25 @@ public class LineAttributes extends AbstractAttributes implements BranchAttribut
     @ApiModelProperty("Side 2 voltage level ID")
     private String voltageLevelId2;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Line name")
     private String name;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("fictitious")
     private boolean fictitious;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Properties")
     private Map<String, String> properties;
 
     @ApiModelProperty("Side 1 connection node in node/breaker topology")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private Integer node1;
 
     @ApiModelProperty("Side 2 connection node in node/breaker topology")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private Integer node2;
 
     @ApiModelProperty("Side 1 connection bus in bus/breaker topology")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private String bus1;
 
     @ApiModelProperty("Side 2 connection bus in bus/breaker topology")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private String bus2;
 
     @ApiModelProperty("Side 1 possible connection bus in bus/breaker topology")
@@ -105,15 +93,12 @@ public class LineAttributes extends AbstractAttributes implements BranchAttribut
     private ConnectablePositionAttributes position2;
 
     @ApiModelProperty("mergedXnode extension for tie lines")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private MergedXnodeAttributes mergedXnode;
 
     @ApiModelProperty("Current limits side 1")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private CurrentLimitsAttributes currentLimits1;
 
     @ApiModelProperty("Current limits side 2")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private CurrentLimitsAttributes currentLimits2;
 
     public LineAttributes(LineAttributes other) {

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/LoadAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/LoadAttributes.java
@@ -6,15 +6,10 @@
  */
 package com.powsybl.network.store.model;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.powsybl.iidm.network.LoadType;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 import java.util.Map;
 
@@ -32,15 +27,12 @@ public class LoadAttributes extends AbstractAttributes implements InjectionAttri
     @ApiModelProperty("Voltage level ID")
     private String voltageLevelId;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Load name")
     private String name;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("fictitious")
     private boolean fictitious;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Properties")
     private Map<String, String> properties;
 

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/MergedXnodeAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/MergedXnodeAttributes.java
@@ -21,42 +21,34 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @ApiModel("MergedXnode extension attributes")
 public class MergedXnodeAttributes {
 
     @ApiModelProperty("r divider position 1 -> 2")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private Float rdp;
 
     @ApiModelProperty("x divider position 1 -> 2")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private Float xdp;
 
     @ApiModelProperty("Xnode active power consumption in MW of side 1")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private Double xnodeP1;
 
     @ApiModelProperty("Xnode reactive power consumption in MW of side 1")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private Double xnodeQ1;
 
     @ApiModelProperty("Xnode active power consumption in MW of side 2")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private Double xnodeP2;
 
     @ApiModelProperty("Xnode reactive power consumption in MW of side 2")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private Double xnodeQ2;
 
     @ApiModelProperty("line name of side 1")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private String line1Name;
 
     @ApiModelProperty("line name of side 2")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private String line2Name;
 
     @ApiModelProperty("UCTE Xnode code corresponding to this line")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private String code;
 }

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/MinMaxReactiveLimitsAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/MinMaxReactiveLimitsAttributes.java
@@ -6,7 +6,6 @@
  */
 package com.powsybl.network.store.model;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.powsybl.iidm.network.ReactiveLimitsKind;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -25,15 +24,12 @@ import lombok.NoArgsConstructor;
 @ApiModel("Min max reactive limits attributes")
 public class MinMaxReactiveLimitsAttributes implements ReactiveLimitsAttributes {
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Kind of reactive limit")
     private final ReactiveLimitsKind kind = ReactiveLimitsKind.MIN_MAX;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Reactive power minimum value")
     private double minQ;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Reactive power maximum value")
     private double maxQ;
 

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/NetworkAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/NetworkAttributes.java
@@ -6,7 +6,6 @@
  */
 package com.powsybl.network.store.model;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.*;
@@ -29,15 +28,12 @@ public class NetworkAttributes extends AbstractAttributes implements Identifiabl
     @ApiModelProperty(value = "Network UUID", required = true)
     private UUID uuid;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Network name")
     private String name;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("fictitious")
     private boolean fictitious;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Properties")
     private Map<String, String> properties;
 
@@ -47,7 +43,6 @@ public class NetworkAttributes extends AbstractAttributes implements Identifiabl
     @ApiModelProperty("Forecast distance")
     private int forecastDistance = 0;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Source format")
     private String sourceFormat;
 

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/PhaseTapChangerAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/PhaseTapChangerAttributes.java
@@ -6,7 +6,6 @@
  */
 package com.powsybl.network.store.model;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.powsybl.iidm.network.PhaseTapChanger;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -27,19 +26,15 @@ import java.util.List;
 @ApiModel("PhaseTapChanger attributes")
 public class PhaseTapChangerAttributes extends TapChangerAttributes {
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("regulationMode")
     private PhaseTapChanger.RegulationMode regulationMode;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("steps")
     private List<PhaseTapChangerStepAttributes> steps;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("regulationValue")
     private double regulationValue;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("targetDeadband")
     private double targetDeadband;
 

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/PhaseTapChangerStepAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/PhaseTapChangerStepAttributes.java
@@ -21,30 +21,25 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @ApiModel("PhaseTapChangerStep attributes")
 public class PhaseTapChangerStepAttributes {
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("rho")
     private double rho;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("r")
     private double r;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("x")
     private double x;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("g")
     private double g;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("b")
     private double b;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("alpha")
     private double alpha;
 }

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/RatioTapChangerAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/RatioTapChangerAttributes.java
@@ -6,7 +6,6 @@
  */
 package com.powsybl.network.store.model;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
@@ -26,19 +25,15 @@ import java.util.List;
 @ApiModel("RatioTapChanger attributes")
 public class RatioTapChangerAttributes extends TapChangerAttributes {
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("steps")
     private List<RatioTapChangerStepAttributes> steps;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("loadTapChangingCapabilities")
     private boolean loadTapChangingCapabilities;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("targetV")
     private double targetV;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("targetDeadband")
     private double targetDeadband;
 

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/RatioTapChangerStepAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/RatioTapChangerStepAttributes.java
@@ -21,26 +21,21 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class RatioTapChangerStepAttributes {
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("rho")
     private double rho;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("r")
     private double r;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("x")
     private double x;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("g")
     private double g;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("b")
     private double b;
-
 }

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/ReactiveCapabilityCurveAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/ReactiveCapabilityCurveAttributes.java
@@ -6,7 +6,6 @@
  */
 package com.powsybl.network.store.model;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.powsybl.iidm.network.ReactiveLimitsKind;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -27,11 +26,9 @@ import java.util.TreeMap;
 @ApiModel("Reactive capability curve attributes")
 public class ReactiveCapabilityCurveAttributes implements ReactiveLimitsAttributes {
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Kind of reactive limit")
     private final ReactiveLimitsKind kind = ReactiveLimitsKind.CURVE;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("curve points")
     private TreeMap<Double, ReactiveCapabilityCurvePointAttributes> points;
 

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/ReactiveCapabilityCurvePointAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/ReactiveCapabilityCurvePointAttributes.java
@@ -21,19 +21,16 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @ApiModel("Point attributes")
 public class ReactiveCapabilityCurvePointAttributes {
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Active power value")
     double p;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Reactive power minimum value")
     double minQ;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Reactive power maximum value")
     double maxQ;
-
 }

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/ReactiveLimitsAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/ReactiveLimitsAttributes.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.network.store.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.powsybl.iidm.network.ReactiveLimitsKind;
@@ -21,6 +22,7 @@ import com.powsybl.iidm.network.ReactiveLimitsKind;
         @JsonSubTypes.Type(value = ReactiveCapabilityCurveAttributes.class, name = "ReactiveCapabilityCurve"),
         @JsonSubTypes.Type(value = MinMaxReactiveLimitsAttributes.class, name = "MinMaxReactiveLimits")
 })
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public interface ReactiveLimitsAttributes {
 
     ReactiveLimitsKind getKind();

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/ShuntCompensatorAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/ShuntCompensatorAttributes.java
@@ -6,14 +6,9 @@
  */
 package com.powsybl.network.store.model;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 import java.util.Map;
 
@@ -31,15 +26,12 @@ public class ShuntCompensatorAttributes extends AbstractAttributes implements In
     @ApiModelProperty("Voltage level ID")
     private String voltageLevelId;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Shunt compensator name")
     private String name;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("fictitious")
     private boolean fictitious;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Properties")
     private Map<String, String> properties;
 

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/StaticVarCompensatorAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/StaticVarCompensatorAttributes.java
@@ -6,15 +6,10 @@
  */
 package com.powsybl.network.store.model;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.powsybl.iidm.network.StaticVarCompensator;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 import java.util.Map;
 
@@ -32,19 +27,15 @@ public class StaticVarCompensatorAttributes extends AbstractAttributes implement
     @ApiModelProperty("Voltage level ID")
     private String voltageLevelId;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Static var compensator name")
     private String name;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("fictitious")
     private boolean fictitious;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Properties")
     private Map<String, String> properties;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Connection node in node/breaker topology")
     private Integer node;
 
@@ -54,35 +45,27 @@ public class StaticVarCompensatorAttributes extends AbstractAttributes implement
     @ApiModelProperty("Possible connection bus in bus/breaker topology")
     private String connectableBus;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Minimum susceptance in S")
     private double bmin;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Maximum susceptance in S")
     private double bmax;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Voltage setpoint in Kv")
     private double voltageSetPoint;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Reactive power setpoint in MVAR")
     private double reactivePowerSetPoint;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Regulating mode")
     private StaticVarCompensator.RegulationMode regulationMode;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Active power in MW")
     private double p;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Reactive power in MW")
     private double q;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Connectable position (for substation diagram)")
     private ConnectablePositionAttributes position;
 

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/SubstationAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/SubstationAttributes.java
@@ -6,7 +6,6 @@
  */
 package com.powsybl.network.store.model;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.powsybl.iidm.network.Country;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -27,23 +26,18 @@ import java.util.Map;
 @ApiModel("Substation attributes")
 public class SubstationAttributes implements IdentifiableAttributes {
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Substation name")
     private String name;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("fictitious")
     private boolean fictitious;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Properties")
     private Map<String, String> properties;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Country where the susbstation is")
     private Country country;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("TSO the substation belongs to")
     private String tso;
 }

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/SwitchAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/SwitchAttributes.java
@@ -7,16 +7,11 @@
 package com.powsybl.network.store.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.google.common.collect.ImmutableSet;
 import com.powsybl.iidm.network.SwitchKind;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 import java.util.Map;
 import java.util.Set;
@@ -35,11 +30,9 @@ public class SwitchAttributes extends AbstractAttributes implements ConnectableA
     @ApiModelProperty("Voltage level ID")
     private String voltageLevelId;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Switch name")
     private String name;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Properties")
     private Map<String, String> properties;
 

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/TapChangerAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/TapChangerAttributes.java
@@ -20,17 +20,15 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor
 @AllArgsConstructor
 @SuperBuilder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class TapChangerAttributes {
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("lowTapPosition")
     private int lowTapPosition;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("tapPosition")
-    private Integer tapPosition;
+    private int tapPosition;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("regulating")
     private boolean regulating;
 }

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/TapChangerParentAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/TapChangerParentAttributes.java
@@ -9,7 +9,6 @@ package com.powsybl.network.store.model;
 /**
  * @author Abdelsalem Hedhili <abdelsalem.hedhili at rte-france.com>
  */
-
 public interface TapChangerParentAttributes {
 
     void setPhaseTapChangerAttributes(PhaseTapChangerAttributes phaseTapChangerAttributes);

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/TerminalRefAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/TerminalRefAttributes.java
@@ -21,14 +21,13 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @ApiModel("TerminalRef attributes")
 public class TerminalRefAttributes {
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("connectableId")
     private String connectableId;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("side")
     private String side;
 }

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/ThreeWindingsTransformerAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/ThreeWindingsTransformerAttributes.java
@@ -7,15 +7,10 @@
 package com.powsybl.network.store.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.google.common.collect.ImmutableSet;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 import java.util.Map;
 import java.util.Set;
@@ -31,15 +26,12 @@ import java.util.Set;
 @ApiModel("Three windings transformer attributes")
 public class ThreeWindingsTransformerAttributes extends AbstractAttributes implements IdentifiableAttributes, RelatedVoltageLevelsAttributes {
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("3 windings transformer name")
     private String name;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("fictitious")
     private boolean fictitious;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Properties")
     private Map<String, String> properties;
 

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/TwoWindingsTransformerAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/TwoWindingsTransformerAttributes.java
@@ -6,14 +6,9 @@
  */
 package com.powsybl.network.store.model;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 import java.util.Map;
 
@@ -34,15 +29,12 @@ public class TwoWindingsTransformerAttributes extends AbstractAttributes impleme
     @ApiModelProperty("Side 2 voltage level ID")
     private String voltageLevelId2;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("2 windings transformer name")
     private String name;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("fictitious")
     private boolean fictitious;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Properties")
     private Map<String, String> properties;
 
@@ -100,20 +92,16 @@ public class TwoWindingsTransformerAttributes extends AbstractAttributes impleme
     @ApiModelProperty("Side 2 connectable position (for substation diagram)")
     private ConnectablePositionAttributes position2;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Phase tap changer")
     private PhaseTapChangerAttributes phaseTapChangerAttributes;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Ratio tap changer")
     private RatioTapChangerAttributes ratioTapChangerAttributes;
 
     @ApiModelProperty("Current limits side 1")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private CurrentLimitsAttributes currentLimits1;
 
     @ApiModelProperty("Current limits side 2")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private CurrentLimitsAttributes currentLimits2;
 
     public TwoWindingsTransformerAttributes(TwoWindingsTransformerAttributes other) {

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/Vertex.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/Vertex.java
@@ -20,6 +20,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @ApiModel("Vertex")
 public class Vertex {
 
@@ -30,14 +31,11 @@ public class Vertex {
     private ConnectableType connectableType;
 
     @ApiModelProperty("Connection node")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private Integer node;
 
     @ApiModelProperty("Connection bus")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private String bus;
 
     @ApiModelProperty("Connection side")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private String side;
 }

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/VoltageLevelAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/VoltageLevelAttributes.java
@@ -63,6 +63,10 @@ public class VoltageLevelAttributes extends AbstractAttributes implements Identi
     @ApiModelProperty("Bus to calculated bus")
     private Map<String, Integer> busToCalculatedBus;
 
+    @Builder.Default
+    @ApiModelProperty("Calculated bus validity")
+    private boolean calculatedBusesValid = false;
+
     public VoltageLevelAttributes(VoltageLevelAttributes other) {
         super(other);
         this.substationId = other.substationId;
@@ -77,5 +81,6 @@ public class VoltageLevelAttributes extends AbstractAttributes implements Identi
         this.calculatedBuses = other.calculatedBuses;
         this.nodeToCalculatedBus = other.nodeToCalculatedBus;
         this.busToCalculatedBus = other.busToCalculatedBus;
+        this.calculatedBusesValid = other.calculatedBusesValid;
     }
 }

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/VoltageLevelAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/VoltageLevelAttributes.java
@@ -6,7 +6,6 @@
  */
 package com.powsybl.network.store.model;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.powsybl.iidm.network.TopologyKind;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -27,35 +26,27 @@ import java.util.Map;
 @ApiModel("Voltage level attributes")
 public class VoltageLevelAttributes extends AbstractAttributes implements IdentifiableAttributes {
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Substation ID")
     private String substationId;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Voltage level name")
     private String name;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("fictitious")
     private boolean fictitious;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Properties")
     private Map<String, String> properties;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Nominal voltage in kV")
     private double nominalV;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Low voltage limit in kV")
     private double lowVoltageLimit;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("High voltage limit in kV")
     private double highVoltageLimit;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Topology kind")
     private TopologyKind topologyKind;
 
@@ -63,15 +54,12 @@ public class VoltageLevelAttributes extends AbstractAttributes implements Identi
     @Builder.Default
     private List<InternalConnectionAttributes> internalConnections = new ArrayList<>();
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Calculated buses")
     private List<CalculatedBusAttributes> calculatedBuses;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Node to calculated bus")
     private Map<Integer, Integer> nodeToCalculatedBus;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Bus to calculated bus")
     private Map<String, Integer> busToCalculatedBus;
 

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/VscConverterStationAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/VscConverterStationAttributes.java
@@ -6,14 +6,9 @@
  */
 package com.powsybl.network.store.model;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 
 import java.util.Map;
 
@@ -31,19 +26,15 @@ public class VscConverterStationAttributes extends AbstractAttributes implements
     @ApiModelProperty("Voltage level ID")
     private String voltageLevelId;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("VSC converter station name")
     private String name;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("fictitious")
     private boolean fictitious;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Properties")
     private Map<String, String> properties;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Connection node in node/breaker topology")
     private Integer node;
 
@@ -53,35 +44,27 @@ public class VscConverterStationAttributes extends AbstractAttributes implements
     @ApiModelProperty("Possible connection bus in bus/breaker topology")
     private String connectableBus;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Loss factor")
     private float lossFactor;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Voltage regulator status")
     private Boolean voltageRegulatorOn;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Reactive power set point in MVar")
     private double reactivePowerSetPoint;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Voltage set point in Kv")
     private double voltageSetPoint;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Reactive limits of the generator")
     private ReactiveLimitsAttributes reactiveLimits;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Active power in MW")
     private double p;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Reactive power in MW")
     private double q;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     @ApiModelProperty("Connectable position (for substation diagram)")
     private ConnectablePositionAttributes position;
 

--- a/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreRepository.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreRepository.java
@@ -111,7 +111,8 @@ public class NetworkStoreRepository {
                 .value("internalConnections", bindMarker())
                 .value("calculatedBuses", bindMarker())
                 .value("nodeToCalculatedBus", bindMarker())
-                .value("busToCalculatedBus", bindMarker()));
+                .value("busToCalculatedBus", bindMarker())
+                .value("calculatedBusesValid", bindMarker()));
         psUpdateVoltageLevel = session.prepare(update(KEYSPACE_IIDM, "voltageLevel")
                 .with(set("name", bindMarker()))
                 .and(set("properties", bindMarker()))
@@ -123,6 +124,7 @@ public class NetworkStoreRepository {
                 .and(set("calculatedBuses", bindMarker()))
                 .and(set("nodeToCalculatedBus", bindMarker()))
                 .and(set("busToCalculatedBus", bindMarker()))
+                .and(set("calculatedBusesValid", bindMarker()))
                 .where(eq("networkUuid", bindMarker()))
                 .and(eq("id", bindMarker()))
                 .and(eq("substationId", bindMarker())));
@@ -777,7 +779,7 @@ public class NetworkStoreRepository {
         for (List<Resource<NetworkAttributes>> subresources : Lists.partition(resources, BATCH_SIZE)) {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<NetworkAttributes> resource : subresources) {
-                batch.add(psUpdateNetwork.bind(
+                batch.add(creationalStatement(psUpdateNetwork.bind(
                         resource.getId(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getCaseDate().toDate(),
@@ -785,7 +787,7 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getSourceFormat(),
                         resource.getAttributes().isConnectedComponentsValid(),
                         resource.getAttributes().isSynchronousComponentsValid(),
-                        resource.getAttributes().getUuid()
+                        resource.getAttributes().getUuid())
                 ));
             }
             session.execute(batch);
@@ -891,7 +893,8 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getInternalConnections(),
                         resource.getAttributes().getCalculatedBuses(),
                         resource.getAttributes().getNodeToCalculatedBus(),
-                        resource.getAttributes().getBusToCalculatedBus()
+                        resource.getAttributes().getBusToCalculatedBus(),
+                        resource.getAttributes().isCalculatedBusesValid()
                         )));
             }
             session.execute(batch);
@@ -902,7 +905,7 @@ public class NetworkStoreRepository {
         for (List<Resource<VoltageLevelAttributes>> subresources : Lists.partition(resources, BATCH_SIZE)) {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<VoltageLevelAttributes> resource : subresources) {
-                batch.add(psUpdateVoltageLevel.bind(
+                batch.add(creationalStatement(psUpdateVoltageLevel.bind(
                         resource.getAttributes().getName(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getNominalV(),
@@ -913,9 +916,10 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getCalculatedBuses(),
                         resource.getAttributes().getNodeToCalculatedBus(),
                         resource.getAttributes().getBusToCalculatedBus(),
+                        resource.getAttributes().isCalculatedBusesValid(),
                         networkUuid,
                         resource.getId(),
-                        resource.getAttributes().getSubstationId()
+                        resource.getAttributes().getSubstationId())
                 ));
             }
             session.execute(batch);
@@ -933,7 +937,8 @@ public class NetworkStoreRepository {
                                                      "internalConnections",
                                                      "calculatedBuses",
                                                      "nodeToCalculatedBus",
-                                                     "busToCalculatedBus")
+                                                     "busToCalculatedBus",
+                                                     "calculatedBusesValid")
                 .from(KEYSPACE_IIDM, "voltageLevelBySubstation")
                 .where(eq("networkUuid", networkUuid)).and(eq("substationId", substationId)));
         List<Resource<VoltageLevelAttributes>> resources = new ArrayList<>();
@@ -952,6 +957,7 @@ public class NetworkStoreRepository {
                             .calculatedBuses(row.isNull(8) ? null : row.getList(8, CalculatedBusAttributes.class))
                             .nodeToCalculatedBus(row.isNull(9) ? null : row.getMap(9, Integer.class, Integer.class))
                             .busToCalculatedBus(row.isNull(10) ? null : row.getMap(10, String.class, Integer.class))
+                            .calculatedBusesValid(row.getBool(11))
                             .build())
                     .build());
         }
@@ -969,7 +975,8 @@ public class NetworkStoreRepository {
                                                      "internalConnections",
                                                      "calculatedBuses",
                                                      "nodeToCalculatedBus",
-                                                     "busToCalculatedBus")
+                                                     "busToCalculatedBus",
+                                                     "calculatedBusesValid")
                 .from(KEYSPACE_IIDM, "voltageLevel")
                 .where(eq("networkUuid", networkUuid)).and(eq("id", voltageLevelId)));
         Row one = resultSet.one();
@@ -988,6 +995,7 @@ public class NetworkStoreRepository {
                             .calculatedBuses(one.isNull(8) ? null : one.getList(8, CalculatedBusAttributes.class))
                             .nodeToCalculatedBus(one.isNull(9) ? null : one.getMap(9, Integer.class, Integer.class))
                             .busToCalculatedBus(one.isNull(10) ? null : one.getMap(10, String.class, Integer.class))
+                            .calculatedBusesValid(one.getBool(11))
                             .build())
                     .build());
         }
@@ -1006,7 +1014,8 @@ public class NetworkStoreRepository {
                                                      "internalConnections",
                                                      "calculatedBuses",
                                                      "nodeToCalculatedBus",
-                                                     "busToCalculatedBus")
+                                                     "busToCalculatedBus",
+                                                     "calculatedBusesValid")
                 .from(KEYSPACE_IIDM, "voltageLevel")
                 .where(eq("networkUuid", networkUuid)));
         List<Resource<VoltageLevelAttributes>> resources = new ArrayList<>();
@@ -1025,6 +1034,7 @@ public class NetworkStoreRepository {
                             .calculatedBuses(row.isNull(9) ? null : row.getList(9, CalculatedBusAttributes.class))
                             .nodeToCalculatedBus(row.isNull(10) ? null : row.getMap(10, Integer.class, Integer.class))
                             .busToCalculatedBus(row.isNull(11) ? null : row.getMap(11, String.class, Integer.class))
+                            .calculatedBusesValid(row.getBool(12))
                             .build())
                     .build());
         }
@@ -1244,7 +1254,7 @@ public class NetworkStoreRepository {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<GeneratorAttributes> resource : subresources) {
                 ReactiveLimitsAttributes reactiveLimits = resource.getAttributes().getReactiveLimits();
-                batch.add(psUpdateGenerator.bind(
+                batch.add(creationalStatement(psUpdateGenerator.bind(
                         resource.getAttributes().getName(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getNode(),
@@ -1268,7 +1278,7 @@ public class NetworkStoreRepository {
                         networkUuid,
                         resource.getId(),
                         resource.getAttributes().getVoltageLevelId())
-                );
+                ));
             }
             session.execute(batch);
         }
@@ -1420,7 +1430,7 @@ public class NetworkStoreRepository {
         for (List<Resource<LoadAttributes>> subresources : Lists.partition(resources, BATCH_SIZE)) {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<LoadAttributes> resource : subresources) {
-                batch.add(psUpdateLoad.bind(
+                batch.add(creationalStatement(psUpdateLoad.bind(
                         resource.getAttributes().getName(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getNode(),
@@ -1435,7 +1445,7 @@ public class NetworkStoreRepository {
                         networkUuid,
                         resource.getId(),
                         resource.getAttributes().getVoltageLevelId())
-                );
+                ));
             }
             session.execute(batch);
         }
@@ -1594,7 +1604,7 @@ public class NetworkStoreRepository {
         for (List<Resource<ShuntCompensatorAttributes>> subresources : Lists.partition(resources, BATCH_SIZE)) {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<ShuntCompensatorAttributes> resource : subresources) {
-                batch.add(psUpdateShuntCompensator.bind(
+                batch.add(creationalStatement(psUpdateShuntCompensator.bind(
                         resource.getAttributes().getName(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getNode(),
@@ -1610,7 +1620,7 @@ public class NetworkStoreRepository {
                         networkUuid,
                         resource.getId(),
                         resource.getAttributes().getVoltageLevelId())
-                );
+                ));
             }
             session.execute(batch);
         }
@@ -1788,7 +1798,7 @@ public class NetworkStoreRepository {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<VscConverterStationAttributes> resource : subresources) {
                 ReactiveLimitsAttributes reactiveLimits = resource.getAttributes().getReactiveLimits();
-                batch.add(psUpdateVscConverterStation.bind(
+                batch.add(creationalStatement(psUpdateVscConverterStation.bind(
                         resource.getAttributes().getName(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getNode(),
@@ -1806,7 +1816,7 @@ public class NetworkStoreRepository {
                         networkUuid,
                         resource.getId(),
                         resource.getAttributes().getVoltageLevelId())
-                );
+                ));
             }
             session.execute(batch);
         }
@@ -1951,7 +1961,7 @@ public class NetworkStoreRepository {
         for (List<Resource<LccConverterStationAttributes>> subresources : Lists.partition(resources, BATCH_SIZE)) {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<LccConverterStationAttributes> resource : subresources) {
-                batch.add(psUpdateLccConverterStation.bind(
+                batch.add(creationalStatement(psUpdateLccConverterStation.bind(
                         resource.getAttributes().getName(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getNode(),
@@ -1965,7 +1975,7 @@ public class NetworkStoreRepository {
                         networkUuid,
                         resource.getId(),
                         resource.getAttributes().getVoltageLevelId())
-                );
+                ));
             }
             session.execute(batch);
         }
@@ -2138,7 +2148,7 @@ public class NetworkStoreRepository {
         for (List<Resource<StaticVarCompensatorAttributes>> subresources : Lists.partition(resources, BATCH_SIZE)) {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<StaticVarCompensatorAttributes> resource : subresources) {
-                batch.add(psUpdateStaticVarCompensator.bind(
+                batch.add(creationalStatement(psUpdateStaticVarCompensator.bind(
                         resource.getAttributes().getName(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getNode(),
@@ -2156,7 +2166,7 @@ public class NetworkStoreRepository {
                         networkUuid,
                         resource.getId(),
                         resource.getAttributes().getVoltageLevelId())
-                );
+                ));
             }
             session.execute(batch);
         }
@@ -2396,7 +2406,7 @@ public class NetworkStoreRepository {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<SwitchAttributes> resource : subresources) {
                 String kind = resource.getAttributes().getKind() != null ? resource.getAttributes().getKind().toString() : null;
-                batch.add(psUpdateSwitch.bind(
+                batch.add(creationalStatement(psUpdateSwitch.bind(
                         resource.getAttributes().getName(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getNode1(),
@@ -2409,7 +2419,8 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getBus2(),
                         networkUuid,
                         resource.getId(),
-                        resource.getAttributes().getVoltageLevelId()));
+                        resource.getAttributes().getVoltageLevelId())
+                ));
             }
             session.execute(batch);
         }
@@ -2668,7 +2679,7 @@ public class NetworkStoreRepository {
         for (List<Resource<TwoWindingsTransformerAttributes>> subresources : Lists.partition(resources, BATCH_SIZE)) {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<TwoWindingsTransformerAttributes> resource : subresources) {
-                batch.add(psUpdateTwoWindingsTransformer.bind(
+                batch.add(creationalStatement(psUpdateTwoWindingsTransformer.bind(
                         resource.getAttributes().getVoltageLevelId1(),
                         resource.getAttributes().getVoltageLevelId2(),
                         resource.getAttributes().getName(),
@@ -2696,7 +2707,8 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getCurrentLimits1(),
                         resource.getAttributes().getCurrentLimits2(),
                         networkUuid,
-                        resource.getId()));
+                        resource.getId())
+                ));
             }
             session.execute(batch);
         }
@@ -3137,7 +3149,7 @@ public class NetworkStoreRepository {
         for (List<Resource<ThreeWindingsTransformerAttributes>> subresources : Lists.partition(resources, BATCH_SIZE)) {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<ThreeWindingsTransformerAttributes> resource : subresources) {
-                batch.add(psUpdateThreeWindingsTransformer.bind(
+                batch.add(creationalStatement(psUpdateThreeWindingsTransformer.bind(
                         resource.getAttributes().getLeg1().getVoltageLevelId(),
                         resource.getAttributes().getLeg2().getVoltageLevelId(),
                         resource.getAttributes().getLeg3().getVoltageLevelId(),
@@ -3187,7 +3199,8 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getLeg3().getBus(),
                         resource.getAttributes().getLeg3().getConnectableBus(),
                         networkUuid,
-                        resource.getId()));
+                        resource.getId())
+                ));
             }
             session.execute(batch);
         }
@@ -3439,7 +3452,7 @@ public class NetworkStoreRepository {
         for (List<Resource<LineAttributes>> subresources : Lists.partition(resources, BATCH_SIZE)) {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<LineAttributes> resource : subresources) {
-                batch.add(psUpdateLines.bind(
+                batch.add(creationalStatement(psUpdateLines.bind(
                         resource.getAttributes().getVoltageLevelId1(),
                         resource.getAttributes().getVoltageLevelId2(),
                         resource.getAttributes().getName(),
@@ -3466,7 +3479,8 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getCurrentLimits1(),
                         resource.getAttributes().getCurrentLimits2(),
                         networkUuid,
-                        resource.getId()));
+                        resource.getId())
+                ));
             }
             session.execute(batch);
         }
@@ -3565,7 +3579,7 @@ public class NetworkStoreRepository {
         for (List<Resource<HvdcLineAttributes>> subresources : Lists.partition(resources, BATCH_SIZE)) {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<HvdcLineAttributes> resource : subresources) {
-                batch.add(psUpdateHvdcLine.bind(
+                batch.add(creationalStatement(psUpdateHvdcLine.bind(
                         resource.getAttributes().getName(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getR(),
@@ -3576,7 +3590,8 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getConverterStationId1(),
                         resource.getAttributes().getConverterStationId2(),
                         networkUuid,
-                        resource.getId()));
+                        resource.getId())
+                ));
             }
             session.execute(batch);
         }
@@ -3767,7 +3782,7 @@ public class NetworkStoreRepository {
         for (List<Resource<DanglingLineAttributes>> subresources : Lists.partition(resources, BATCH_SIZE)) {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<DanglingLineAttributes> resource : subresources) {
-                batch.add(psUpdateDanglingLine.bind(
+                batch.add(creationalStatement(psUpdateDanglingLine.bind(
                         resource.getAttributes().getName(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getNode(),
@@ -3786,7 +3801,8 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getConnectableBus(),
                         networkUuid,
                         resource.getId(),
-                        resource.getAttributes().getVoltageLevelId()));
+                        resource.getAttributes().getVoltageLevelId())
+                ));
             }
             session.execute(batch);
         }
@@ -3891,14 +3907,15 @@ public class NetworkStoreRepository {
         for (List<Resource<ConfiguredBusAttributes>> subresources : Lists.partition(resources, BATCH_SIZE)) {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<ConfiguredBusAttributes> resource : subresources) {
-                batch.add(psUpdateConfiguredBus.bind(
+                batch.add(creationalStatement(psUpdateConfiguredBus.bind(
                         resource.getAttributes().getName(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getV(),
                         resource.getAttributes().getAngle(),
                         networkUuid,
                         resource.getId(),
-                        resource.getAttributes().getVoltageLevelId()));
+                        resource.getAttributes().getVoltageLevelId())
+                ));
             }
             session.execute(batch);
         }

--- a/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreRepository.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreRepository.java
@@ -688,7 +688,7 @@ public class NetworkStoreRepository {
 
     // This method unsets the null valued columns of a bound statement in order to avoid creation of tombstones
     // It must be used only for statements used for creation, not for those used for update
-    private static BoundStatement creationalStatement(BoundStatement bs) {
+    private static BoundStatement unsetNullValues(BoundStatement bs) {
         ColumnDefinitions colDef = bs.preparedStatement().getVariables();
         for (int i = 0; i < colDef.size(); i++) {
             if (bs.isNull(colDef.getName(i))) {
@@ -760,7 +760,7 @@ public class NetworkStoreRepository {
         for (List<Resource<NetworkAttributes>> subresources : Lists.partition(resources, BATCH_SIZE)) {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<NetworkAttributes> resource : subresources) {
-                batch.add(creationalStatement(psInsertNetwork.bind(
+                batch.add(unsetNullValues(psInsertNetwork.bind(
                         resource.getAttributes().getUuid(),
                         resource.getId(),
                         resource.getAttributes().getProperties(),
@@ -779,7 +779,7 @@ public class NetworkStoreRepository {
         for (List<Resource<NetworkAttributes>> subresources : Lists.partition(resources, BATCH_SIZE)) {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<NetworkAttributes> resource : subresources) {
-                batch.add(creationalStatement(psUpdateNetwork.bind(
+                batch.add(unsetNullValues(psUpdateNetwork.bind(
                         resource.getId(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getCaseDate().toDate(),
@@ -861,7 +861,7 @@ public class NetworkStoreRepository {
         for (List<Resource<SubstationAttributes>> subresources : Lists.partition(resources, BATCH_SIZE)) {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<SubstationAttributes> resource : subresources) {
-                batch.add(creationalStatement(psInsertSubstation.bind(
+                batch.add(unsetNullValues(psInsertSubstation.bind(
                         networkUuid,
                         resource.getId(),
                         resource.getAttributes().getName(),
@@ -880,7 +880,7 @@ public class NetworkStoreRepository {
         for (List<Resource<VoltageLevelAttributes>> subresources : Lists.partition(resources, BATCH_SIZE)) {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<VoltageLevelAttributes> resource : subresources) {
-                batch.add(creationalStatement(psInsertVoltageLevel.bind(
+                batch.add(unsetNullValues(psInsertVoltageLevel.bind(
                         networkUuid,
                         resource.getId(),
                         resource.getAttributes().getSubstationId(),
@@ -905,7 +905,7 @@ public class NetworkStoreRepository {
         for (List<Resource<VoltageLevelAttributes>> subresources : Lists.partition(resources, BATCH_SIZE)) {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<VoltageLevelAttributes> resource : subresources) {
-                batch.add(creationalStatement(psUpdateVoltageLevel.bind(
+                batch.add(unsetNullValues(psUpdateVoltageLevel.bind(
                         resource.getAttributes().getName(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getNominalV(),
@@ -1048,7 +1048,7 @@ public class NetworkStoreRepository {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<GeneratorAttributes> resource : subresources) {
                 ReactiveLimitsAttributes reactiveLimits = resource.getAttributes().getReactiveLimits();
-                batch.add(creationalStatement(psInsertGenerator.bind(
+                batch.add(unsetNullValues(psInsertGenerator.bind(
                         networkUuid,
                         resource.getId(),
                         resource.getAttributes().getVoltageLevelId(),
@@ -1254,7 +1254,7 @@ public class NetworkStoreRepository {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<GeneratorAttributes> resource : subresources) {
                 ReactiveLimitsAttributes reactiveLimits = resource.getAttributes().getReactiveLimits();
-                batch.add(creationalStatement(psUpdateGenerator.bind(
+                batch.add(unsetNullValues(psUpdateGenerator.bind(
                         resource.getAttributes().getName(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getNode(),
@@ -1290,7 +1290,7 @@ public class NetworkStoreRepository {
         for (List<Resource<LoadAttributes>> subresources : Lists.partition(resources, BATCH_SIZE)) {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<LoadAttributes> resource : subresources) {
-                batch.add(creationalStatement(psInsertLoad.bind(
+                batch.add(unsetNullValues(psInsertLoad.bind(
                         networkUuid,
                         resource.getId(),
                         resource.getAttributes().getVoltageLevelId(),
@@ -1430,7 +1430,7 @@ public class NetworkStoreRepository {
         for (List<Resource<LoadAttributes>> subresources : Lists.partition(resources, BATCH_SIZE)) {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<LoadAttributes> resource : subresources) {
-                batch.add(creationalStatement(psUpdateLoad.bind(
+                batch.add(unsetNullValues(psUpdateLoad.bind(
                         resource.getAttributes().getName(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getNode(),
@@ -1457,7 +1457,7 @@ public class NetworkStoreRepository {
         for (List<Resource<ShuntCompensatorAttributes>> subresources : Lists.partition(resources, BATCH_SIZE)) {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<ShuntCompensatorAttributes> resource : subresources) {
-                batch.add(creationalStatement(psInsertShuntCompensator.bind(
+                batch.add(unsetNullValues(psInsertShuntCompensator.bind(
                         networkUuid,
                         resource.getId(),
                         resource.getAttributes().getVoltageLevelId(),
@@ -1604,7 +1604,7 @@ public class NetworkStoreRepository {
         for (List<Resource<ShuntCompensatorAttributes>> subresources : Lists.partition(resources, BATCH_SIZE)) {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<ShuntCompensatorAttributes> resource : subresources) {
-                batch.add(creationalStatement(psUpdateShuntCompensator.bind(
+                batch.add(unsetNullValues(psUpdateShuntCompensator.bind(
                         resource.getAttributes().getName(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getNode(),
@@ -1633,7 +1633,7 @@ public class NetworkStoreRepository {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<VscConverterStationAttributes> resource : subresources) {
                 ReactiveLimitsAttributes reactiveLimits = resource.getAttributes().getReactiveLimits();
-                batch.add(creationalStatement(psInsertVscConverterStation.bind(
+                batch.add(unsetNullValues(psInsertVscConverterStation.bind(
                         networkUuid,
                         resource.getId(),
                         resource.getAttributes().getVoltageLevelId(),
@@ -1798,7 +1798,7 @@ public class NetworkStoreRepository {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<VscConverterStationAttributes> resource : subresources) {
                 ReactiveLimitsAttributes reactiveLimits = resource.getAttributes().getReactiveLimits();
-                batch.add(creationalStatement(psUpdateVscConverterStation.bind(
+                batch.add(unsetNullValues(psUpdateVscConverterStation.bind(
                         resource.getAttributes().getName(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getNode(),
@@ -1828,7 +1828,7 @@ public class NetworkStoreRepository {
         for (List<Resource<LccConverterStationAttributes>> subresources : Lists.partition(resources, BATCH_SIZE)) {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<LccConverterStationAttributes> resource : subresources) {
-                batch.add(creationalStatement(psInsertLccConverterStation.bind(
+                batch.add(unsetNullValues(psInsertLccConverterStation.bind(
                         networkUuid,
                         resource.getId(),
                         resource.getAttributes().getVoltageLevelId(),
@@ -1961,7 +1961,7 @@ public class NetworkStoreRepository {
         for (List<Resource<LccConverterStationAttributes>> subresources : Lists.partition(resources, BATCH_SIZE)) {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<LccConverterStationAttributes> resource : subresources) {
-                batch.add(creationalStatement(psUpdateLccConverterStation.bind(
+                batch.add(unsetNullValues(psUpdateLccConverterStation.bind(
                         resource.getAttributes().getName(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getNode(),
@@ -1987,7 +1987,7 @@ public class NetworkStoreRepository {
         for (List<Resource<StaticVarCompensatorAttributes>> subresources : Lists.partition(resources, BATCH_SIZE)) {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<StaticVarCompensatorAttributes> resource : subresources) {
-                batch.add(creationalStatement(psInsertStaticVarCompensator.bind(
+                batch.add(unsetNullValues(psInsertStaticVarCompensator.bind(
                         networkUuid,
                         resource.getId(),
                         resource.getAttributes().getVoltageLevelId(),
@@ -2148,7 +2148,7 @@ public class NetworkStoreRepository {
         for (List<Resource<StaticVarCompensatorAttributes>> subresources : Lists.partition(resources, BATCH_SIZE)) {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<StaticVarCompensatorAttributes> resource : subresources) {
-                batch.add(creationalStatement(psUpdateStaticVarCompensator.bind(
+                batch.add(unsetNullValues(psUpdateStaticVarCompensator.bind(
                         resource.getAttributes().getName(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getNode(),
@@ -2178,7 +2178,7 @@ public class NetworkStoreRepository {
         for (List<Resource<BusbarSectionAttributes>> subresources : Lists.partition(resources, BATCH_SIZE)) {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<BusbarSectionAttributes> resource : subresources) {
-                batch.add(creationalStatement(psInsertBusbarSection.bind(
+                batch.add(unsetNullValues(psInsertBusbarSection.bind(
                         networkUuid,
                         resource.getId(),
                         resource.getAttributes().getVoltageLevelId(),
@@ -2272,7 +2272,7 @@ public class NetworkStoreRepository {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<SwitchAttributes> resource : subresources) {
                 String kind = resource.getAttributes().getKind() != null ? resource.getAttributes().getKind().toString() : null;
-                batch.add(creationalStatement(psInsertSwitch.bind(
+                batch.add(unsetNullValues(psInsertSwitch.bind(
                         networkUuid,
                         resource.getId(),
                         resource.getAttributes().getVoltageLevelId(),
@@ -2406,7 +2406,7 @@ public class NetworkStoreRepository {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<SwitchAttributes> resource : subresources) {
                 String kind = resource.getAttributes().getKind() != null ? resource.getAttributes().getKind().toString() : null;
-                batch.add(creationalStatement(psUpdateSwitch.bind(
+                batch.add(unsetNullValues(psUpdateSwitch.bind(
                         resource.getAttributes().getName(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getNode1(),
@@ -2432,7 +2432,7 @@ public class NetworkStoreRepository {
         for (List<Resource<TwoWindingsTransformerAttributes>> subresources : Lists.partition(resources, BATCH_SIZE)) {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<TwoWindingsTransformerAttributes> resource : subresources) {
-                batch.add(creationalStatement(psInsertTwoWindingsTransformer.bind(
+                batch.add(unsetNullValues(psInsertTwoWindingsTransformer.bind(
                         networkUuid,
                         resource.getId(),
                         resource.getAttributes().getVoltageLevelId1(),
@@ -2679,7 +2679,7 @@ public class NetworkStoreRepository {
         for (List<Resource<TwoWindingsTransformerAttributes>> subresources : Lists.partition(resources, BATCH_SIZE)) {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<TwoWindingsTransformerAttributes> resource : subresources) {
-                batch.add(creationalStatement(psUpdateTwoWindingsTransformer.bind(
+                batch.add(unsetNullValues(psUpdateTwoWindingsTransformer.bind(
                         resource.getAttributes().getVoltageLevelId1(),
                         resource.getAttributes().getVoltageLevelId2(),
                         resource.getAttributes().getName(),
@@ -2720,7 +2720,7 @@ public class NetworkStoreRepository {
         for (List<Resource<ThreeWindingsTransformerAttributes>> subresources : Lists.partition(resources, BATCH_SIZE)) {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<ThreeWindingsTransformerAttributes> resource : subresources) {
-                batch.add(creationalStatement(psInsertThreeWindingsTransformer.bind(
+                batch.add(unsetNullValues(psInsertThreeWindingsTransformer.bind(
                         networkUuid,
                         resource.getId(),
                         resource.getAttributes().getLeg1().getVoltageLevelId(),
@@ -3149,7 +3149,7 @@ public class NetworkStoreRepository {
         for (List<Resource<ThreeWindingsTransformerAttributes>> subresources : Lists.partition(resources, BATCH_SIZE)) {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<ThreeWindingsTransformerAttributes> resource : subresources) {
-                batch.add(creationalStatement(psUpdateThreeWindingsTransformer.bind(
+                batch.add(unsetNullValues(psUpdateThreeWindingsTransformer.bind(
                         resource.getAttributes().getLeg1().getVoltageLevelId(),
                         resource.getAttributes().getLeg2().getVoltageLevelId(),
                         resource.getAttributes().getLeg3().getVoltageLevelId(),
@@ -3212,7 +3212,7 @@ public class NetworkStoreRepository {
         for (List<Resource<LineAttributes>> subresources : Lists.partition(resources, BATCH_SIZE)) {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<LineAttributes> resource : subresources) {
-                batch.add(creationalStatement(psInsertLine.bind(
+                batch.add(unsetNullValues(psInsertLine.bind(
                         networkUuid,
                         resource.getId(),
                         resource.getAttributes().getVoltageLevelId1(),
@@ -3452,7 +3452,7 @@ public class NetworkStoreRepository {
         for (List<Resource<LineAttributes>> subresources : Lists.partition(resources, BATCH_SIZE)) {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<LineAttributes> resource : subresources) {
-                batch.add(creationalStatement(psUpdateLines.bind(
+                batch.add(unsetNullValues(psUpdateLines.bind(
                         resource.getAttributes().getVoltageLevelId1(),
                         resource.getAttributes().getVoltageLevelId2(),
                         resource.getAttributes().getName(),
@@ -3557,7 +3557,7 @@ public class NetworkStoreRepository {
         for (List<Resource<HvdcLineAttributes>> subresources : Lists.partition(resources, BATCH_SIZE)) {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<HvdcLineAttributes> resource : subresources) {
-                batch.add(creationalStatement(psInsertHvdcLine.bind(
+                batch.add(unsetNullValues(psInsertHvdcLine.bind(
                         networkUuid,
                         resource.getId(),
                         resource.getAttributes().getName(),
@@ -3579,7 +3579,7 @@ public class NetworkStoreRepository {
         for (List<Resource<HvdcLineAttributes>> subresources : Lists.partition(resources, BATCH_SIZE)) {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<HvdcLineAttributes> resource : subresources) {
-                batch.add(creationalStatement(psUpdateHvdcLine.bind(
+                batch.add(unsetNullValues(psUpdateHvdcLine.bind(
                         resource.getAttributes().getName(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getR(),
@@ -3748,7 +3748,7 @@ public class NetworkStoreRepository {
         for (List<Resource<DanglingLineAttributes>> subresources : Lists.partition(resources, BATCH_SIZE)) {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<DanglingLineAttributes> resource : subresources) {
-                batch.add(creationalStatement(psInsertDanglingLine.bind(
+                batch.add(unsetNullValues(psInsertDanglingLine.bind(
                         networkUuid,
                         resource.getId(),
                         resource.getAttributes().getVoltageLevelId(),
@@ -3782,7 +3782,7 @@ public class NetworkStoreRepository {
         for (List<Resource<DanglingLineAttributes>> subresources : Lists.partition(resources, BATCH_SIZE)) {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<DanglingLineAttributes> resource : subresources) {
-                batch.add(creationalStatement(psUpdateDanglingLine.bind(
+                batch.add(unsetNullValues(psUpdateDanglingLine.bind(
                         resource.getAttributes().getName(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getNode(),
@@ -3814,7 +3814,7 @@ public class NetworkStoreRepository {
         for (List<Resource<ConfiguredBusAttributes>> subresources : Lists.partition(resources, BATCH_SIZE)) {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<ConfiguredBusAttributes> resource : subresources) {
-                batch.add(creationalStatement(psInsertConfiguredBus.bind(
+                batch.add(unsetNullValues(psInsertConfiguredBus.bind(
                         networkUuid,
                         resource.getId(),
                         resource.getAttributes().getVoltageLevelId(),
@@ -3907,7 +3907,7 @@ public class NetworkStoreRepository {
         for (List<Resource<ConfiguredBusAttributes>> subresources : Lists.partition(resources, BATCH_SIZE)) {
             BatchStatement batch = new BatchStatement(BatchStatement.Type.UNLOGGED);
             for (Resource<ConfiguredBusAttributes> resource : subresources) {
-                batch.add(creationalStatement(psUpdateConfiguredBus.bind(
+                batch.add(unsetNullValues(psUpdateConfiguredBus.bind(
                         resource.getAttributes().getName(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getV(),

--- a/network-store-server/src/main/resources/iidm.cql
+++ b/network-store-server/src/main/resources/iidm.cql
@@ -290,7 +290,7 @@ CREATE TABLE IF NOT EXISTS iidm.busbarSection (
     name text,
     properties frozen<map<text, text>>,
     node int,
-    position frozen<iidm.busbarSectionPosition>,
+    position iidm.busbarSectionPosition,
     PRIMARY KEY (networkUuid, id, voltageLevelId)
 );
 

--- a/network-store-server/src/main/resources/iidm.cql
+++ b/network-store-server/src/main/resources/iidm.cql
@@ -60,11 +60,12 @@ CREATE TABLE IF NOT EXISTS iidm.voltageLevel (
     calculatedBuses frozen<list<iidm.calculatedBus>>,
     nodeToCalculatedBus frozen<map<int, int>>,
     busToCalculatedBus frozen<map<text, int>>,
+    calculatedBusesValid boolean,
     PRIMARY KEY (networkUuid, id, substationId)
 );
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS iidm.voltageLevelBySubstation AS
-    SELECT networkUuid, id, substationId, name, properties, nominalV, lowVoltageLimit, highVoltageLimit, topologyKind, internalConnections, calculatedBuses, nodeToCalculatedBus, busToCalculatedBus
+    SELECT networkUuid, id, substationId, name, properties, nominalV, lowVoltageLimit, highVoltageLimit, topologyKind, internalConnections, calculatedBuses, nodeToCalculatedBus, busToCalculatedBus, calculatedBusesValid
     FROM iidm.voltageLevel
     WHERE networkUuid IS NOT NULL AND id IS NOT NULL AND substationId IS NOT NULL
     PRIMARY KEY (networkUuid, substationId, id);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
When updating network state a lot of tombstone are created because of null setting.


**What is the new behavior (if this is a feature change)?**
We filter null when updating the db so it means we are making some assumptions about how we model the network: we never set to null when deleting a field but we use another boolean field to define the deletion status
This is what has been done in this PR for calculatedBuses


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
