### PR TITLE
Add load detail provider to avoid exception

### DIFF
--- a/network-store-iidm-impl/src/main/java/com/powsybl/iidm/network/extensions/LoadDetailAdderImplNetworkStoreProvider.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/iidm/network/extensions/LoadDetailAdderImplNetworkStoreProvider.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.iidm.network.extensions;
+
+import com.google.auto.service.AutoService;
+import com.powsybl.commons.extensions.ExtensionAdderProvider;
+import com.powsybl.iidm.network.Load;
+
+/**
+ *  @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+@AutoService(ExtensionAdderProvider.class)
+public class LoadDetailAdderImplNetworkStoreProvider implements
+        ExtensionAdderProvider<Load, LoadDetail, LoadDetailAdderImpl> {
+
+    @Override
+    public String getImplementationName() {
+        return "NetworkStore";
+    }
+
+    @Override
+    public Class<LoadDetailAdderImpl> getAdderClass() {
+        return LoadDetailAdderImpl.class;
+    }
+
+    @Override
+    public LoadDetailAdderImpl newAdder(Load load) {
+        return new LoadDetailAdderImpl(load);
+    }
+}


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
As LoadDetail new extension is not supported we cannot anymore import some CGMES.


**What is the new behavior (if this is a feature change)?**
A fake LoadDetail extension provider is added to avoid the exception. The full LoadDetail support will be added in another PR.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
