### PR TITLE
Workaroudn compilation crash with jdk11 < 11.0.8

### DIFF
--- a/network-store-client/src/main/java/com/powsybl/network/store/client/RestClient.java
+++ b/network-store-client/src/main/java/com/powsybl/network/store/client/RestClient.java
@@ -31,7 +31,7 @@ public class RestClient {
         return restTemplate.exchange(url,
                 HttpMethod.GET,
                 new HttpEntity<>(new HttpHeaders()),
-                new ParameterizedTypeReference<>() {
+                new ParameterizedTypeReference<TopLevelDocument<T>>() {
                 },
                 uriVariables);
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug Fix


**What is the current behavior?** *(You can also link to an open issue here)*
compilation crash with jdk 11.0.7 and before


**What is the new behavior (if this is a feature change)?**
compilation works


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
NO

**Other information**:
    See
    https://stackoverflow.com/questions/54775253/jdk-11-0-2-compilation-fails-with-javac-npe-on-anonymous-parameterized-class-typ
    https://bugs.openjdk.java.net/browse/JDK-8212586
    
    Error message from the command line:
            compiler message file broken: key=compiler.misc.msg.bug arguments=11.0.5, {1}, {2}, {3}, {4}, {5}, {6}, {7}
            java.lang.NullPointerException
                    at jdk.compiler/com.sun.tools.javac.comp.Flow$FlowAnalyzer.visitApply(Flow.java:1235)
                    at jdk.compiler/com.sun.tools.javac.tree.JCTree$JCMethodInvocation.accept(JCTree.java:1634)
                    at jdk.compiler/com.sun.tools.javac.tree.TreeScanner.scan(TreeScanner.java:49)
                    ...
    
