### PR TITLE
use cassandra-extras 3.7 because spring set cassandra-core 3.7, not 3.6

### DIFF
--- a/network-store-server/pom.xml
+++ b/network-store-server/pom.xml
@@ -65,7 +65,6 @@
         <dependency>
           <groupId>com.datastax.cassandra</groupId>
           <artifactId>cassandra-driver-extras</artifactId>
-          <version>3.6.0</version>
         </dependency>
         <dependency>
             <groupId>io.springfox</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,9 @@
     <properties>
         <java.version>11</java.version>
 
-        <datastax.java-driver.version>4.5.1</datastax.java-driver.version>
+        <!-- same as spring-boot-dependencies 2.2.7.RELEASE ; check when upgrading spring boot -->
+        <cassandra-driver.version>3.7.2</cassandra-driver.version>
+
         <embedded-cassandra.version>3.0.3</embedded-cassandra.version>
         <guava.version>28.2-jre</guava.version>
         <jgrapht.version>1.0.1</jgrapht.version>
@@ -92,6 +94,11 @@
     <dependencyManagement>
         <dependencies>
             <!-- Compilation dependencies -->
+            <dependency>
+              <groupId>com.datastax.cassandra</groupId>
+              <artifactId>cassandra-driver-extras</artifactId>
+              <version>${cassandra-driver.version}</version>
+            </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug Fix


**What is the current behavior?** *(You can also link to an open issue here)*
Using cassandra-driver-core 3.6 and extras 3.7


**What is the new behavior (if this is a feature change)?**
Using cassandra-driver-core 3.7 and extras 3.7



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
NO
