### PR TITLE
Implementation of substations and voltage levels removal

### DIFF
--- a/network-store-client/src/main/java/com/powsybl/network/store/client/BufferedNetworkStoreClient.java
+++ b/network-store-client/src/main/java/com/powsybl/network/store/client/BufferedNetworkStoreClient.java
@@ -43,7 +43,7 @@ public class BufferedNetworkStoreClient extends ForwardingNetworkStoreClient {
             = new NetworkCollectionIndex<>(uuid -> new CollectionBuffer<>(delegate::createBusbarSections, null, delegate::removeBusBarSections));
 
     private final NetworkCollectionIndex<CollectionBuffer<SwitchAttributes>> switchResourcesToFlush
-            = new NetworkCollectionIndex<>(uuid -> new CollectionBuffer<>(delegate::createSwitches, delegate::updateSwitches, null));
+            = new NetworkCollectionIndex<>(uuid -> new CollectionBuffer<>(delegate::createSwitches, delegate::updateSwitches, delegate::removeSwitches));
 
     private final NetworkCollectionIndex<CollectionBuffer<ShuntCompensatorAttributes>> shuntCompensatorResourcesToFlush
             = new NetworkCollectionIndex<>(uuid -> new CollectionBuffer<>(delegate::createShuntCompensators, delegate::updateShuntCompensators, delegate::removeShuntCompensators));
@@ -73,7 +73,7 @@ public class BufferedNetworkStoreClient extends ForwardingNetworkStoreClient {
             = new NetworkCollectionIndex<>(uuid -> new CollectionBuffer<>(delegate::createLines, delegate::updateLines, delegate::removeLines));
 
     private final NetworkCollectionIndex<CollectionBuffer<ConfiguredBusAttributes>> busResourcesToFlush
-            = new NetworkCollectionIndex<>(uuid -> new CollectionBuffer<>(delegate::createConfiguredBuses, delegate::updateConfiguredBuses, null));
+            = new NetworkCollectionIndex<>(uuid -> new CollectionBuffer<>(delegate::createConfiguredBuses, delegate::updateConfiguredBuses, delegate::removeConfiguredBuses));
 
     public BufferedNetworkStoreClient(NetworkStoreClient delegate) {
         super(delegate);
@@ -155,6 +155,11 @@ public class BufferedNetworkStoreClient extends ForwardingNetworkStoreClient {
     @Override
     public void updateSwitch(UUID networkUuid, Resource<SwitchAttributes> switchResource) {
         switchResourcesToFlush.getCollection(networkUuid).update(switchResource);
+    }
+
+    @Override
+    public void removeSwitch(UUID networkUuid, String switchId) {
+        switchResourcesToFlush.getCollection(networkUuid).remove(switchId);
     }
 
     @Override
@@ -357,6 +362,11 @@ public class BufferedNetworkStoreClient extends ForwardingNetworkStoreClient {
     @Override
     public void updateConfiguredBus(UUID networkUuid, Resource<ConfiguredBusAttributes> busesResource) {
         busResourcesToFlush.getCollection(networkUuid).update(busesResource);
+    }
+
+    @Override
+    public void removeConfiguredBus(UUID networkUuid, String busId) {
+        busResourcesToFlush.getCollection(networkUuid).remove(busId);
     }
 
     @Override

--- a/network-store-client/src/main/java/com/powsybl/network/store/client/BufferedNetworkStoreClient.java
+++ b/network-store-client/src/main/java/com/powsybl/network/store/client/BufferedNetworkStoreClient.java
@@ -25,10 +25,10 @@ public class BufferedNetworkStoreClient extends ForwardingNetworkStoreClient {
     private final Map<UUID, Resource<NetworkAttributes>> updateNetworkResourcesToFlush = new HashMap<>();
 
     private final NetworkCollectionIndex<CollectionBuffer<SubstationAttributes>> substationResourcesToFlush
-            = new NetworkCollectionIndex<>(uuid -> new CollectionBuffer<>(delegate::createSubstations, null, null));
+            = new NetworkCollectionIndex<>(uuid -> new CollectionBuffer<>(delegate::createSubstations, null, delegate::removeSubstations));
 
     private final NetworkCollectionIndex<CollectionBuffer<VoltageLevelAttributes>> voltageLevelResourcesToFlush
-            = new NetworkCollectionIndex<>(uuid -> new CollectionBuffer<>(delegate::createVoltageLevels, delegate::updateVoltageLevels, null));
+            = new NetworkCollectionIndex<>(uuid -> new CollectionBuffer<>(delegate::createVoltageLevels, delegate::updateVoltageLevels, delegate::removeVoltageLevels));
 
     private final NetworkCollectionIndex<CollectionBuffer<GeneratorAttributes>> generatorResourcesToFlush
             = new NetworkCollectionIndex<>(uuid -> new CollectionBuffer<>(delegate::createGenerators, delegate::updateGenerators, delegate::removeGenerators));
@@ -128,6 +128,11 @@ public class BufferedNetworkStoreClient extends ForwardingNetworkStoreClient {
     }
 
     @Override
+    public void removeSubstation(UUID networkUuid, String substationId) {
+        substationResourcesToFlush.getCollection(networkUuid).remove(substationId);
+    }
+
+    @Override
     public void createVoltageLevels(UUID networkUuid, List<Resource<VoltageLevelAttributes>> voltageLevelResources) {
         voltageLevelResourcesToFlush.getCollection(networkUuid).create(voltageLevelResources);
     }
@@ -135,6 +140,11 @@ public class BufferedNetworkStoreClient extends ForwardingNetworkStoreClient {
     @Override
     public void updateVoltageLevel(UUID networkUuid, Resource<VoltageLevelAttributes> voltageLevelResource) {
         voltageLevelResourcesToFlush.getCollection(networkUuid).update(voltageLevelResource);
+    }
+
+    @Override
+    public void removeVoltageLevel(UUID networkUuid, String voltageLevelId) {
+        voltageLevelResourcesToFlush.getCollection(networkUuid).remove(voltageLevelId);
     }
 
     @Override

--- a/network-store-client/src/main/java/com/powsybl/network/store/client/PreloadingNetworkStoreClient.java
+++ b/network-store-client/src/main/java/com/powsybl/network/store/client/PreloadingNetworkStoreClient.java
@@ -145,6 +145,12 @@ public class PreloadingNetworkStoreClient extends ForwardingNetworkStoreClient i
     }
 
     @Override
+    public void removeSubstation(UUID networkUuid, String substationId) {
+        ensureCached(ResourceType.SUBSTATION, networkUuid);
+        delegate.removeSubstation(networkUuid, substationId);
+    }
+
+    @Override
     public void createVoltageLevels(UUID networkUuid, List<Resource<VoltageLevelAttributes>> voltageLevelResources) {
         ensureCached(ResourceType.VOLTAGE_LEVEL, networkUuid);
         delegate.createVoltageLevels(networkUuid, voltageLevelResources);
@@ -172,6 +178,12 @@ public class PreloadingNetworkStoreClient extends ForwardingNetworkStoreClient i
     public int getVoltageLevelCount(UUID networkUuid) {
         ensureCached(ResourceType.VOLTAGE_LEVEL, networkUuid);
         return delegate.getVoltageLevelCount(networkUuid);
+    }
+
+    @Override
+    public void removeVoltageLevel(UUID networkUuid, String voltageLevelId) {
+        ensureCached(ResourceType.VOLTAGE_LEVEL, networkUuid);
+        delegate.removeVoltageLevel(networkUuid, voltageLevelId);
     }
 
     @Override

--- a/network-store-client/src/main/java/com/powsybl/network/store/client/PreloadingNetworkStoreClient.java
+++ b/network-store-client/src/main/java/com/powsybl/network/store/client/PreloadingNetworkStoreClient.java
@@ -361,6 +361,12 @@ public class PreloadingNetworkStoreClient extends ForwardingNetworkStoreClient i
     }
 
     @Override
+    public void removeSwitch(UUID networkUuid, String switchId) {
+        ensureCached(ResourceType.SWITCH, networkUuid);
+        delegate.removeSwitch(networkUuid, switchId);
+    }
+
+    @Override
     public void createBusbarSections(UUID networkUuid, List<Resource<BusbarSectionAttributes>> busbarSectionResources) {
         ensureCached(ResourceType.BUSBAR_SECTION, networkUuid);
         delegate.createBusbarSections(networkUuid, busbarSectionResources);
@@ -787,4 +793,11 @@ public class PreloadingNetworkStoreClient extends ForwardingNetworkStoreClient i
         ensureCached(ResourceType.CONFIGURED_BUS, networkUuid);
         delegate.updateConfiguredBus(networkUuid, busesResource);
     }
+
+    @Override
+    public void removeConfiguredBus(UUID networkUuid, String configuredBusId) {
+        ensureCached(ResourceType.CONFIGURED_BUS, networkUuid);
+        delegate.removeConfiguredBus(networkUuid, configuredBusId);
+    }
+
 }

--- a/network-store-client/src/main/java/com/powsybl/network/store/client/RestNetworkStoreClient.java
+++ b/network-store-client/src/main/java/com/powsybl/network/store/client/RestNetworkStoreClient.java
@@ -207,6 +207,16 @@ public class RestNetworkStoreClient implements NetworkStoreClient {
         return getTotalCount("substation", "/networks/{networkUuid}/substations?limit=0", networkUuid);
     }
 
+    @Override
+    public void removeSubstation(UUID networkUuid, String substationId) {
+        restClient.delete("/networks/{networkUuid}/substations/{substationId}", networkUuid, substationId);
+    }
+
+    @Override
+    public void removeSubstations(UUID networkUuid, List<String> substationsId) {
+        substationsId.forEach(substationId -> removeSubstation(networkUuid, substationId));
+    }
+
     // voltage level
 
     @Override
@@ -242,6 +252,16 @@ public class RestNetworkStoreClient implements NetworkStoreClient {
     @Override
     public void updateVoltageLevel(UUID networkUuid, Resource<VoltageLevelAttributes> voltageLevelResource) {
         updateVoltageLevels(networkUuid, Collections.singletonList(voltageLevelResource));
+    }
+
+    @Override
+    public void removeVoltageLevel(UUID networkUuid, String voltageLevelId) {
+        restClient.delete("/networks/{networkUuid}/voltage-levels/{voltageLevelId}", networkUuid, voltageLevelId);
+    }
+
+    @Override
+    public void removeVoltageLevels(UUID networkUuid, List<String> voltageLevelsId) {
+        voltageLevelsId.forEach(voltageLevelId -> removeVoltageLevel(networkUuid, voltageLevelId));
     }
 
     @Override

--- a/network-store-client/src/main/java/com/powsybl/network/store/client/RestNetworkStoreClient.java
+++ b/network-store-client/src/main/java/com/powsybl/network/store/client/RestNetworkStoreClient.java
@@ -461,6 +461,16 @@ public class RestNetworkStoreClient implements NetworkStoreClient {
         updateSwitches(networkUuid, Collections.singletonList(resource));
     }
 
+    @Override
+    public void removeSwitch(UUID networkUuid, String switchId) {
+        restClient.delete("/networks/{networkUuid}/switches/{switchId}", networkUuid, switchId);
+    }
+
+    @Override
+    public void removeSwitches(UUID networkUuid, List<String> switchesId) {
+        switchesId.forEach(switchId -> removeConfiguredBus(networkUuid, switchId));
+    }
+
     // busbar section
 
     @Override
@@ -927,6 +937,16 @@ public class RestNetworkStoreClient implements NetworkStoreClient {
     @Override
     public void updateConfiguredBus(UUID networkUuid, Resource<ConfiguredBusAttributes> resource) {
         updateConfiguredBuses(networkUuid, Collections.singletonList(resource));
+    }
+
+    @Override
+    public void removeConfiguredBus(UUID networkUuid, String busId) {
+        restClient.delete("/networks/{networkUuid}/configured-buses/{busId}", networkUuid, busId);
+    }
+
+    @Override
+    public void removeConfiguredBuses(UUID networkUuid, List<String> busesId) {
+        busesId.forEach(busId -> removeConfiguredBus(networkUuid, busId));
     }
 
     @Override

--- a/network-store-client/src/main/java/com/powsybl/network/store/client/RestNetworkStoreClient.java
+++ b/network-store-client/src/main/java/com/powsybl/network/store/client/RestNetworkStoreClient.java
@@ -468,7 +468,7 @@ public class RestNetworkStoreClient implements NetworkStoreClient {
 
     @Override
     public void removeSwitches(UUID networkUuid, List<String> switchesId) {
-        switchesId.forEach(switchId -> removeConfiguredBus(networkUuid, switchId));
+        switchesId.forEach(switchId -> removeSwitch(networkUuid, switchId));
     }
 
     // busbar section

--- a/network-store-client/src/test/java/com/powsybl/network/store/client/PreloadingNetworkStoreClientTest.java
+++ b/network-store-client/src/test/java/com/powsybl/network/store/client/PreloadingNetworkStoreClientTest.java
@@ -8,6 +8,7 @@ package com.powsybl.network.store.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
+import com.powsybl.iidm.network.Country;
 import com.powsybl.iidm.network.LoadType;
 import com.powsybl.iidm.network.SwitchKind;
 import com.powsybl.network.store.iidm.impl.ResourceUpdaterImpl;
@@ -63,6 +64,80 @@ public class PreloadingNetworkStoreClientTest {
     }
 
     @Test
+    public void testSubstationCache() throws IOException {
+        // Two successive substation retrievals, only the first should send a REST request, the second uses the cache
+        Resource<SubstationAttributes> substation = Resource.substationBuilder()
+                .id("sub1")
+                .attributes(SubstationAttributes.builder()
+                        .country(Country.FR)
+                        .tso("TSO_FR")
+                        .name("SUB1")
+                        .build())
+                .build();
+
+        String substationJson = objectMapper.writeValueAsString(TopLevelDocument.of(ImmutableList.of(substation)));
+
+        server.expect(ExpectedCount.once(), requestTo("/networks/" + networkUuid + "/substations"))
+                .andExpect(method(GET))
+                .andRespond(withSuccess(substationJson, MediaType.APPLICATION_JSON));
+
+        // First time substation retrieval by Id
+        Resource<SubstationAttributes> substationAttributesResource = cachedClient.getSubstation(networkUuid, "sub1").orElse(null);
+        assertNotNull(substationAttributesResource);
+        assertEquals(Boolean.TRUE, substationAttributesResource.getAttributes().getName().equals("SUB1"));  // test substation name
+
+        substationAttributesResource.getAttributes().setName("SUBSTATION1");  // change substation name
+
+        // Second time substation retrieval by Id
+        substationAttributesResource = cachedClient.getSubstation(networkUuid, "sub1").orElse(null);
+        assertNotNull(substationAttributesResource);
+        assertEquals(Boolean.TRUE, substationAttributesResource.getAttributes().getName().equals("SUBSTATION1"));  // test substation name
+
+        // Remove component
+        assertEquals(1, cachedClient.getSubstationCount(networkUuid));
+        cachedClient.removeSubstation(networkUuid, "sub1");
+        assertEquals(0, cachedClient.getSubstationCount(networkUuid));
+        server.verify();
+    }
+
+    @Test
+    public void testVoltageLevelCache() throws IOException {
+        // Two successive voltage level retrievals, only the first should send a REST request, the second uses the cache
+        Resource<VoltageLevelAttributes> vl = Resource.voltageLevelBuilder()
+                .id("vl1")
+                .attributes(VoltageLevelAttributes.builder()
+                        .name("VL1")
+                        .lowVoltageLimit(100)
+                        .highVoltageLimit(200)
+                        .build())
+                .build();
+
+        String voltageLevelJson = objectMapper.writeValueAsString(TopLevelDocument.of(ImmutableList.of(vl)));
+
+        server.expect(ExpectedCount.once(), requestTo("/networks/" + networkUuid + "/voltage-levels"))
+                .andExpect(method(GET))
+                .andRespond(withSuccess(voltageLevelJson, MediaType.APPLICATION_JSON));
+
+        // First time voltage level retrieval by Id
+        Resource<VoltageLevelAttributes> voltageLevelAttributesResource = cachedClient.getVoltageLevel(networkUuid, "vl1").orElse(null);
+        assertNotNull(voltageLevelAttributesResource);
+        assertEquals(Boolean.TRUE, voltageLevelAttributesResource.getAttributes().getName().equals("VL1"));  // test voltage level name
+
+        voltageLevelAttributesResource.getAttributes().setName("VOLTAGE_LEVEL_1");  // change substation name
+
+        // Second time voltage level retrieval by Id
+        voltageLevelAttributesResource = cachedClient.getVoltageLevel(networkUuid, "vl1").orElse(null);
+        assertNotNull(voltageLevelAttributesResource);
+        assertEquals(Boolean.TRUE, voltageLevelAttributesResource.getAttributes().getName().equals("VOLTAGE_LEVEL_1"));  // test voltage level name
+
+        // Remove component
+        assertEquals(1, cachedClient.getVoltageLevelCount(networkUuid));
+        cachedClient.removeVoltageLevel(networkUuid, "vl1");
+        assertEquals(0, cachedClient.getVoltageLevelCount(networkUuid));
+        server.verify();
+    }
+
+    @Test
     public void testSwitchCache() throws IOException {
         // Two successive switch retrievals, only the first should send a REST request, the second uses the cache
         Resource<SwitchAttributes> breaker = Resource.switchBuilder(networkUuid, resourceUpdater)
@@ -96,6 +171,10 @@ public class PreloadingNetworkStoreClientTest {
         assertNotNull(switchAttributesResource);
         assertEquals(Boolean.TRUE, switchAttributesResource.getAttributes().isOpen());  // test switch is open
 
+        // Remove component
+        assertEquals(1, cachedClient.getSwitchCount(networkUuid));
+        cachedClient.removeSwitch(networkUuid, "b1");
+        assertEquals(0, cachedClient.getSwitchCount(networkUuid));
         server.verify();
     }
 

--- a/network-store-client/src/test/java/com/powsybl/network/store/client/PreloadingNetworkStoreClientTest.java
+++ b/network-store-client/src/test/java/com/powsybl/network/store/client/PreloadingNetworkStoreClientTest.java
@@ -688,6 +688,9 @@ public class PreloadingNetworkStoreClientTest {
         assertNotNull(configuredBusAttributesResource);
         assertEquals(5., configuredBusAttributesResource.getAttributes().getAngle(), 0.001);
 
+        assertEquals(1, cachedClient.getConfiguredBuses(networkUuid).size());
+        cachedClient.removeConfiguredBus(networkUuid, "cb1");
+        assertEquals(0, cachedClient.getConfiguredBuses(networkUuid).size());
         server.verify();
     }
 }

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/BusBreakerViewImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/BusBreakerViewImpl.java
@@ -69,7 +69,7 @@ public class BusBreakerViewImpl implements VoltageLevel.BusBreakerView {
     @Override
     public void removeBus(String busId) {
         checkTopologyKind();
-        throw new UnsupportedOperationException("TODO");
+        index.removeBus(busId);
     }
 
     @Override
@@ -99,13 +99,13 @@ public class BusBreakerViewImpl implements VoltageLevel.BusBreakerView {
     @Override
     public void removeSwitch(String switchId) {
         checkTopologyKind();
-        throw new UnsupportedOperationException("TODO");
+        index.removeSwitch(switchId);
     }
 
     @Override
     public void removeAllSwitches() {
         checkTopologyKind();
-        throw new UnsupportedOperationException("TODO");
+        getSwitches().forEach(s -> removeSwitch(s.getId()));
     }
 
     @Override

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/BusBreakerViewImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/BusBreakerViewImpl.java
@@ -69,7 +69,9 @@ public class BusBreakerViewImpl implements VoltageLevel.BusBreakerView {
     @Override
     public void removeBus(String busId) {
         checkTopologyKind();
+        Bus removedBus = getBus(busId);
         index.removeBus(busId);
+        index.notifyRemoval(removedBus);
     }
 
     @Override
@@ -99,7 +101,9 @@ public class BusBreakerViewImpl implements VoltageLevel.BusBreakerView {
     @Override
     public void removeSwitch(String switchId) {
         checkTopologyKind();
+        Switch removedSwitch = getSwitch(switchId);
         index.removeSwitch(switchId);
+        index.notifyRemoval(removedSwitch);
     }
 
     @Override

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/BusBreakerViewImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/BusBreakerViewImpl.java
@@ -75,7 +75,7 @@ public class BusBreakerViewImpl implements VoltageLevel.BusBreakerView {
     @Override
     public void removeAllBuses() {
         checkTopologyKind();
-        throw new UnsupportedOperationException("TODO");
+        getBuses().forEach(bus -> removeBus(bus.getId()));
     }
 
     @Override

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/CachedNetworkStoreClient.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/CachedNetworkStoreClient.java
@@ -220,6 +220,12 @@ public class CachedNetworkStoreClient extends ForwardingNetworkStoreClient imple
     }
 
     @Override
+    public void removeSubstation(UUID networkUuid, String substationId) {
+        delegate.removeSubstation(networkUuid, substationId);
+        substationsCache.getCollection(networkUuid).removeResource(substationId);
+    }
+
+    @Override
     public void createVoltageLevels(UUID networkUuid, List<Resource<VoltageLevelAttributes>> voltageLevelResources) {
         delegate.createVoltageLevels(networkUuid, voltageLevelResources);
         voltageLevelsCache.getCollection(networkUuid).createResources(voltageLevelResources);
@@ -251,6 +257,12 @@ public class CachedNetworkStoreClient extends ForwardingNetworkStoreClient imple
     @Override
     public int getVoltageLevelCount(UUID networkUuid) {
         return voltageLevelsCache.getCollection(networkUuid).getResourceCount();
+    }
+
+    @Override
+    public void removeVoltageLevel(UUID networkUuid, String voltageLevelId) {
+        delegate.removeVoltageLevel(networkUuid, voltageLevelId);
+        voltageLevelsCache.getCollection(networkUuid).removeResource(voltageLevelId);
     }
 
     @Override

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/CachedNetworkStoreClient.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/CachedNetworkStoreClient.java
@@ -418,6 +418,12 @@ public class CachedNetworkStoreClient extends ForwardingNetworkStoreClient imple
     }
 
     @Override
+    public void removeSwitch(UUID networkUuid, String switchId) {
+        delegate.removeSwitch(networkUuid, switchId);
+        switchesCache.getCollection(networkUuid).removeResource(switchId);
+    }
+
+    @Override
     public void createBusbarSections(UUID networkUuid, List<Resource<BusbarSectionAttributes>> busbarSectionResources) {
         delegate.createBusbarSections(networkUuid, busbarSectionResources);
         busbarSectionsCache.getCollection(networkUuid).createResources(busbarSectionResources);
@@ -807,5 +813,11 @@ public class CachedNetworkStoreClient extends ForwardingNetworkStoreClient imple
     public void updateConfiguredBus(UUID networkUuid, Resource<ConfiguredBusAttributes> busesResource) {
         delegate.updateConfiguredBus(networkUuid, busesResource);
         configuredBusesCache.getCollection(networkUuid).updateResource(busesResource);
+    }
+
+    @Override
+    public void removeConfiguredBus(UUID networkUuid, String busId) {
+        delegate.removeConfiguredBus(networkUuid, busId);
+        configuredBusesCache.getCollection(networkUuid).removeResource(busId);
     }
 }

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkImpl.java
@@ -548,8 +548,9 @@ public class NetworkImpl extends AbstractIdentifiableImpl<Network, NetworkAttrib
 
     @Override
     public HvdcLine getHvdcLine(HvdcConverterStation converterStation) {
+        Objects.requireNonNull(converterStation);
         return getHvdcLineStream()
-                .filter(l -> l.getConverterStation1() == converterStation || l.getConverterStation2() == converterStation)
+                .filter(l -> l.getConverterStation1().getId().equals(converterStation.getId()) || l.getConverterStation2().getId().equals(converterStation.getId()))
                 .findFirst()
                 .orElse(null);
     }

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkImpl.java
@@ -546,6 +546,14 @@ public class NetworkImpl extends AbstractIdentifiableImpl<Network, NetworkAttrib
         return new HvdcLineAdderImpl(index);
     }
 
+    @Override
+    public HvdcLine getHvdcLine(HvdcConverterStation converterStation) {
+        return getHvdcLineStream()
+                .filter(l -> l.getConverterStation1() == converterStation || l.getConverterStation2() == converterStation)
+                .findFirst()
+                .orElse(null);
+    }
+
     // VSC converter station
 
     @Override

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkObjectIndex.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkObjectIndex.java
@@ -245,6 +245,11 @@ public class NetworkObjectIndex {
         });
     }
 
+    public void removeSubstation(String substationId) {
+        storeClient.removeSubstation(network.getUuid(), substationId);
+        substationById.remove(substationId);
+    }
+
     // voltage level
 
     Optional<VoltageLevelImpl> getVoltageLevel(String id) {
@@ -274,6 +279,11 @@ public class NetworkObjectIndex {
             storeClient.createVoltageLevels(network.getUuid(), Collections.singletonList(r));
             return VoltageLevelImpl.create(this, r);
         });
+    }
+
+    public void removeVoltageLevel(String voltageLevelId) {
+        storeClient.removeVoltageLevel(network.getUuid(), voltageLevelId);
+        voltageLevelById.remove(voltageLevelId);
     }
 
     // generator

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkObjectIndex.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkObjectIndex.java
@@ -463,7 +463,7 @@ public class NetworkObjectIndex {
 
     public void removeSwitch(String switchId) {
         storeClient.removeSwitch(network.getUuid(), switchId);
-        busbarSectionById.remove(switchId);
+        switchById.remove(switchId);
     }
 
     // 2 windings transformer

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkObjectIndex.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkObjectIndex.java
@@ -461,6 +461,11 @@ public class NetworkObjectIndex {
         });
     }
 
+    public void removeSwitch(String switchId) {
+        storeClient.removeSwitch(network.getUuid(), switchId);
+        busbarSectionById.remove(switchId);
+    }
+
     // 2 windings transformer
 
     Optional<TwoWindingsTransformerImpl> getTwoWindingsTransformer(String id) {
@@ -860,6 +865,11 @@ public class NetworkObjectIndex {
             storeClient.createConfiguredBuses(network.getUuid(), Collections.singletonList(r));
             return ConfiguredBusImpl.create(this, r);
         });
+    }
+
+    public void removeBus(String busId) {
+        storeClient.removeConfiguredBus(network.getUuid(), busId);
+        busesById.remove(busId);
     }
 
     static void checkId(String id) {

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkStoreClient.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkStoreClient.java
@@ -44,6 +44,10 @@ public interface NetworkStoreClient {
 
     int getSubstationCount(UUID networkUuid);
 
+    void removeSubstation(UUID networkUuid, String substationId);
+
+    void removeSubstations(UUID networkUuid, List<String> substationsId);
+
     // voltage level
 
     void createVoltageLevels(UUID networkUuid, List<Resource<VoltageLevelAttributes>> voltageLevelResources);
@@ -59,6 +63,10 @@ public interface NetworkStoreClient {
     void updateVoltageLevel(UUID networkUuid, Resource<VoltageLevelAttributes> voltageLevelResource);
 
     void updateVoltageLevels(UUID networkUuid, List<Resource<VoltageLevelAttributes>> voltageLevelResources);
+
+    void removeVoltageLevel(UUID networkUuid, String voltageLevelId);
+
+    void removeVoltageLevels(UUID networkUuid, List<String> voltageLevelsId);
 
     List<Resource<BusbarSectionAttributes>> getVoltageLevelBusbarSections(UUID networkUuid, String voltageLevelId);
 

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkStoreClient.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkStoreClient.java
@@ -110,6 +110,10 @@ public interface NetworkStoreClient {
 
     void updateSwitches(UUID networkUuid, List<Resource<SwitchAttributes>> switchResources);
 
+    void removeSwitch(UUID networkUuid, String switchId);
+
+    void removeSwitches(UUID networkUuid, List<String> switchesId);
+
     // busbar section
 
     void createBusbarSections(UUID networkUuid, List<Resource<BusbarSectionAttributes>> busbarSectionResources);
@@ -351,6 +355,10 @@ public interface NetworkStoreClient {
     void updateConfiguredBus(UUID networkUuid, Resource<ConfiguredBusAttributes> busesResource);
 
     void updateConfiguredBuses(UUID networkUuid, List<Resource<ConfiguredBusAttributes>> busesResources);
+
+    void removeConfiguredBus(UUID networkUuid, String busId);
+
+    void removeConfiguredBuses(UUID networkUuid, List<String> busesId);
 
     void flush();
 

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NodeBreakerViewImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NodeBreakerViewImpl.java
@@ -178,7 +178,9 @@ public class NodeBreakerViewImpl implements VoltageLevel.NodeBreakerView {
     @Override
     public void removeSwitch(String switchId) {
         checkTopologyKind();
+        Switch removedSwitch = getSwitch(switchId);
         index.removeSwitch(switchId);
+        index.notifyRemoval(removedSwitch);
     }
 
     public Switch getSwitch(String id) {

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NodeBreakerViewImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NodeBreakerViewImpl.java
@@ -178,7 +178,7 @@ public class NodeBreakerViewImpl implements VoltageLevel.NodeBreakerView {
     @Override
     public void removeSwitch(String switchId) {
         checkTopologyKind();
-        throw new UnsupportedOperationException("TODO");
+        index.removeSwitch(switchId);
     }
 
     public Switch getSwitch(String id) {

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/OfflineNetworkStoreClient.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/OfflineNetworkStoreClient.java
@@ -70,6 +70,16 @@ public class OfflineNetworkStoreClient implements NetworkStoreClient {
     }
 
     @Override
+    public void removeSubstation(UUID networkUuid, String substationId) {
+        // nothing to do
+    }
+
+    @Override
+    public void removeSubstations(UUID networkUuid, List<String> substationsId) {
+        // nothing to do
+    }
+
+    @Override
     public void createVoltageLevels(UUID networkUuid, List<Resource<VoltageLevelAttributes>> voltageLevelResources) {
         // nothing to do
     }
@@ -101,6 +111,16 @@ public class OfflineNetworkStoreClient implements NetworkStoreClient {
 
     @Override
     public void updateVoltageLevels(UUID networkUuid, List<Resource<VoltageLevelAttributes>> voltageLevelResources) {
+        // nothing to do
+    }
+
+    @Override
+    public void removeVoltageLevel(UUID networkUuid, String voltageLevelId) {
+        // nothing to do
+    }
+
+    @Override
+    public void removeVoltageLevels(UUID networkUuid, List<String> voltageLevelsId) {
         // nothing to do
     }
 

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/OfflineNetworkStoreClient.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/OfflineNetworkStoreClient.java
@@ -335,6 +335,16 @@ public class OfflineNetworkStoreClient implements NetworkStoreClient {
     }
 
     @Override
+    public void removeSwitch(UUID networkUuid, String switchId) {
+        // nothing to do
+    }
+
+    @Override
+    public void removeSwitches(UUID networkUuid, List<String> switchesId) {
+        // nothing to do
+    }
+
+    @Override
     public void createBusbarSections(UUID networkUuid, List<Resource<BusbarSectionAttributes>> busbarSectionResources) {
         // nothing to do
     }
@@ -756,6 +766,16 @@ public class OfflineNetworkStoreClient implements NetworkStoreClient {
 
     @Override
     public void updateConfiguredBuses(UUID networkUuid, List<Resource<ConfiguredBusAttributes>> busesResources) {
+        // nothing to do
+    }
+
+    @Override
+    public void removeConfiguredBus(UUID networkUuid, String busId) {
+        // nothing to do
+    }
+
+    @Override
+    public void removeConfiguredBuses(UUID networkUuid, List<String> busesId) {
         // nothing to do
     }
 

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/SubstationUtil.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/SubstationUtil.java
@@ -1,0 +1,57 @@
+package com.powsybl.network.store.iidm.impl;
+
+import com.powsybl.commons.PowsyblException;
+import com.powsybl.iidm.network.*;
+
+public final class SubstationUtil {
+
+    private SubstationUtil() {
+    }
+
+    static void checkRemovability(Substation substation) {
+        for (VoltageLevel vl : substation.getVoltageLevels()) {
+            for (Connectable connectable : vl.getConnectables()) {
+                if (connectable instanceof Branch) {
+                    checkRemovability(substation, (Branch) connectable);
+                } else if (connectable instanceof ThreeWindingsTransformer) {
+                    checkRemovability(substation, (ThreeWindingsTransformer) connectable);
+                } else if (connectable instanceof HvdcConverterStation) {
+                    checkRemovability(substation, (HvdcConverterStation) connectable);
+                }
+            }
+        }
+    }
+
+    private static void checkRemovability(Substation substation, Branch branch) {
+        Substation s1 = branch.getTerminal1().getVoltageLevel().getSubstation();
+        Substation s2 = branch.getTerminal2().getVoltageLevel().getSubstation();
+        if ((s1 != substation) || (s2 != substation)) {
+            throw createIsolationException(substation);
+        }
+    }
+
+    private static void checkRemovability(Substation substation, ThreeWindingsTransformer twt) {
+        Substation s1 = twt.getLeg1().getTerminal().getVoltageLevel().getSubstation();
+        Substation s2 = twt.getLeg2().getTerminal().getVoltageLevel().getSubstation();
+        Substation s3 = twt.getLeg3().getTerminal().getVoltageLevel().getSubstation();
+        if ((s1 != substation) || (s2 != substation) || (s3 != substation)) {
+            throw createIsolationException(substation);
+        }
+    }
+
+    private static void checkRemovability(Substation substation, HvdcConverterStation station) {
+        HvdcLine hvdcLine = substation.getNetwork().getHvdcLine(station);
+        if (hvdcLine != null) {
+            Substation s1 = hvdcLine.getConverterStation1().getTerminal().getVoltageLevel().getSubstation();
+            Substation s2 = hvdcLine.getConverterStation2().getTerminal().getVoltageLevel().getSubstation();
+            if ((s1 != substation) || (s2 != substation)) {
+                throw createIsolationException(substation);
+            }
+        }
+    }
+
+    private static PowsyblException createIsolationException(Substation substation) {
+        return new PowsyblException("The substation " + substation.getId() + " is still connected to another substation");
+
+    }
+}

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/VoltageLevelImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/VoltageLevelImpl.java
@@ -7,6 +7,7 @@
 package com.powsybl.network.store.iidm.impl;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import com.powsybl.commons.extensions.Extension;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.extensions.SlackTerminal;
@@ -505,6 +506,25 @@ public class VoltageLevelImpl extends AbstractIdentifiableImpl<VoltageLevel, Vol
     public VoltageLevelImpl initSlackTerminalAttributes(Terminal terminal) {
         resource.getAttributes().setSlackTerminal(TerminalRefUtils.getTerminalRefAttributes(terminal));
         return this;
+    }
+
+    @Override
+    public void remove() {
+        VoltageLevelUtil.checkRemovability(this);
+
+        // Remove all connectables
+        List<Connectable> connectables = Lists.newArrayList(getConnectables());
+        for (Connectable connectable : connectables) {
+            connectable.remove();
+        }
+
+        // Remove the topology
+        //TODO removeTopology();
+
+        // Remove this voltage level from the network
+        index.removeVoltageLevel(this.getId());
+
+        index.notifyRemoval(this);
     }
 
     @Override

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/VoltageLevelImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/VoltageLevelImpl.java
@@ -519,12 +519,19 @@ public class VoltageLevelImpl extends AbstractIdentifiableImpl<VoltageLevel, Vol
         }
 
         // Remove the topology
-        //TODO removeTopology();
+        removeTopology();
 
         // Remove this voltage level from the network
         index.removeVoltageLevel(this.getId());
 
         index.notifyRemoval(this);
+    }
+
+    private void removeTopology() {
+        if (resource.getAttributes().getTopologyKind() == TopologyKind.BUS_BREAKER) {
+            getBusBreakerView().removeAllSwitches();
+            getBusBreakerView().removeAllBuses();
+        }
     }
 
     @Override

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/VoltageLevelImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/VoltageLevelImpl.java
@@ -531,6 +531,10 @@ public class VoltageLevelImpl extends AbstractIdentifiableImpl<VoltageLevel, Vol
         if (resource.getAttributes().getTopologyKind() == TopologyKind.BUS_BREAKER) {
             getBusBreakerView().removeAllSwitches();
             getBusBreakerView().removeAllBuses();
+        } else if (resource.getAttributes().getTopologyKind() == TopologyKind.NODE_BREAKER) {
+            getNodeBreakerView().getSwitches().forEach(s -> {
+                getNodeBreakerView().removeSwitch(s.getId());
+            });
         }
     }
 

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/VoltageLevelUtil.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/VoltageLevelUtil.java
@@ -1,0 +1,32 @@
+package com.powsybl.network.store.iidm.impl;
+
+import com.google.common.collect.Sets;
+import com.powsybl.iidm.network.*;
+
+import java.util.Set;
+
+public final class VoltageLevelUtil {
+
+    static final Set<ConnectableType> MULTIPLE_TERMINALS_CONNECTABLE_TYPES = Sets.immutableEnumSet(
+            ConnectableType.LINE,
+            ConnectableType.TWO_WINDINGS_TRANSFORMER,
+            ConnectableType.THREE_WINDINGS_TRANSFORMER);
+
+    private VoltageLevelUtil() {
+    }
+
+    static void checkRemovability(VoltageLevel voltageLevel) {
+        Network network = voltageLevel.getNetwork();
+
+        for (Connectable connectable : voltageLevel.getConnectables()) {
+            ConnectableType type = connectable.getType();
+            if (MULTIPLE_TERMINALS_CONNECTABLE_TYPES.contains(type)) {
+                // Reject lines, 2WT and 3WT
+                throw new AssertionError("The voltage level '" + voltageLevel.getId() + "' cannot be removed because of a remaining " + type);
+            } else if ((type == ConnectableType.HVDC_CONVERTER_STATION) && (network.getHvdcLine((HvdcConverterStation) connectable) != null)) {
+                // Reject all converter stations connected to a HVDC line
+                throw new AssertionError("The voltage level '" + voltageLevel.getId() + "' cannot be removed because of a remaining HVDC line");
+            }
+        }
+    }
+}

--- a/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStorageTestCaseFactory.java
+++ b/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStorageTestCaseFactory.java
@@ -189,6 +189,20 @@ public final class NetworkStorageTestCaseFactory {
         lccConverterStation.getTerminal().setP(440);
         lccConverterStation.getTerminal().setQ(320);
 
+        Line l1 = network.newLine()
+                .setId("LINE1")
+                .setVoltageLevel1("VL1")
+                .setVoltageLevel2("VL2")
+                .setNode1(1)
+                .setNode2(2)
+                .setR(50)
+                .setX(20)
+                .setG1(12)
+                .setG2(24)
+                .setB1(45)
+                .setB2(32)
+                .add();
+
         VoltageLevel vl3 = s2.newVoltageLevel()
                 .setId("VL3")
                 .setNominalV(225)

--- a/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreIT.java
+++ b/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreIT.java
@@ -590,8 +590,8 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
             assertEquals(1, networkIds.size());
 
             Network readNetwork = service.getNetwork(networkIds.keySet().stream().findFirst().get());
-            assertEquals(2, readNetwork.getSubstationCount());
-            assertEquals(4, readNetwork.getVoltageLevelCount());
+            assertEquals(3, readNetwork.getSubstationCount());
+            assertEquals(6, readNetwork.getVoltageLevelCount());
             assertEquals(2, readNetwork.getVscConverterStationCount());
             assertEquals(2, readNetwork.getDanglingLineCount());
             assertEquals(2, readNetwork.getShuntCompensatorCount());
@@ -607,8 +607,8 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
             readNetwork.getLine("LINE1").remove();
             readNetwork.getSubstation("S1").remove();
 
-            assertEquals(1, readNetwork.getSubstationCount());
-            assertEquals(3, readNetwork.getVoltageLevelCount());
+            assertEquals(2, readNetwork.getSubstationCount());
+            assertEquals(5, readNetwork.getVoltageLevelCount());
             assertEquals(1, readNetwork.getVscConverterStationCount());
             assertEquals(0, readNetwork.getDanglingLineCount());
             assertEquals(1, readNetwork.getShuntCompensatorCount());
@@ -619,8 +619,8 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
             Map<UUID, String> networkIds = service.getNetworkIds();
             assertEquals(1, networkIds.size());
             Network readNetwork = service.getNetwork(networkIds.keySet().stream().findFirst().get());
-            assertEquals(1, readNetwork.getSubstationCount());
-            assertEquals(3, readNetwork.getVoltageLevelCount());
+            assertEquals(2, readNetwork.getSubstationCount());
+            assertEquals(5, readNetwork.getVoltageLevelCount());
             assertEquals(1, readNetwork.getVscConverterStationCount());
             assertEquals(0, readNetwork.getDanglingLineCount());
             assertEquals(1, readNetwork.getShuntCompensatorCount());
@@ -630,7 +630,7 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
             readNetwork.getSubstation("S2").remove();
 
             assertEquals(0, readNetwork.getThreeWindingsTransformerCount());
-            assertEquals(0, readNetwork.getSubstationCount());
+            assertEquals(1, readNetwork.getSubstationCount());
             assertEquals(0, readNetwork.getShuntCompensatorCount());
         }
     }

--- a/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreController.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreController.java
@@ -143,6 +143,17 @@ public class NetworkStoreController {
         return createAll(resource -> repository.createSubstations(networkId, resource), substationResources);
     }
 
+    @DeleteMapping(value = "/{networkId}/substations/{substationId}", produces = APPLICATION_JSON_VALUE)
+    @ApiOperation(value = "Delete a substation by id")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Successfully delete substation")
+    })
+    public ResponseEntity<Void> deleteSubstation(@ApiParam(value = "Network ID", required = true) @PathVariable("networkId") UUID networkId,
+                                                @ApiParam(value = "Substation ID", required = true) @PathVariable("substationId") String substationId) {
+        repository.deleteSubstation(networkId, substationId);
+        return ResponseEntity.ok().build();
+    }
+
     // voltage level
 
     @GetMapping(value = "/{networkId}/voltage-levels", produces = APPLICATION_JSON_VALUE)
@@ -179,6 +190,17 @@ public class NetworkStoreController {
                                                     @ApiParam(value = "voltage level resources", required = true) @RequestBody List<Resource<VoltageLevelAttributes>> voltageLevelResources) {
 
         return updateAll(resources -> repository.updateVoltageLevels(networkId, resources), voltageLevelResources);
+    }
+
+    @DeleteMapping(value = "/{networkId}/voltage-levels/{voltageLevelId}", produces = APPLICATION_JSON_VALUE)
+    @ApiOperation(value = "Delete a voltage level by id")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Successfully delete voltage level")
+    })
+    public ResponseEntity<Void> deleteVoltageLevel(@ApiParam(value = "Network ID", required = true) @PathVariable("networkId") UUID networkId,
+                                                   @ApiParam(value = "Voltage level ID", required = true) @PathVariable("voltageLevelId") String voltageLevelId) {
+        repository.deleteVoltageLevel(networkId, voltageLevelId);
+        return ResponseEntity.ok().build();
     }
 
     @GetMapping(value = "/{networkId}/substations/{substationId}/voltage-levels", produces = APPLICATION_JSON_VALUE)

--- a/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreController.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreController.java
@@ -737,6 +737,17 @@ public class NetworkStoreController {
         return updateAll(resources -> repository.updateSwitches(networkId, resources), switchResources);
     }
 
+    @DeleteMapping(value = "/{networkId}/switches/{switchId}", produces = APPLICATION_JSON_VALUE)
+    @ApiOperation(value = "Delete a switch by id")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Successfully delete switch")
+    })
+    public ResponseEntity<Void> deleteSwitch(@ApiParam(value = "Network ID", required = true) @PathVariable("networkId") UUID networkId,
+                                             @ApiParam(value = "Switch ID", required = true) @PathVariable("switchId") String switchId) {
+        repository.deleteSwitch(networkId, switchId);
+        return ResponseEntity.ok().build();
+    }
+
     // 2 windings transformer
 
     @PostMapping(value = "/{networkId}/2-windings-transformers")
@@ -1029,5 +1040,16 @@ public class NetworkStoreController {
                                             @ApiParam(value = "bus resource", required = true) @RequestBody List<Resource<ConfiguredBusAttributes>> busResources) {
 
         return updateAll(resources -> repository.updateBuses(networkId, resources), busResources);
+    }
+
+    @DeleteMapping(value = "/{networkId}/configured-buses/{busId}", produces = APPLICATION_JSON_VALUE)
+    @ApiOperation(value = "Delete a bus by id")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Successfully delete bus")
+    })
+    public ResponseEntity<Void> deleteBus(@ApiParam(value = "Network ID", required = true) @PathVariable("networkId") UUID networkId,
+                                          @ApiParam(value = "Bus ID", required = true) @PathVariable("busId") String busId) {
+        repository.deleteBus(networkId, busId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreRepository.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreRepository.java
@@ -2796,6 +2796,10 @@ public class NetworkStoreRepository {
         }
     }
 
+    public void deleteSwitch(UUID networkUuid, String switchId) {
+        session.execute(delete().from("switch").where(eq("networkUuid", networkUuid)).and(eq("id", switchId)));
+    }
+
     // 2 windings transformer
 
     public void createTwoWindingsTransformers(UUID networkUuid, List<Resource<TwoWindingsTransformerAttributes>> resources) {
@@ -4338,4 +4342,9 @@ public class NetworkStoreRepository {
             session.execute(batch);
         }
     }
+
+    public void deleteBus(UUID networkUuid, String configuredBusId) {
+        session.execute(delete().from("configuredBus").where(eq("networkUuid", networkUuid)).and(eq("id", configuredBusId)));
+    }
+
 }

--- a/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreRepository.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreRepository.java
@@ -948,6 +948,10 @@ public class NetworkStoreRepository {
         }
     }
 
+    public void deleteSubstation(UUID networkUuid, String substationId) {
+        session.execute(delete().from("substation").where(eq("networkUuid", networkUuid)).and(eq("id", substationId)));
+    }
+
     // voltage level
 
     public void createVoltageLevels(UUID networkUuid, List<Resource<VoltageLevelAttributes>> resources) {
@@ -1121,6 +1125,10 @@ public class NetworkStoreRepository {
                     .build());
         }
         return resources;
+    }
+
+    public void deleteVoltageLevel(UUID networkUuid, String voltageLevelId) {
+        session.execute(delete().from("voltageLevel").where(eq("networkUuid", networkUuid)).and(eq("id", voltageLevelId)));
     }
 
     // generator

--- a/network-store-server/src/test/java/com/powsybl/network/store/server/NetworkStoreControllerIT.java
+++ b/network-store-server/src/test/java/com/powsybl/network/store/server/NetworkStoreControllerIT.java
@@ -202,6 +202,10 @@ public class NetworkStoreControllerIT extends AbstractEmbeddedCassandraSetup {
                 .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
                 .andExpect(jsonPath("data", hasSize(1)));
 
+        mvc.perform(delete("/" + VERSION + "/networks/" + networkUuid + "/switches/b1")
+                .contentType(APPLICATION_JSON))
+                .andExpect(status().isOk());
+
         // switch creation and update
         Resource<SwitchAttributes> resBreaker = Resource.switchBuilder()
                 .id("b1")
@@ -522,5 +526,18 @@ public class NetworkStoreControllerIT extends AbstractEmbeddedCassandraSetup {
                 .andExpect(jsonPath("data[0].attributes.generation.maxP").value(33))
                 .andExpect(jsonPath("data[0].attributes.generation.targetQ").value(54))
                 .andExpect(jsonPath("data[0].attributes.generation.voltageRegulationOn").value(true));
+
+        // Test removals
+        mvc.perform(delete("/" + VERSION + "/networks/" + networkUuid + "/switches/b1")
+                .contentType(APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        mvc.perform(delete("/" + VERSION + "/networks/" + networkUuid + "/voltage-levels/baz")
+                .contentType(APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        mvc.perform(delete("/" + VERSION + "/networks/" + networkUuid + "/substations/bar")
+                .contentType(APPLICATION_JSON))
+                .andExpect(status().isOk());
     }
 }


### PR DESCRIPTION
Signed-off-by: NOIR Nicolas ext <nicolas.noir@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
Substations and voltage levels removal methods are not implemented


**What is the new behavior (if this is a feature change)?**
Substations and voltage levels removal methods are now implemented and substations and voltage levels can thus be correctly removed from network


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
