### PR TITLE
Removed TODO exceptions thrown by variant creation/removal methodes

### DIFF
--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/VariantManagerImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/VariantManagerImpl.java
@@ -34,27 +34,27 @@ public class VariantManagerImpl implements VariantManager {
 
     @Override
     public void cloneVariant(String s, List<String> list) {
-        throw new UnsupportedOperationException("TODO");
+        // TODO
     }
 
     @Override
     public void cloneVariant(String s, List<String> list, boolean b) {
-        throw new UnsupportedOperationException("TODO");
+        // TODO
     }
 
     @Override
     public void cloneVariant(String s, String s1) {
-        throw new UnsupportedOperationException("TODO");
+        // TODO
     }
 
     @Override
     public void cloneVariant(String s, String s1, boolean b) {
-        throw new UnsupportedOperationException("TODO");
+        // TODO
     }
 
     @Override
     public void removeVariant(String s) {
-        throw new UnsupportedOperationException("TODO");
+        // TODO
     }
 
     @Override


### PR DESCRIPTION
Replaced by empty implementations

Signed-off-by: NOIR Nicolas ext <nicolas.noir@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
This PR introduces empty implementations of some methods related to variant management, instead of throwing UnsupportedOperationException exceptions


**What is the current behavior?** *(You can also link to an open issue here)*
Currently, those unimplemented methods throw UnsupportedOperationException


**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
