### PR TITLE
Implementation of the ExtensionAdderProvider for EntsoeArea

### DIFF
--- a/network-store-iidm-impl/src/main/java/com/powsybl/iidm/network/extensions/EntsoeAreaAdderImplNetworkStoreProvider.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/iidm/network/extensions/EntsoeAreaAdderImplNetworkStoreProvider.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.network.extensions;
+
+import com.google.auto.service.AutoService;
+import com.powsybl.commons.extensions.ExtensionAdderProvider;
+import com.powsybl.entsoe.util.EntsoeArea;
+import com.powsybl.entsoe.util.EntsoeAreaAdderImpl;
+import com.powsybl.iidm.network.Substation;
+
+/**
+ * @author Nicolas Noir <nicolas.noir at rte-france.com>
+ */
+@AutoService(ExtensionAdderProvider.class)
+public class EntsoeAreaAdderImplNetworkStoreProvider implements
+        ExtensionAdderProvider<Substation, EntsoeArea, EntsoeAreaAdderImpl> {
+
+    @Override
+    public String getImplementationName() {
+        return "NetworkStore";
+    }
+
+    @Override
+    public Class<EntsoeAreaAdderImpl> getAdderClass() {
+        return EntsoeAreaAdderImpl.class;
+    }
+
+    @Override
+    public EntsoeAreaAdderImpl newAdder(Substation extendable) {
+        return new EntsoeAreaAdderImpl(extendable);
+    }
+}

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/SubstationImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/SubstationImpl.java
@@ -6,7 +6,12 @@
  */
 package com.powsybl.network.store.iidm.impl;
 
+import com.powsybl.commons.extensions.Extension;
+import com.powsybl.entsoe.util.EntsoeArea;
+import com.powsybl.entsoe.util.EntsoeAreaImpl;
+import com.powsybl.entsoe.util.EntsoeGeographicalCode;
 import com.powsybl.iidm.network.*;
+import com.powsybl.network.store.model.EntsoeAreaAttributes;
 import com.powsybl.network.store.model.Resource;
 import com.powsybl.network.store.model.SubstationAttributes;
 
@@ -142,6 +147,46 @@ public class SubstationImpl extends AbstractIdentifiableImpl<Substation, Substat
     @Override
     public Set<String> getGeographicalTags() {
         return Collections.emptySet();
+    }
+
+    @Override
+    public <E extends Extension<Substation>> void addExtension(Class<? super E> type, E extension) {
+        if (type == EntsoeArea.class) {
+            EntsoeArea entsoeArea = (EntsoeArea) extension;
+            resource.getAttributes().setEntsoeArea(
+                    EntsoeAreaAttributes.builder()
+                            .name(entsoeArea.getName())
+                            .code(entsoeArea.getCode().toString())
+                    .build());
+        }
+        super.addExtension(type, extension);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <E extends Extension<Substation>> E getExtension(Class<? super E> type) {
+        if (type == EntsoeArea.class) {
+            return (E) createEntsoeArea();
+        }
+        return super.getExtension(type);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <E extends Extension<Substation>> E getExtensionByName(String name) {
+        if (name.equals("entsoeArea")) {
+            return (E) createEntsoeArea();
+        }
+        return super.getExtensionByName(name);
+    }
+
+    private EntsoeArea createEntsoeArea() {
+
+        if (resource.getAttributes().getEntsoeArea() != null) {
+            return new EntsoeAreaImpl(this,
+                    EntsoeGeographicalCode.valueOf(resource.getAttributes().getEntsoeArea().getCode()));
+        }
+        return null;
     }
 
     @Override

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/SubstationImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/SubstationImpl.java
@@ -155,7 +155,6 @@ public class SubstationImpl extends AbstractIdentifiableImpl<Substation, Substat
             EntsoeArea entsoeArea = (EntsoeArea) extension;
             resource.getAttributes().setEntsoeArea(
                     EntsoeAreaAttributes.builder()
-                            .name(entsoeArea.getName())
                             .code(entsoeArea.getCode().toString())
                     .build());
         }

--- a/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreIT.java
+++ b/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreIT.java
@@ -13,9 +13,7 @@ import com.powsybl.cgmes.conformity.test.CgmesConformity1Catalog;
 import com.powsybl.commons.datasource.ReadOnlyDataSource;
 import com.powsybl.commons.datasource.ResourceDataSource;
 import com.powsybl.commons.datasource.ResourceSet;
-import com.powsybl.entsoe.util.MergedXnode;
-import com.powsybl.entsoe.util.MergedXnodeImpl;
-import com.powsybl.entsoe.util.Xnode;
+import com.powsybl.entsoe.util.*;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.VoltageLevel.NodeBreakerView.InternalConnection;
 import com.powsybl.iidm.network.extensions.ActivePowerControl;
@@ -1192,6 +1190,17 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
             regularLine.getTerminal1().setP(500.);
             regularLine.getTerminal2().setQ(300.);
 
+            Substation s2 = readNetwork.newSubstation()
+                    .setId("D7_TEST_SUB_EA")
+                    .setCountry(Country.DE)
+                    .add();
+
+            assertNull(s2.getExtension(EntsoeArea.class));
+            s2.addExtension(EntsoeArea.class,
+                    new EntsoeAreaImpl(s2, EntsoeGeographicalCode.D7));
+            assertNotNull(s2.getExtension(EntsoeArea.class));
+            assertEquals(EntsoeGeographicalCode.D7, s2.getExtension(EntsoeArea.class).getCode());
+
             service.flush(readNetwork);  // flush the network
         }
 
@@ -1210,6 +1219,10 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
 
             assertEquals(500., regularLine.getTerminal1().getP(), 0.);
             assertEquals(300., regularLine.getTerminal2().getQ(), 0.);
+
+            Substation substationTestEntsoeArea = readNetwork.getSubstation("D7_TEST_SUB_EA");
+            assertNotNull(substationTestEntsoeArea);
+            assertEquals(EntsoeGeographicalCode.D7, substationTestEntsoeArea.getExtension(EntsoeArea.class).getCode());
         }
     }
 

--- a/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreIT.java
+++ b/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreIT.java
@@ -1196,9 +1196,11 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
                     .add();
 
             assertNull(s2.getExtension(EntsoeArea.class));
+            assertNull(s2.getExtensionByName("entsoeArea"));
             s2.addExtension(EntsoeArea.class,
                     new EntsoeAreaImpl(s2, EntsoeGeographicalCode.D7));
             assertNotNull(s2.getExtension(EntsoeArea.class));
+            assertNotNull(s2.getExtensionByName("entsoeArea"));
             assertEquals(EntsoeGeographicalCode.D7, s2.getExtension(EntsoeArea.class).getCode());
 
             service.flush(readNetwork);  // flush the network

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/EntsoeAreaAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/EntsoeAreaAttributes.java
@@ -26,9 +26,6 @@ import lombok.NoArgsConstructor;
 
 public class EntsoeAreaAttributes {
 
-    @ApiModelProperty("name")
-    String name;
-
     @ApiModelProperty("code")
     String code;
 }

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/EntsoeAreaAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/EntsoeAreaAttributes.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.network.store.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * @author Nicolas Noir <nicolas.noir at rte-france.com>
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@ApiModel("Entsoe area extension attributes")
+
+public class EntsoeAreaAttributes {
+
+    @ApiModelProperty("name")
+    String name;
+
+    @ApiModelProperty("code")
+    String code;
+}

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/SubstationAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/SubstationAttributes.java
@@ -40,4 +40,7 @@ public class SubstationAttributes implements IdentifiableAttributes {
 
     @ApiModelProperty("TSO the substation belongs to")
     private String tso;
+
+    @ApiModelProperty("Entsoe area the substation belongs to")
+    private EntsoeAreaAttributes entsoeArea;
 }

--- a/network-store-server/src/main/java/com/powsybl/network/store/server/CassandraConfig.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/CassandraConfig.java
@@ -1027,13 +1027,11 @@ public class CassandraConfig extends AbstractCassandraConfiguration {
 
         protected EntsoeAreaAttributes toEntsoeArea(UDTValue value) {
             return value == null ? null : new EntsoeAreaAttributes(
-                    value.getString("name"),
                     value.getString("code"));
         }
 
         protected UDTValue toUDTValue(EntsoeAreaAttributes value) {
             return value == null ? null : userType.newValue()
-                    .setString("name", value.getName())
                     .setString("code", value.getCode());
         }
     }

--- a/network-store-server/src/main/java/com/powsybl/network/store/server/CassandraConfig.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/CassandraConfig.java
@@ -139,6 +139,11 @@ public class CassandraConfig extends AbstractCassandraConfiguration {
             ActivePowerControlCodec activePowerControlCodec = new ActivePowerControlCodec(activePowerControlTypeCodec, ActivePowerControlAttributes.class);
             codecRegistry.register(activePowerControlCodec);
 
+            UserType entsoeAreaType = keyspace.getUserType("entsoeArea");
+            TypeCodec<UDTValue> entsoeAreaTypeCodec = codecRegistry.codecFor(entsoeAreaType);
+            EntsoeAreaCodec entsoeAreaCodec = new EntsoeAreaCodec(entsoeAreaTypeCodec, EntsoeAreaAttributes.class);
+            codecRegistry.register(entsoeAreaCodec);
+
             codecRegistry.register(InstantCodec.instance);
             return builder;
         });
@@ -987,4 +992,50 @@ public class CassandraConfig extends AbstractCassandraConfiguration {
                     .setFloat("droop", value.getDroop());
         }
     }
+
+    private static class EntsoeAreaCodec extends TypeCodec<EntsoeAreaAttributes> {
+
+        private final TypeCodec<UDTValue> innerCodec;
+
+        private final UserType userType;
+
+        public EntsoeAreaCodec(TypeCodec<UDTValue> innerCodec, Class<EntsoeAreaAttributes> javaType) {
+            super(innerCodec.getCqlType(), javaType);
+            this.innerCodec = innerCodec;
+            this.userType = (UserType) innerCodec.getCqlType();
+        }
+
+        @Override
+        public ByteBuffer serialize(EntsoeAreaAttributes value, ProtocolVersion protocolVersion) throws InvalidTypeException {
+            return innerCodec.serialize(toUDTValue(value), protocolVersion);
+        }
+
+        @Override
+        public EntsoeAreaAttributes deserialize(ByteBuffer bytes, ProtocolVersion protocolVersion) throws InvalidTypeException {
+            return toEntsoeArea(innerCodec.deserialize(bytes, protocolVersion));
+        }
+
+        @Override
+        public EntsoeAreaAttributes parse(String value) throws InvalidTypeException {
+            return value == null || value.isEmpty() ? null : toEntsoeArea(innerCodec.parse(value));
+        }
+
+        @Override
+        public String format(EntsoeAreaAttributes value) throws InvalidTypeException {
+            return value == null ? null : innerCodec.format(toUDTValue(value));
+        }
+
+        protected EntsoeAreaAttributes toEntsoeArea(UDTValue value) {
+            return value == null ? null : new EntsoeAreaAttributes(
+                    value.getString("name"),
+                    value.getString("code"));
+        }
+
+        protected UDTValue toUDTValue(EntsoeAreaAttributes value) {
+            return value == null ? null : userType.newValue()
+                    .setString("name", value.getName())
+                    .setString("code", value.getCode());
+        }
+    }
+
 }

--- a/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreRepository.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreRepository.java
@@ -96,7 +96,8 @@ public class NetworkStoreRepository {
                 .value("name", bindMarker())
                 .value("properties", bindMarker())
                 .value("country", bindMarker())
-                .value("tso", bindMarker()));
+                .value("tso", bindMarker())
+                .value("entsoeArea", bindMarker()));
 
         psInsertVoltageLevel = session.prepare(insertInto(KEYSPACE_IIDM, "voltageLevel")
                 .value("networkUuid", bindMarker())
@@ -818,7 +819,7 @@ public class NetworkStoreRepository {
     // substation
 
     public List<Resource<SubstationAttributes>> getSubstations(UUID networkUuid) {
-        ResultSet resultSet = session.execute(select("id", "name", "properties", "country", "tso").from(KEYSPACE_IIDM, "substation")
+        ResultSet resultSet = session.execute(select("id", "name", "properties", "country", "tso", "entsoeArea").from(KEYSPACE_IIDM, "substation")
                 .where(eq("networkUuid", networkUuid)));
         List<Resource<SubstationAttributes>> resources = new ArrayList<>();
         for (Row row : resultSet) {
@@ -829,6 +830,7 @@ public class NetworkStoreRepository {
                             .properties(row.getMap(2, String.class, String.class))
                             .country(row.getString(3) != null ? Country.valueOf(row.getString(3)) : null)
                             .tso(row.getString(4))
+                            .entsoeArea(row.get(5, EntsoeAreaAttributes.class))
                             .build())
                     .build());
         }
@@ -839,7 +841,8 @@ public class NetworkStoreRepository {
         ResultSet resultSet = session.execute(select("name",
                                                      "properties",
                                                      "country",
-                                                     "tso")
+                                                     "tso",
+                                                     "entsoeArea")
                 .from(KEYSPACE_IIDM, "substation")
                 .where(eq("networkUuid", networkUuid)).and(eq("id", substationId)));
         Row one = resultSet.one();
@@ -851,6 +854,7 @@ public class NetworkStoreRepository {
                             .properties(one.getMap(1, String.class, String.class))
                             .country(one.getString(2) != null ? Country.valueOf(one.getString(2)) : null)
                             .tso(one.getString(3))
+                            .entsoeArea(one.get(4, EntsoeAreaAttributes.class))
                             .build())
                     .build());
         }
@@ -867,7 +871,8 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getName(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getCountry() != null ? resource.getAttributes().getCountry().toString() : null,
-                        resource.getAttributes().getTso()
+                        resource.getAttributes().getTso(),
+                        resource.getAttributes().getEntsoeArea()
                         )));
             }
             session.execute(batch);

--- a/network-store-server/src/main/resources/iidm.cql
+++ b/network-store-server/src/main/resources/iidm.cql
@@ -11,7 +11,6 @@ CREATE TABLE IF NOT EXISTS iidm.network (
 );
 
 CREATE TYPE  IF NOT EXISTS iidm.entsoeArea (
-    name text,
     code text
 );
 

--- a/network-store-server/src/main/resources/iidm.cql
+++ b/network-store-server/src/main/resources/iidm.cql
@@ -10,6 +10,11 @@ CREATE TABLE IF NOT EXISTS iidm.network (
     PRIMARY KEY (uuid)
 );
 
+CREATE TYPE  IF NOT EXISTS iidm.entsoeArea (
+    name text,
+    code text
+);
+
 CREATE TABLE IF NOT EXISTS iidm.substation (
     networkUuid uuid,
     id text,
@@ -17,6 +22,7 @@ CREATE TABLE IF NOT EXISTS iidm.substation (
     properties frozen<map<text, text>>,
     country text,
     tso text,
+    entsoeArea iidm.entsoeArea,
     PRIMARY KEY (networkUuid, id)
 );
 

--- a/network-store-server/src/test/java/com/powsybl/network/store/server/NetworkStoreControllerIT.java
+++ b/network-store-server/src/test/java/com/powsybl/network/store/server/NetworkStoreControllerIT.java
@@ -92,6 +92,7 @@ public class NetworkStoreControllerIT extends AbstractEmbeddedCassandraSetup {
                 .attributes(SubstationAttributes.builder()
                         .country(Country.FR)
                         .tso("RTE")
+                        .entsoeArea(EntsoeAreaAttributes.builder().code("D7").build())
                         .build())
                 .build();
         mvc.perform(post("/" + VERSION + "/networks/" + networkUuid + "/substations")
@@ -104,7 +105,8 @@ public class NetworkStoreControllerIT extends AbstractEmbeddedCassandraSetup {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("data[0].id").value("bar"))
                 .andExpect(jsonPath("data[0].attributes.country").value("FR"))
-                .andExpect(jsonPath("data[0].attributes.tso").value("RTE"));
+                .andExpect(jsonPath("data[0].attributes.tso").value("RTE"))
+                .andExpect(jsonPath("data[0].attributes.entsoeArea.code").value("D7"));
 
         Resource<SubstationAttributes> bar2 = Resource.substationBuilder()
                 .id("bar2")


### PR DESCRIPTION

Signed-off-by: NOIR Nicolas ext <nicolas.noir@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
This PR fixes a bug when importing a UCTE network.


**What is the current behavior?** *(You can also link to an open issue here)*
Currently, when trying to import a UCTE network file, an error is raised due to the lack of implementation of the EntsoeAreaAdder provider for the network store. The extension for the substation dedicated to the EntsoeArea is also not implemented.


**What is the new behavior (if this is a feature change)?**


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
