### PR TITLE
Fix caching regression when loading container resources

### DIFF
--- a/network-store-client/src/main/java/com/powsybl/network/store/client/CollectionCache.java
+++ b/network-store-client/src/main/java/com/powsybl/network/store/client/CollectionCache.java
@@ -170,7 +170,7 @@ public class CollectionCache<T extends IdentifiableAttributes> {
             throw new PowsyblException("it is not possible to load resources by container, if container resources loader has not been specified");
         }
 
-        if (!containerFullyLoaded.contains(containerId)) {
+        if (!fullyLoaded && !containerFullyLoaded.contains(containerId)) {
             List<Resource<T>> resourcesToAdd = containerLoaderFunction.apply(containerId);
 
             // by container cache update


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Caching is broken, when loading resources from a container, even if collection has been fully loaded it might is some case query the resource from the server.


**What is the new behavior (if this is a feature change)?**
Caching has been fixed


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
