### PR TITLE
Initialization of attributes in powsyble core way to have identical xml exports

### DIFF
--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/ConfiguredBusAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/ConfiguredBusAdderImpl.java
@@ -35,6 +35,7 @@ public class ConfiguredBusAdderImpl extends AbstractIdentifiableAdder<Configured
                         .name(getName())
                         .fictitious(isFictitious())
                         .voltageLevelId(voltageLevelResource.getId())
+                        .fictitious(isFictitious())
                         .build())
                 .build();
         return getIndex().createBus(resource);

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/DanglingLineAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/DanglingLineAdderImpl.java
@@ -22,9 +22,9 @@ public class DanglingLineAdderImpl extends AbstractInjectionAdder<DanglingLineAd
 
     class GenerationAdderImpl implements GenerationAdder {
 
-        private double minP = Double.NaN;
+        private double minP = -Double.MAX_VALUE;
 
-        private double maxP = Double.NaN;
+        private double maxP = Double.MAX_VALUE;
 
         private double targetP = Double.NaN;
 

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/SubstationImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/SubstationImpl.java
@@ -163,6 +163,16 @@ public class SubstationImpl extends AbstractIdentifiableImpl<Substation, Substat
     }
 
     @Override
+    public <E extends Extension<Substation>> Collection<E> getExtensions() {
+        Collection<E> extensions = super.getExtensions();
+        E extension = createEntsoeArea();
+        if (extension != null) {
+            extensions.add(extension);
+        }
+        return extensions;
+    }
+
+    @Override
     @SuppressWarnings("unchecked")
     public <E extends Extension<Substation>> E getExtension(Class<? super E> type) {
         if (type == EntsoeArea.class) {
@@ -180,13 +190,13 @@ public class SubstationImpl extends AbstractIdentifiableImpl<Substation, Substat
         return super.getExtensionByName(name);
     }
 
-    private EntsoeArea createEntsoeArea() {
-
+    private <E extends Extension<Substation>> E  createEntsoeArea() {
+        E extension = null;
         if (resource.getAttributes().getEntsoeArea() != null) {
-            return new EntsoeAreaImpl(this,
+            extension = (E) new EntsoeAreaImpl(this,
                     EntsoeGeographicalCode.valueOf(resource.getAttributes().getEntsoeArea().getCode()));
         }
-        return null;
+        return extension;
     }
 
     @Override

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/TwoWindingsTransformerAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/TwoWindingsTransformerAdderImpl.java
@@ -121,6 +121,7 @@ class TwoWindingsTransformerAdderImpl extends AbstractBranchAdder<TwoWindingsTra
                         .g(g)
                         .ratedU1(ratedU1)
                         .ratedU2(ratedU2)
+                        .fictitious(isFictitious())
                         .build())
                 .build();
         return getIndex().createTwoWindingsTransformer(resource);

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/VoltageLevelAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/VoltageLevelAdderImpl.java
@@ -23,11 +23,11 @@ class VoltageLevelAdderImpl extends AbstractIdentifiableAdder<VoltageLevelAdderI
 
     private final Resource<SubstationAttributes> substationResource;
 
-    private double nominalV;
+    private double nominalV = Double.NaN;
 
-    private double lowVoltageLimit;
+    private double lowVoltageLimit = Double.NaN;
 
-    private double highVoltageLimit;
+    private double highVoltageLimit = Double.NaN;
 
     private TopologyKind topologyKind;
 

--- a/network-store-integration-test/pom.xml
+++ b/network-store-integration-test/pom.xml
@@ -90,6 +90,11 @@
             <artifactId>powsybl-network-store-tools</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-network-store-model</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <!-- test dependencies -->
         <dependency>

--- a/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreIT.java
+++ b/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreIT.java
@@ -2537,17 +2537,17 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
 
             assertFalse(bus1.isFictitious());
             assertEquals("VL5", bus1.getVoltageLevel().getId());
-            assertEquals(.0, bus1.getV(), .0);
-            assertEquals(.0, bus1.getAngle(), .0);
+            assertTrue(Double.isNaN(bus1.getV()));
+            assertTrue(Double.isNaN(bus1.getAngle()));
 
             assertFalse(bus2.isFictitious());
             assertEquals("VL6", bus2.getVoltageLevel().getId());
-            assertEquals(.0, bus2.getV(), .0);
-            assertEquals(.0, bus2.getAngle(), .0);
+            assertTrue(Double.isNaN(bus2.getV()));
+            assertTrue(Double.isNaN(bus2.getAngle()));
 
             bus1.setFictitious(true);
-            bus1.setV(Double.NaN);
-            bus1.setAngle(Double.NaN);
+            bus1.setV(0);
+            bus1.setAngle(0);
 
             service.flush(readNetwork);  // flush the network
         }
@@ -2562,8 +2562,8 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
             Bus bus1 = readNetwork.getVoltageLevel("VL5").getBusBreakerView().getBus("BUS5");
 
             assertTrue(bus1.isFictitious());
-            assertTrue(Double.isNaN(bus1.getV()));
-            assertTrue(Double.isNaN(bus1.getAngle()));
+            assertEquals(.0, bus1.getV(), .0);
+            assertEquals(.0, bus1.getAngle(), .0);
         }
     }
 

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/BatteryAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/BatteryAttributes.java
@@ -57,10 +57,12 @@ public class BatteryAttributes extends AbstractAttributes implements InjectionAt
     private double maxP;
 
     @ApiModelProperty("Active power in MW")
-    private double p;
+    @Builder.Default
+    private double p = Double.NaN;
 
     @ApiModelProperty("Reactive power in MW")
-    private double q;
+    @Builder.Default
+    private double q = Double.NaN;
 
     @ApiModelProperty("Connectable position (for substation diagram)")
     private ConnectablePositionAttributes position;

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/ConfiguredBusAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/ConfiguredBusAttributes.java
@@ -40,10 +40,12 @@ public class ConfiguredBusAttributes extends AbstractAttributes implements Ident
     private String voltageLevelId;
 
     @ApiModelProperty("bus voltage magnitude in Kv")
-    private double v;
+    @Builder.Default
+    private double v = Double.NaN;
 
     @ApiModelProperty("voltage angle of the bus in degree")
-    private double angle;
+    @Builder.Default
+    private double angle = Double.NaN;
 
     @ApiModelProperty("Properties")
     private Map<String, String> properties;

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/DanglingLineAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/DanglingLineAttributes.java
@@ -67,10 +67,12 @@ public class DanglingLineAttributes extends AbstractAttributes implements Inject
     private CurrentLimitsAttributes currentLimits;
 
     @ApiModelProperty("Active power in MW")
-    private double p;
+    @Builder.Default
+    private double p = Double.NaN;
 
     @ApiModelProperty("Reactive power in MW")
-    private double q;
+    @Builder.Default
+    private double q = Double.NaN;
 
     @ApiModelProperty("Connectable position (for substation diagram)")
     private ConnectablePositionAttributes position;

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/GeneratorAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/GeneratorAttributes.java
@@ -70,10 +70,12 @@ public class GeneratorAttributes extends AbstractAttributes implements Injection
     private double ratedS;
 
     @ApiModelProperty("Active power in MW")
-    private double p;
+    @Builder.Default
+    private double p = Double.NaN;
 
     @ApiModelProperty("Reactive power in MW")
-    private double q;
+    @Builder.Default
+    private double q = Double.NaN;
 
     @ApiModelProperty("Connectable position (for substation diagram)")
     private ConnectablePositionAttributes position;

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/LineAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/LineAttributes.java
@@ -75,16 +75,20 @@ public class LineAttributes extends AbstractAttributes implements BranchAttribut
     private double b2;
 
     @ApiModelProperty("Side 1 active power in MW")
-    private double p1;
+    @Builder.Default
+    private double p1 = Double.NaN;
 
     @ApiModelProperty("Side 1 reactive power in MVar")
-    private double q1;
+    @Builder.Default
+    private double q1 = Double.NaN;
 
     @ApiModelProperty("Side 2 active power in MW")
-    private double p2;
+    @Builder.Default
+    private double p2 = Double.NaN;
 
     @ApiModelProperty("Side 2 reactive power in MVar")
-    private double q2;
+    @Builder.Default
+    private double q2 = Double.NaN;
 
     @ApiModelProperty("Side 1 connectable position (for substation diagram)")
     private ConnectablePositionAttributes position1;

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/LoadAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/LoadAttributes.java
@@ -55,10 +55,12 @@ public class LoadAttributes extends AbstractAttributes implements InjectionAttri
     private double q0;
 
     @ApiModelProperty("Active power in MW")
-    private double p;
+    @Builder.Default
+    private double p = Double.NaN;
 
     @ApiModelProperty("Reactive power in MW")
-    private double q;
+    @Builder.Default
+    private double q = Double.NaN;
 
     @ApiModelProperty("Load detail")
     private LoadDetailAttributes loadDetail;

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/ThreeWindingsTransformerAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/ThreeWindingsTransformerAttributes.java
@@ -36,22 +36,28 @@ public class ThreeWindingsTransformerAttributes extends AbstractAttributes imple
     private Map<String, String> properties;
 
     @ApiModelProperty("Side 1 active power in MW")
-    private double p1;
+    @Builder.Default
+    private double p1 = Double.NaN;
 
     @ApiModelProperty("Side 1 reactive power in MVar")
-    private double q1;
+    @Builder.Default
+    private double q1 = Double.NaN;
 
     @ApiModelProperty("Side 2 active power in MW")
-    private double p2;
+    @Builder.Default
+    private double p2 = Double.NaN;
 
     @ApiModelProperty("Side 2 reactive power in MVar")
-    private double q2;
+    @Builder.Default
+    private double q2 = Double.NaN;
 
     @ApiModelProperty("Side 3 active power in MW")
-    private double p3;
+    @Builder.Default
+    private double p3 = Double.NaN;
 
     @ApiModelProperty("Side 3 reactive power in MVar")
-    private double q3;
+    @Builder.Default
+    private double q3 = Double.NaN;
 
     @ApiModelProperty("Side 1 leg")
     private LegAttributes leg1;

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/TwoWindingsTransformerAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/TwoWindingsTransformerAttributes.java
@@ -75,16 +75,20 @@ public class TwoWindingsTransformerAttributes extends AbstractAttributes impleme
     private double ratedU2;
 
     @ApiModelProperty("Side 1 active power in MW")
-    private double p1;
+    @Builder.Default
+    private double p1 = Double.NaN;
 
     @ApiModelProperty("Side 1 reactive power in MVar")
-    private double q1;
+    @Builder.Default
+    private double q1 = Double.NaN;
 
     @ApiModelProperty("Side 2 active power in MW")
-    private double p2;
+    @Builder.Default
+    private double p2 = Double.NaN;
 
     @ApiModelProperty("Side 2 reactive power in MVar")
-    private double q2;
+    @Builder.Default
+    private double q2 = Double.NaN;
 
     @ApiModelProperty("Side 1 connectable position (for substation diagram)")
     private ConnectablePositionAttributes position1;

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/VoltageLevelAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/VoltageLevelAttributes.java
@@ -84,6 +84,7 @@ public class VoltageLevelAttributes extends AbstractAttributes implements Identi
         this.nodeToCalculatedBus = other.nodeToCalculatedBus;
         this.busToCalculatedBus = other.busToCalculatedBus;
         this.calculatedBusesValid = other.calculatedBusesValid;
+        this.slackTerminal = other.slackTerminal;
     }
 
     @Override

--- a/network-store-model/src/test/java/com/powsybl/network/store/model/ResourceTest.java
+++ b/network-store-model/src/test/java/com/powsybl/network/store/model/ResourceTest.java
@@ -10,11 +10,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.powsybl.commons.json.JsonUtil;
-import com.powsybl.iidm.network.Country;
-import com.powsybl.iidm.network.EnergySource;
-import com.powsybl.iidm.network.ReactiveLimitsKind;
-import com.powsybl.iidm.network.ShuntCompensatorModelType;
-import com.powsybl.iidm.network.SwitchKind;
+import com.powsybl.iidm.network.*;
 import org.joda.time.DateTime;
 import org.junit.Test;
 
@@ -76,6 +72,31 @@ public class ResourceTest {
     }
 
     @Test
+    public void configuredBus() {
+        UUID testNetworkId = UUID.fromString("7928181c-7977-4592-ba19-88027e4254e4");
+
+        ResourceUpdater updateR = (networkUuid, resource) -> {
+        };
+
+        ConfiguredBusAttributes configuredBusAttributesAttributes = ConfiguredBusAttributes
+                .builder()
+                .voltageLevelId("vl1")
+                .name("bus1")
+                .fictitious(false)
+                .build();
+
+        Resource<ConfiguredBusAttributes> resourceConfiguredBus = Resource.configuredBusBuilder(testNetworkId, updateR)
+                .id("load1")
+                .attributes(new ConfiguredBusAttributes(configuredBusAttributesAttributes))
+                .build();
+
+        assertFalse(resourceConfiguredBus.getAttributes().isFictitious());
+
+        assertTrue(Double.isNaN(resourceConfiguredBus.getAttributes().getV()));
+        assertTrue(Double.isNaN(resourceConfiguredBus.getAttributes().getAngle()));
+    }
+
+    @Test
     public void switchTest() {
         UUID testNetworkId = UUID.fromString("7928181c-7977-4592-ba19-88027e4254e4");
 
@@ -96,6 +117,8 @@ public class ResourceTest {
                         .fictitious(false)
                         .build())
                 .build();
+
+        assertFalse(resourceBreaker.getAttributes().isFictitious());
 
         assertEquals(Boolean.FALSE, dirty[0]);
         assertEquals(Boolean.FALSE, resourceBreaker.getAttributes().isOpen());
@@ -149,15 +172,17 @@ public class ResourceTest {
                         .b1(1)
                         .g2(1)
                         .b2(1)
-                        .p1(0)
-                        .q1(0)
-                        .p2(0)
-                        .q2(0)
                         .build())
                 .build();
 
+        assertFalse(resourceLine.getAttributes().isFictitious());
+
+        assertTrue(Double.isNaN(resourceLine.getAttributes().getP1()));
+        assertTrue(Double.isNaN(resourceLine.getAttributes().getQ1()));
+        assertTrue(Double.isNaN(resourceLine.getAttributes().getP2()));
+        assertTrue(Double.isNaN(resourceLine.getAttributes().getQ2()));
+
         assertEquals(Boolean.FALSE, dirty[0]);
-        assertEquals(0., resourceLine.getAttributes().getP1(), 0);
         resourceLine.getAttributes().setP1(100.0);
         assertEquals(Boolean.TRUE, dirty[0]);
         assertEquals(100.0, resourceLine.getAttributes().getP1(), 0);
@@ -188,15 +213,17 @@ public class ResourceTest {
                         .g(1)
                         .ratedU1(1.)
                         .ratedU2(1.)
-                        .p1(0)
-                        .p2(0)
-                        .q1(0)
-                        .q2(0)
                         .build())
                 .build();
 
+        assertFalse(resourceTransformer.getAttributes().isFictitious());
+
+        assertTrue(Double.isNaN(resourceTransformer.getAttributes().getP1()));
+        assertTrue(Double.isNaN(resourceTransformer.getAttributes().getQ1()));
+        assertTrue(Double.isNaN(resourceTransformer.getAttributes().getP2()));
+        assertTrue(Double.isNaN(resourceTransformer.getAttributes().getQ2()));
+
         assertEquals(Boolean.FALSE, dirty[0]);
-        assertEquals(0., resourceTransformer.getAttributes().getP1(), 0);
         resourceTransformer.getAttributes().setP1(100.0);
         assertEquals(Boolean.TRUE, dirty[0]);
         assertEquals(100.0, resourceTransformer.getAttributes().getP1(), 0);
@@ -216,20 +243,19 @@ public class ResourceTest {
                 .attributes(ThreeWindingsTransformerAttributes.builder()
                         .name("id3WT")
                         .ratedU0(1)
-                        .p1(0)
-                        .p2(0)
-                        .p3(0)
-                        .q1(0)
-                        .q2(0)
-                        .q3(0)
                         .build())
                 .build();
 
-        assertEquals(Boolean.FALSE, dirty[0]);
-        assertEquals(0., resourceTransformer.getAttributes().getP1(), 0);
-        assertEquals(0., resourceTransformer.getAttributes().getQ2(), 0);
-        assertEquals(0., resourceTransformer.getAttributes().getP3(), 0);
+        assertFalse(resourceTransformer.getAttributes().isFictitious());
 
+        assertTrue(Double.isNaN(resourceTransformer.getAttributes().getP1()));
+        assertTrue(Double.isNaN(resourceTransformer.getAttributes().getQ1()));
+        assertTrue(Double.isNaN(resourceTransformer.getAttributes().getP2()));
+        assertTrue(Double.isNaN(resourceTransformer.getAttributes().getQ2()));
+        assertTrue(Double.isNaN(resourceTransformer.getAttributes().getP3()));
+        assertTrue(Double.isNaN(resourceTransformer.getAttributes().getQ3()));
+
+        assertEquals(Boolean.FALSE, dirty[0]);
         resourceTransformer.getAttributes().setP1(200.);
         resourceTransformer.getAttributes().setQ2(500.);
         resourceTransformer.getAttributes().setP3(700.);
@@ -238,6 +264,34 @@ public class ResourceTest {
         assertEquals(200., resourceTransformer.getAttributes().getP1(), 0);
         assertEquals(500., resourceTransformer.getAttributes().getQ2(), 0);
         assertEquals(700., resourceTransformer.getAttributes().getP3(), 0);
+    }
+
+    @Test
+    public void load() {
+        UUID testNetworkId = UUID.fromString("7928181c-7977-4592-ba19-88027e4254e4");
+
+        ResourceUpdater updateR = (networkUuid, resource) -> {
+        };
+
+        LoadAttributes loadAttributes = LoadAttributes
+                .builder()
+                .voltageLevelId("vl1")
+                .name("name")
+                .bus("bus1")
+                .fictitious(false)
+                .node(1)
+                .build();
+
+        Resource<LoadAttributes> resourceLoad = Resource.loadBuilder(testNetworkId, updateR)
+                .id("load1")
+                .attributes(new LoadAttributes(loadAttributes))
+                .build();
+
+        assertFalse(resourceLoad.getAttributes().isFictitious());
+        assertEquals(1, resourceLoad.getAttributes().getNode(), 0);
+
+        assertTrue(Double.isNaN(resourceLoad.getAttributes().getP()));
+        assertTrue(Double.isNaN(resourceLoad.getAttributes().getQ()));
     }
 
     @Test
@@ -262,20 +316,23 @@ public class ResourceTest {
                 .regulatingTerminal(TerminalRefAttributes.builder().side("ONE").connectableId("idEq").build())
                 .build();
 
-        Resource<GeneratorAttributes> resourceTransformer = Resource.generatorBuilder(testNetworkId, updateR)
+        Resource<GeneratorAttributes> resourceGenerator = Resource.generatorBuilder(testNetworkId, updateR)
                 .id("gen1")
                 .attributes(new GeneratorAttributes(generatorAttributes))
                 .build();
 
-        assertEquals(Boolean.FALSE, resourceTransformer.getAttributes().isFictitious());
-        assertEquals(1, resourceTransformer.getAttributes().getMaxP(), 0);
-        assertEquals(2, resourceTransformer.getAttributes().getMinP(), 0);
-        assertEquals(3, resourceTransformer.getAttributes().getTargetP(), 0);
-        assertEquals(4, resourceTransformer.getAttributes().getTargetV(), 0);
-        assertEquals(1, resourceTransformer.getAttributes().getNode(), 0);
+        assertFalse(resourceGenerator.getAttributes().isFictitious());
+        assertEquals(1, resourceGenerator.getAttributes().getMaxP(), 0);
+        assertEquals(2, resourceGenerator.getAttributes().getMinP(), 0);
+        assertEquals(3, resourceGenerator.getAttributes().getTargetP(), 0);
+        assertEquals(4, resourceGenerator.getAttributes().getTargetV(), 0);
+        assertEquals(1, resourceGenerator.getAttributes().getNode(), 0);
 
-        assertEquals("idEq", resourceTransformer.getAttributes().getRegulatingTerminal().getConnectableId());
-        assertEquals("ONE", resourceTransformer.getAttributes().getRegulatingTerminal().getSide());
+        assertTrue(Double.isNaN(resourceGenerator.getAttributes().getP()));
+        assertTrue(Double.isNaN(resourceGenerator.getAttributes().getQ()));
+
+        assertEquals("idEq", resourceGenerator.getAttributes().getRegulatingTerminal().getConnectableId());
+        assertEquals("ONE", resourceGenerator.getAttributes().getRegulatingTerminal().getSide());
 
     }
 
@@ -299,18 +356,20 @@ public class ResourceTest {
                 .node(1)
                 .build();
 
-        Resource<BatteryAttributes> resourceTransformer = Resource.batteryBuilder(testNetworkId, updateR)
+        Resource<BatteryAttributes> resourceBattery = Resource.batteryBuilder(testNetworkId, updateR)
                 .id("battery1")
                 .attributes(new BatteryAttributes(batteryAttributes))
                 .build();
 
-        assertEquals(Boolean.FALSE, resourceTransformer.getAttributes().isFictitious());
-        assertEquals(300, resourceTransformer.getAttributes().getMaxP(), 0);
-        assertEquals(200, resourceTransformer.getAttributes().getMinP(), 0);
-        assertEquals(250, resourceTransformer.getAttributes().getP0(), 0);
-        assertEquals(100, resourceTransformer.getAttributes().getQ0(), 0);
-        assertEquals(1, resourceTransformer.getAttributes().getNode(), 0);
+        assertEquals(Boolean.FALSE, resourceBattery.getAttributes().isFictitious());
+        assertEquals(300, resourceBattery.getAttributes().getMaxP(), 0);
+        assertEquals(200, resourceBattery.getAttributes().getMinP(), 0);
+        assertEquals(250, resourceBattery.getAttributes().getP0(), 0);
+        assertEquals(100, resourceBattery.getAttributes().getQ0(), 0);
+        assertEquals(1, resourceBattery.getAttributes().getNode(), 0);
 
+        assertTrue(Double.isNaN(resourceBattery.getAttributes().getP()));
+        assertTrue(Double.isNaN(resourceBattery.getAttributes().getQ()));
     }
 
     @Test
@@ -354,6 +413,7 @@ public class ResourceTest {
                 .attributes(new ShuntCompensatorAttributes(shuntCompensatorAttributes))
                 .build();
 
+        assertFalse(resourceShunt.getAttributes().isFictitious());
         assertEquals("idEq", resourceShunt.getAttributes().getRegulatingTerminal().getConnectableId());
         assertEquals("ONE", resourceShunt.getAttributes().getRegulatingTerminal().getSide());
         assertEquals(100., resourceShunt.getAttributes().getP(), 0.001);
@@ -397,8 +457,6 @@ public class ResourceTest {
                 .b(4)
                 .generation(danglingLineGenerationAttributes)
                 .ucteXnodeCode("XN1")
-                .p(100)
-                .q(200)
                 .bus("bus1")
                 .build();
 
@@ -427,8 +485,9 @@ public class ResourceTest {
         assertEquals(10, ((MinMaxReactiveLimitsAttributes) resourceDanglingLine.getAttributes().getGeneration().getReactiveLimits()).getMinQ(), 0);
         assertEquals(20, ((MinMaxReactiveLimitsAttributes) resourceDanglingLine.getAttributes().getGeneration().getReactiveLimits()).getMaxQ(), 0);
         assertEquals("XN1", resourceDanglingLine.getAttributes().getUcteXnodeCode());
-        assertEquals(100., resourceDanglingLine.getAttributes().getP(), 0);
-        assertEquals(200, resourceDanglingLine.getAttributes().getQ(), 0);
         assertEquals("bus1", resourceDanglingLine.getAttributes().getBus());
+
+        assertTrue(Double.isNaN(resourceDanglingLine.getAttributes().getP()));
+        assertTrue(Double.isNaN(resourceDanglingLine.getAttributes().getQ()));
     }
 }


### PR DESCRIPTION
This PR must be merged after this one :
https://github.com/powsybl/powsybl-network-store/pull/157


**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
Some attributes are not initiated like powsybl core which generates non-identical xml exports


**What is the new behavior (if this is a feature change)?**
All attributes are initiated like powsybl core which generates identical xml exports


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No

**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
