### PR TITLE
Add missing fictitious attributes in cassandra

### DIFF
--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/BatteryAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/BatteryAdderImpl.java
@@ -75,6 +75,7 @@ public class BatteryAdderImpl extends AbstractInjectionAdder<BatteryAdderImpl> i
                 .attributes(BatteryAttributes.builder()
                         .voltageLevelId(getVoltageLevelResource().getId())
                         .name(getName())
+                        .fictitious(isFictitious())
                         .node(getNode())
                         .bus(getBus())
                         .connectableBus(getConnectableBus())

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/BusbarSectionAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/BusbarSectionAdderImpl.java
@@ -41,6 +41,7 @@ class BusbarSectionAdderImpl extends AbstractIdentifiableAdder<BusbarSectionAdde
                 .attributes(BusbarSectionAttributes.builder()
                                                    .voltageLevelId(voltageLevelResource.getId())
                                                    .name(getName())
+                                                   .fictitious(isFictitious())
                                                    .node(node)
                                                    .build())
                 .build();

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/ConfiguredBusAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/ConfiguredBusAdderImpl.java
@@ -33,6 +33,7 @@ public class ConfiguredBusAdderImpl extends AbstractIdentifiableAdder<Configured
                 .attributes(ConfiguredBusAttributes.builder()
                         .id(id)
                         .name(getName())
+                        .fictitious(isFictitious())
                         .voltageLevelId(voltageLevelResource.getId())
                         .build())
                 .build();

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/DanglingLineAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/DanglingLineAdderImpl.java
@@ -172,6 +172,7 @@ public class DanglingLineAdderImpl extends AbstractInjectionAdder<DanglingLineAd
                 .attributes(DanglingLineAttributes.builder()
                         .voltageLevelId(getVoltageLevelResource().getId())
                         .name(getName())
+                        .fictitious(isFictitious())
                         .node(getNode())
                         .bus(getBus())
                         .connectableBus(getConnectableBus())

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/GeneratorAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/GeneratorAdderImpl.java
@@ -124,6 +124,7 @@ class GeneratorAdderImpl extends AbstractInjectionAdder<GeneratorAdderImpl> impl
                 .attributes(GeneratorAttributes.builder()
                         .voltageLevelId(getVoltageLevelResource().getId())
                         .name(getName())
+                        .fictitious(isFictitious())
                         .node(getNode())
                         .bus(getBus())
                         .connectableBus(getConnectableBus())

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/HvdcLineAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/HvdcLineAdderImpl.java
@@ -100,6 +100,7 @@ public class HvdcLineAdderImpl extends AbstractIdentifiableAdder<HvdcLineAdderIm
                 .id(id)
                 .attributes(HvdcLineAttributes.builder()
                         .name(getName())
+                        .fictitious(isFictitious())
                         .r(r)
                         .convertersMode(convertersMode)
                         .nominalV(nominalV)

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/LccConverterStationAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/LccConverterStationAdderImpl.java
@@ -41,6 +41,7 @@ public class LccConverterStationAdderImpl extends AbstractHvdcConverterStationAd
                 .attributes(LccConverterStationAttributes.builder()
                         .voltageLevelId(getVoltageLevelResource().getId())
                         .name(getName())
+                        .fictitious(isFictitious())
                         .node(getNode())
                         .bus(getBus())
                         .connectableBus(getConnectableBus())

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/LineAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/LineAdderImpl.java
@@ -90,6 +90,7 @@ class LineAdderImpl extends AbstractBranchAdder<LineAdderImpl> implements LineAd
                         .voltageLevelId1(getVoltageLevelId1())
                         .voltageLevelId2(getVoltageLevelId2())
                         .name(getName())
+                        .fictitious(isFictitious())
                         .node1(getNode1())
                         .node2(getNode2())
                         .bus1(getBus1())

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/LoadAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/LoadAdderImpl.java
@@ -62,6 +62,7 @@ class LoadAdderImpl extends AbstractInjectionAdder<LoadAdderImpl> implements Loa
                 .attributes(LoadAttributes.builder()
                                           .voltageLevelId(getVoltageLevelResource().getId())
                                           .name(getName())
+                                          .fictitious(isFictitious())
                                           .node(getNode())
                                           .bus(getBus())
                                           .connectableBus(getConnectableBus())

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkImpl.java
@@ -53,7 +53,7 @@ public class NetworkImpl extends AbstractIdentifiableImpl<Network, NetworkAttrib
 
         @Override
         public Stream<Bus> getBusStream() {
-            return getVoltageLevelStream().filter(vl -> vl.getTopologyKind() == TopologyKind.BUS_BREAKER).flatMap(vl -> vl.getBusBreakerView().getBusStream());
+            return getVoltageLevelStream().flatMap(vl -> vl.getBusBreakerView().getBusStream());
         }
 
         @Override
@@ -73,7 +73,7 @@ public class NetworkImpl extends AbstractIdentifiableImpl<Network, NetworkAttrib
 
         @Override
         public Bus getBus(String id) {
-            return getVoltageLevelStream().filter(vl -> vl.getTopologyKind() == TopologyKind.BUS_BREAKER).map(vl -> vl.getBusBreakerView().getBus(id))
+            return getVoltageLevelStream().map(vl -> vl.getBusBreakerView().getBus(id))
                     .filter(Objects::nonNull)
                     .findFirst()
                     .orElse(null);

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkImpl.java
@@ -53,7 +53,7 @@ public class NetworkImpl extends AbstractIdentifiableImpl<Network, NetworkAttrib
 
         @Override
         public Stream<Bus> getBusStream() {
-            return getVoltageLevelStream().flatMap(vl -> vl.getBusBreakerView().getBusStream());
+            return getVoltageLevelStream().filter(vl -> vl.getTopologyKind() == TopologyKind.BUS_BREAKER).flatMap(vl -> vl.getBusBreakerView().getBusStream());
         }
 
         @Override
@@ -73,7 +73,7 @@ public class NetworkImpl extends AbstractIdentifiableImpl<Network, NetworkAttrib
 
         @Override
         public Bus getBus(String id) {
-            return getVoltageLevelStream().map(vl -> vl.getBusBreakerView().getBus(id))
+            return getVoltageLevelStream().filter(vl -> vl.getTopologyKind() == TopologyKind.BUS_BREAKER).map(vl -> vl.getBusBreakerView().getBus(id))
                     .filter(Objects::nonNull)
                     .findFirst()
                     .orElse(null);

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/ShuntCompensatorAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/ShuntCompensatorAdderImpl.java
@@ -228,6 +228,7 @@ public class ShuntCompensatorAdderImpl extends AbstractInjectionAdder<ShuntCompe
                 .attributes(ShuntCompensatorAttributes.builder()
                         .voltageLevelId(getVoltageLevelResource().getId())
                         .name(getName())
+                        .fictitious(isFictitious())
                         .node(getNode())
                         .bus(getBus())
                         .connectableBus(getConnectableBus())

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/StaticVarCompensatorAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/StaticVarCompensatorAdderImpl.java
@@ -85,6 +85,7 @@ public class StaticVarCompensatorAdderImpl extends AbstractInjectionAdder<Static
                 .attributes(StaticVarCompensatorAttributes.builder()
                         .voltageLevelId(getVoltageLevelResource().getId())
                         .name(getName())
+                        .fictitious(isFictitious())
                         .node(getNode())
                         .bus(getBus())
                         .connectableBus(getConnectableBus())

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/SubstationAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/SubstationAdderImpl.java
@@ -51,6 +51,7 @@ class SubstationAdderImpl extends AbstractIdentifiableAdder<SubstationAdderImpl>
                 .id(id)
                 .attributes(SubstationAttributes.builder()
                                                 .name(getName())
+                                                .fictitious(isFictitious())
                                                 .country(country)
                                                 .tso(tso)
                                                 .build())

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/SwitchAdderBusBreakerImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/SwitchAdderBusBreakerImpl.java
@@ -54,6 +54,7 @@ class SwitchAdderBusBreakerImpl extends AbstractSwitchAdder<SwitchAdderBusBreake
                 .attributes(SwitchAttributes.builder()
                         .voltageLevelId(getVoltageLevelResource().getId())
                         .name(getName())
+                        .fictitious(isFictitious())
                         .bus1(bus1)
                         .bus2(bus2)
                         .kind(SwitchKind.BREAKER)

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/SwitchAdderNodeBreakerImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/SwitchAdderNodeBreakerImpl.java
@@ -79,6 +79,7 @@ class SwitchAdderNodeBreakerImpl extends AbstractSwitchAdder<SwitchAdderNodeBrea
                 .attributes(SwitchAttributes.builder()
                         .voltageLevelId(getVoltageLevelResource().getId())
                         .name(getName())
+                        .fictitious(isFictitious())
                         .kind(kind)
                         .node1(node1)
                         .node2(node2)

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/ThreeWindingsTransformerAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/ThreeWindingsTransformerAdderImpl.java
@@ -288,6 +288,7 @@ public class ThreeWindingsTransformerAdderImpl extends AbstractIdentifiableAdder
                 .id(id)
                 .attributes(ThreeWindingsTransformerAttributes.builder()
                         .name(getName())
+                        .fictitious(isFictitious())
                         .ratedU0(ratedU0)
                         .leg1(leg1)
                         .leg2(leg2)

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/TieLineAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/TieLineAdderImpl.java
@@ -234,6 +234,7 @@ public class TieLineAdderImpl extends AbstractBranchAdder<TieLineAdderImpl> impl
                 .id(id)
                 .attributes(LineAttributes.builder()
                         .name(getName())
+                        .fictitious(isFictitious())
                         .r(r)
                         .x(x)
                         .b1(b1)

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/TwoWindingsTransformerAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/TwoWindingsTransformerAdderImpl.java
@@ -108,6 +108,7 @@ class TwoWindingsTransformerAdderImpl extends AbstractBranchAdder<TwoWindingsTra
                         .voltageLevelId1(getVoltageLevelId1())
                         .voltageLevelId2(getVoltageLevelId2())
                         .name(getName())
+                        .fictitious(isFictitious())
                         .node1(getNode1())
                         .node2(getNode2())
                         .bus1(getBus1())

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/VoltageLevelAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/VoltageLevelAdderImpl.java
@@ -78,6 +78,7 @@ class VoltageLevelAdderImpl extends AbstractIdentifiableAdder<VoltageLevelAdderI
                 .attributes(VoltageLevelAttributes.builder()
                                                   .substationId(substationResource.getId())
                                                   .name(getName())
+                                                  .fictitious(isFictitious())
                                                   .nominalV(nominalV)
                                                   .lowVoltageLimit(lowVoltageLimit)
                                                   .highVoltageLimit(highVoltageLimit)

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/VscConverterStationAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/VscConverterStationAdderImpl.java
@@ -57,6 +57,7 @@ public class VscConverterStationAdderImpl extends AbstractHvdcConverterStationAd
                 .attributes(VscConverterStationAttributes.builder()
                         .voltageLevelId(getVoltageLevelResource().getId())
                         .name(getName())
+                        .fictitious(isFictitious())
                         .node(getNode())
                         .bus(getBus())
                         .connectableBus(getConnectableBus())

--- a/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreIT.java
+++ b/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreIT.java
@@ -104,6 +104,7 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
     }
 
     private static void testNetwork(Network network) {
+        assertEquals(false, network.isFictitious());
         assertEquals("sim1", network.getId());
         assertEquals("sim1", network.getName());
         assertEquals("test", network.getSourceFormat());
@@ -236,6 +237,7 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
 
             Stream<StaticVarCompensator> svcs = readNetwork.getStaticVarCompensatorStream();
             StaticVarCompensator svc = svcs.findFirst().get();
+            assertFalse(svc.isFictitious());
             assertEquals(0.0002, svc.getBmin(), 0.00001);
             assertEquals(0.0008, svc.getBmax(), 0.00001);
             assertEquals(StaticVarCompensator.RegulationMode.VOLTAGE, svc.getRegulationMode());
@@ -244,6 +246,7 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
             assertEquals(435, svc.getTerminal().getP(), 0.1);
             assertEquals(315, svc.getTerminal().getQ(), 0.1);
 
+            svc.setFictitious(true);
             svc.setBmin(0.5);
             svc.setBmax(0.7);
             svc.setRegulationMode(StaticVarCompensator.RegulationMode.REACTIVE_POWER);
@@ -263,6 +266,7 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
             StaticVarCompensator svc = readNetwork.getStaticVarCompensatorStream().findFirst().get();
             assertNotNull(svc);
 
+            assertTrue(svc.isFictitious());
             assertEquals(0.5, svc.getBmin(), 0.00001);
             assertEquals(0.7, svc.getBmax(), 0.00001);
             assertEquals(StaticVarCompensator.RegulationMode.REACTIVE_POWER, svc.getRegulationMode());
@@ -319,6 +323,7 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
 
             Stream<VscConverterStation> vscConverterStationsStream = readNetwork.getVscConverterStationStream();
             VscConverterStation vscConverterStation = vscConverterStationsStream.filter(vsc -> vsc.getId().equals("VSC1")).findFirst().get();
+            assertFalse(vscConverterStation.isFictitious());
             assertEquals("VSC1", vscConverterStation.getId());
             assertEquals(24, vscConverterStation.getLossFactor(), 0.1);
             assertEquals(300, vscConverterStation.getReactivePowerSetpoint(), 0.1);
@@ -336,6 +341,7 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
             assertEquals(2, limits.getPoints().size());
 
             VscConverterStation vscConverterStation2 = readNetwork.getVscConverterStation("VSC2");
+            assertFalse(vscConverterStation2.isFictitious());
             assertEquals("VSC2", vscConverterStation2.getId());
             assertEquals(17, vscConverterStation2.getLossFactor(), 0.1);
             assertEquals(227, vscConverterStation2.getReactivePowerSetpoint(), 0.1);
@@ -355,6 +361,8 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
             vscConverterStation.getTerminal().setP(452);
             vscConverterStation.getTerminal().setQ(318);
 
+            vscConverterStation2.setFictitious(true);
+
             service.flush(readNetwork);  // flush the network
         }
 
@@ -372,6 +380,10 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
             assertEquals(300, vscConverterStation.getVoltageSetpoint(), 0.1);
             assertEquals(452, vscConverterStation.getTerminal().getP(), 0.1);
             assertEquals(318, vscConverterStation.getTerminal().getQ(), 0.1);
+
+            VscConverterStation vscConverterStation2 = readNetwork.getVscConverterStation("VSC2");
+            assertNotNull(vscConverterStation2);
+            assertTrue(vscConverterStation2.isFictitious());
         }
     }
 
@@ -421,11 +433,13 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
 
             Stream<LccConverterStation> lccConverterStations = readNetwork.getLccConverterStationStream();
             LccConverterStation lccConverterStation = lccConverterStations.findFirst().get();
+            assertFalse(lccConverterStation.isFictitious());
             assertEquals("LCC2", lccConverterStation.getId());
             assertEquals(0.5, lccConverterStation.getPowerFactor(), 0.1);
             assertEquals(440, lccConverterStation.getTerminal().getP(), 0.1);
             assertEquals(320, lccConverterStation.getTerminal().getQ(), 0.1);
 
+            lccConverterStation.setFictitious(true);
             lccConverterStation.setPowerFactor(0.5F);
             lccConverterStation.setLossFactor(50);
             lccConverterStation.getTerminal().setP(423);
@@ -442,6 +456,7 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
             LccConverterStation lccConverterStation = readNetwork.getLccConverterStationStream().findFirst().get();
             assertNotNull(lccConverterStation);
 
+            assertTrue(lccConverterStation.isFictitious());
             assertEquals(0.5F, lccConverterStation.getPowerFactor(), 0.1);
             assertEquals(50, lccConverterStation.getLossFactor(), 0.1);
             assertEquals(423, lccConverterStation.getTerminal().getP(), 0.1);
@@ -656,11 +671,16 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
 
             Substation s1 = network.newSubstation()
                     .setId("S1")
+                    .setFictitious(true)
                     .setCountry(Country.FR)
                     .setTso("TSO_FR")
                     .add();
 
             verify(mockedListener, times(1)).onCreation(s1);
+
+            assertTrue(s1.isFictitious());
+            s1.setFictitious(false);
+            assertFalse(s1.isFictitious());
 
             assertEquals(Country.FR, s1.getCountry().get());
             assertEquals("TSO_FR", s1.getTso());
@@ -699,6 +719,7 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
                     .add();
 
             VoltageLevel vl1 = s1.newVoltageLevel()
+                    .setFictitious(true)
                     .setId("vl1")
                     .setNominalV(400)
                     .setLowVoltageLimit(385)
@@ -708,14 +729,17 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
 
             verify(mockedListener, times(1)).onCreation(vl1);
 
+            assertTrue(vl1.isFictitious());
             assertEquals(400, vl1.getNominalV(), 0.1);
             assertEquals(385, vl1.getLowVoltageLimit(), 0.1);
             assertEquals(415, vl1.getHighVoltageLimit(), 0.1);
 
+            vl1.setFictitious(false);
             vl1.setNominalV(380);
             vl1.setLowVoltageLimit(370);
             vl1.setHighVoltageLimit(390);
 
+            assertFalse(vl1.isFictitious());
             assertEquals(380, vl1.getNominalV(), 0.1);
             assertEquals(370, vl1.getLowVoltageLimit(), 0.1);
             assertEquals(390, vl1.getHighVoltageLimit(), 0.1);
@@ -761,6 +785,7 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
 
             Line line = network.newLine()
                     .setId("line")
+                    .setFictitious(true)
                     .setVoltageLevel1("vl1")
                     .setBus1("b1")
                     .setVoltageLevel2("vl2")
@@ -775,7 +800,7 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
 
             verify(mockedListener, times(1)).onCreation(line);
 
-            assertFalse(line.isFictitious());
+            assertTrue(line.isFictitious());
             assertEquals(1, line.getR(), 0.1);
             assertEquals(3, line.getX(), 0.1);
             assertEquals(4, line.getG1(), 0.1);
@@ -783,7 +808,7 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
             assertEquals(2, line.getB1(), 0.1);
             assertEquals(4, line.getB2(), 0.1);
 
-            line.setFictitious(true);
+            line.setFictitious(false);
             line.setR(5);
             line.setX(6);
             line.setG1(12);
@@ -791,7 +816,7 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
             line.setB1(8);
             line.setB2(16);
 
-            assertTrue(line.isFictitious());
+            assertFalse(line.isFictitious());
             assertEquals(5, line.getR(), 0.1);
             assertEquals(6, line.getX(), 0.1);
             assertEquals(12, line.getG1(), 0.1);
@@ -830,6 +855,7 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
                     .add();
 
             Battery battery = vl1.newBattery()
+                    .setFictitious(true)
                     .setId("battery")
                     .setConnectableBus("b1")
                     .setBus("b1")
@@ -841,6 +867,7 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
 
             verify(mockedListener, times(1)).onCreation(battery);
 
+            assertTrue(battery.isFictitious());
             assertEquals(50, battery.getP0(), 0.1);
             assertEquals(10, battery.getQ0(), 0.1);
             assertEquals(40, battery.getMinP(), 0.1);
@@ -848,9 +875,11 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
 
             assertTrue(assertThrows(ValidationException.class, () -> battery.setP0(75)).getMessage().contains("invalid active power p > maxP"));
 
+            battery.setFictitious(false);
             battery.setP0(65);
             battery.setQ0(20);
 
+            assertFalse(battery.isFictitious());
             assertEquals(65, battery.getP0(), 0.1);
             assertEquals(20, battery.getQ0(), 0.1);
 
@@ -914,6 +943,7 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
                     .add();
             Load load = vl1.newLoad()
                     .setId("load")
+                    .setFictitious(true)
                     .setConnectableBus("b1")
                     .setBus("b1")
                     .setP0(50)
@@ -922,12 +952,15 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
 
             verify(mockedListener, times(1)).onCreation(load);
 
+            assertTrue(load.isFictitious());
             assertEquals(50, load.getP0(), 0.1);
             assertEquals(10, load.getQ0(), 0.1);
 
+            load.setFictitious(false);
             load.setP0(70);
             load.setQ0(20);
 
+            assertFalse(load.isFictitious());
             assertEquals(70, load.getP0(), 0.1);
             assertEquals(20, load.getQ0(), 0.1);
 
@@ -957,6 +990,7 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
 
             Stream<DanglingLine> danglingLines = readNetwork.getDanglingLineStream();
             DanglingLine danglingLine = danglingLines.findFirst().get();
+            assertFalse(danglingLine.isFictitious());
             assertEquals("DL1", danglingLine.getId());
             assertEquals("Dangling line 1", danglingLine.getName());
             assertEquals(533, danglingLine.getP0(), 0.1);
@@ -1040,9 +1074,11 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
                     .add();
 
             DanglingLine danglingLine2 = readNetwork.getDanglingLineStream().skip(1).findFirst().get();
+            assertFalse(danglingLine2.isFictitious());
             assertEquals("DL2", danglingLine2.getId());
             assertEquals(ReactiveLimitsKind.MIN_MAX, danglingLine2.getGeneration().getReactiveLimits().getKind());
 
+            danglingLine2.setFictitious(true);
             danglingLine2.setR(50);
             danglingLine2.getGeneration().newReactiveCapabilityCurve().beginPoint()
                     .setP(25)
@@ -1085,6 +1121,7 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
             assertEquals(2, curveLimits.getPointCount());
 
             DanglingLine danglingLine2 = readNetwork.getDanglingLineStream().skip(1).findFirst().get();
+            assertTrue(danglingLine2.isFictitious());
             assertEquals("DL2", danglingLine2.getId());
             assertEquals(ReactiveLimitsKind.CURVE, danglingLine2.getGeneration().getReactiveLimits().getKind());
             assertEquals(2, ((ReactiveCapabilityCurve) danglingLine2.getGeneration().getReactiveLimits()).getPointCount());
@@ -1114,6 +1151,7 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
 
             Stream<HvdcLine> hvdcLines = readNetwork.getHvdcLineStream();
             HvdcLine hvdcLine = hvdcLines.findFirst().get();
+            assertFalse(hvdcLine.isFictitious());
             assertEquals(256, hvdcLine.getR(), 0.1);
             assertEquals(HvdcLine.ConvertersMode.SIDE_1_RECTIFIER_SIDE_2_INVERTER, hvdcLine.getConvertersMode());
             assertEquals(330, hvdcLine.getActivePowerSetpoint(), 0.1);
@@ -1124,6 +1162,7 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
             assertEquals("HVDC1", hvdcLine.getConverterStation1().getHvdcLine().getId());
             assertEquals("HVDC1", hvdcLine.getConverterStation2().getHvdcLine().getId());
 
+            hvdcLine.setFictitious(true);
             hvdcLine.setR(240);
             hvdcLine.setConvertersMode(HvdcLine.ConvertersMode.SIDE_1_INVERTER_SIDE_2_RECTIFIER);
             hvdcLine.setActivePowerSetpoint(350);
@@ -1140,6 +1179,7 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
 
             HvdcLine hvdcLine = readNetwork.getHvdcLineStream().findFirst().get();
 
+            assertTrue(hvdcLine.isFictitious());
             assertEquals(240, hvdcLine.getR(), 0.1);
             assertEquals(HvdcLine.ConvertersMode.SIDE_1_INVERTER_SIDE_2_RECTIFIER, hvdcLine.getConvertersMode());
             assertEquals(350, hvdcLine.getActivePowerSetpoint(), 0.1);
@@ -1226,6 +1266,7 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
 
             Stream<ThreeWindingsTransformer> threeWindingsTransformerStream = readNetwork.getThreeWindingsTransformerStream();
             ThreeWindingsTransformer threeWindingsTransformer = threeWindingsTransformerStream.findFirst().get();
+            assertFalse(threeWindingsTransformer.isFictitious());
             assertEquals(234, threeWindingsTransformer.getRatedU0(), 0.1);
             assertEquals(45, threeWindingsTransformer.getLeg1().getR(), 0.1);
             assertEquals(35, threeWindingsTransformer.getLeg1().getX(), 0.1);
@@ -1274,6 +1315,7 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
 
             assertEquals(25, threeWindingsTransformer.getLeg1().getCurrentLimits().getPermanentLimit(), .0001);
 
+            threeWindingsTransformer.setFictitious(true);
             threeWindingsTransformer.getLeg1().getTerminal().setP(1000.);
             threeWindingsTransformer.getLeg2().getTerminal().setQ(2000.);
             threeWindingsTransformer.getLeg3().getTerminal().setP(3000.);
@@ -1289,6 +1331,7 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
             ThreeWindingsTransformer transformer = readNetwork.getThreeWindingsTransformer("TWT1");
             assertNotNull(transformer);
 
+            assertTrue(transformer.isFictitious());
             assertEquals(1000., transformer.getLeg1().getTerminal().getP(), 0.);
             assertEquals(2000., transformer.getLeg2().getTerminal().getQ(), 0.);
             assertEquals(3000., transformer.getLeg3().getTerminal().getP(), 0.);
@@ -1341,6 +1384,7 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
 
             Stream<TwoWindingsTransformer> twoWindingsTransformerStream = readNetwork.getTwoWindingsTransformerStream();
             TwoWindingsTransformer twoWindingsTransformer = twoWindingsTransformerStream.findFirst().get();
+            assertFalse(twoWindingsTransformer.isFictitious());
             assertEquals(250, twoWindingsTransformer.getR(), 0.1);
             assertEquals(100, twoWindingsTransformer.getX(), 0.1);
             assertEquals(52, twoWindingsTransformer.getG(), 0.1);
@@ -1373,6 +1417,7 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
             // Add observer changes to current network
             readNetwork.addListener(mockedListener);
 
+            twoWindingsTransformer.setFictitious(true);
             twoWindingsTransformer.setR(280);
             twoWindingsTransformer.setX(130);
             twoWindingsTransformer.setG(82);
@@ -1380,6 +1425,7 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
             twoWindingsTransformer.setRatedU1(95);
             twoWindingsTransformer.setRatedU2(120);
 
+            assertTrue(twoWindingsTransformer.isFictitious());
             assertEquals(280, twoWindingsTransformer.getR(), 0.1);
             assertEquals(130, twoWindingsTransformer.getX(), 0.1);
             assertEquals(82, twoWindingsTransformer.getG(), 0.1);
@@ -1393,6 +1439,7 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
             verify(mockedListener, times(1)).onUpdate(twoWindingsTransformer, "b", 12d, 42d);
             verify(mockedListener, times(1)).onUpdate(twoWindingsTransformer, "ratedU1", 65d, 95d);
             verify(mockedListener, times(1)).onUpdate(twoWindingsTransformer, "ratedU2", 90d, 120d);
+            verify(mockedListener, times(1)).onUpdate(twoWindingsTransformer, "fictitious", false, true);
 
             readNetwork.removeListener(mockedListener);
         }
@@ -1730,6 +1777,7 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
             assertEquals("Generator network", readNetwork.getId());
 
             Generator generator = readNetwork.getGeneratorStream().findFirst().get();
+            assertFalse(generator.isFictitious());
             assertEquals("GEN", generator.getId());
 
             ReactiveLimits reactiveLimits = generator.getReactiveLimits();
@@ -1756,6 +1804,7 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
             assertEquals(6, generator.getTargetV(), .0001);
             assertFalse(generator.isVoltageRegulatorOn());
 
+            generator.setFictitious(true);
             generator.setEnergySource(EnergySource.NUCLEAR);
             generator.setMaxP(1200);
             generator.setMinP(100);
@@ -1775,6 +1824,7 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
 
             Generator generator = readNetwork.getGeneratorStream().findFirst().get();
             assertNotNull(generator);
+            assertTrue(generator.isFictitious());
 
             assertEquals(EnergySource.NUCLEAR, generator.getEnergySource());
             assertEquals(1200, generator.getMaxP(), .0001);
@@ -1809,6 +1859,7 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
             assertEquals("Generator network", readNetwork.getId());
 
             Generator generator = readNetwork.getGeneratorStream().findFirst().get();
+            assertFalse(generator.isFictitious());
             assertEquals("GEN", generator.getId());
 
             ReactiveLimits reactiveLimits = generator.getReactiveLimits();
@@ -2273,9 +2324,11 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
 
             Switch breaker = readNetwork.getSwitch("v1b1");
             assertNotNull(breaker);
+            assertFalse(breaker.isFictitious());
 
             assertEquals(Boolean.FALSE, breaker.isOpen());
 
+            breaker.setFictitious(true);
             breaker.setOpen(true); // open breaker switch
 
             service.flush(readNetwork);  // flush the network
@@ -2288,6 +2341,7 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
 
             Switch breaker = readNetwork.getSwitch("v1b1");
             assertNotNull(breaker);
+            assertTrue(breaker.isFictitious());
 
             assertEquals(Boolean.TRUE, breaker.isOpen());  // the breaker switch must be opened
         }
@@ -2444,6 +2498,62 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
             assertEquals(1, t3wsVL2.size());
             List<ThreeWindingsTransformer> t3wsVL3 = (List<ThreeWindingsTransformer>) t3wVl3.getConnectables(ThreeWindingsTransformer.class);
             assertEquals(1, t3wsVL3.size());
+        }
+    }
+
+    @Test
+    public void configuredBusTest() {
+        try (NetworkStoreService service = createNetworkStoreService()) {
+            Network network = NetworkStorageTestCaseFactory.create(service.getNetworkFactory());
+            service.flush(network);
+        }
+
+        try (NetworkStoreService service = createNetworkStoreService()) {
+
+            Map<UUID, String> networkIds = service.getNetworkIds();
+
+            assertEquals(1, networkIds.size());
+
+            Network readNetwork = service.getNetwork(networkIds.keySet().stream().findFirst().get());
+
+            assertEquals("networkTestCase", readNetwork.getId());
+
+            List<Bus> buses = readNetwork.getBusBreakerView().getBusStream().collect(Collectors.toList());
+            assertEquals(2, buses.size());
+
+            Bus bus1 = readNetwork.getBusBreakerView().getBus("BUS5");
+            Bus bus2 = readNetwork.getBusBreakerView().getBus("BUS6");
+
+            assertNotNull(bus1);
+            assertNotNull(bus2);
+
+            assertFalse(bus1.isFictitious());
+            assertEquals("VL5", bus1.getVoltageLevel().getId());
+            assertEquals(.0, bus1.getV(), .0);
+            assertEquals(.0, bus1.getAngle(), .0);
+
+            assertFalse(bus2.isFictitious());
+            assertEquals("VL6", bus2.getVoltageLevel().getId());
+            assertEquals(.0, bus2.getV(), .0);
+            assertEquals(.0, bus2.getAngle(), .0);
+
+            bus1.setFictitious(true);
+            bus1.setV(Double.NaN);
+            bus1.setAngle(Double.NaN);
+
+            service.flush(readNetwork);  // flush the network
+        }
+
+        // reload modified network
+        try (NetworkStoreService service = createNetworkStoreService()) {
+            Map<UUID, String> networkIds = service.getNetworkIds();
+            Network readNetwork = service.getNetwork(networkIds.keySet().stream().findFirst().get());
+
+            Bus bus1 = readNetwork.getBusBreakerView().getBus("BUS5");
+
+            assertTrue(bus1.isFictitious());
+            assertTrue(Double.isNaN(bus1.getV()));
+            assertTrue(Double.isNaN(bus1.getAngle()));
         }
     }
 
@@ -3136,6 +3246,7 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
 
             ShuntCompensator shunt1 = readNetwork.getShuntCompensatorStream().findFirst().get();
             assertEquals("SHUNT1", shunt1.getId());
+            assertFalse(shunt1.isFictitious());
             assertTrue(shunt1.isVoltageRegulatorOn());
             assertEquals(5, shunt1.getSectionCount());
             assertEquals(10, shunt1.getMaximumSectionCount());
@@ -3163,6 +3274,7 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
 
             ShuntCompensator shunt2 = readNetwork.getShuntCompensatorStream().skip(1).findFirst().get();
             assertEquals("SHUNT2", shunt2.getId());
+            assertFalse(shunt2.isFictitious());
             assertFalse(shunt2.isVoltageRegulatorOn());
             assertEquals(3, shunt2.getSectionCount());
             assertEquals(420, shunt2.getTargetV(), 0.1);
@@ -3180,6 +3292,7 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
             ((ShuntCompensatorNonLinearModel) shunt2.getModel()).getAllSections().get(0).setB(11);
             ((ShuntCompensatorNonLinearModel) shunt2.getModel()).getAllSections().get(0).setG(12);
 
+            shunt2.setFictitious(true);
             shunt2.setTargetV(450);
             shunt2.setVoltageRegulatorOn(true);
             shunt2.setSectionCount(1);
@@ -3196,7 +3309,7 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
 
             ShuntCompensator shunt1 = readNetwork.getShuntCompensatorStream().findFirst().get();
             assertNotNull(shunt1);
-
+            assertFalse(shunt1.isFictitious());
             assertFalse(shunt1.isVoltageRegulatorOn());
             assertEquals(8, shunt1.getSectionCount());
             assertEquals(420, shunt1.getTargetV(), 0.1);
@@ -3205,7 +3318,7 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
 
             ShuntCompensator shunt2 = readNetwork.getShuntCompensatorStream().skip(1).findFirst().get();
             assertNotNull(shunt2);
-
+            assertTrue(shunt2.isFictitious());
             assertTrue(shunt2.isVoltageRegulatorOn());
             assertEquals(1, shunt2.getSectionCount());
             assertEquals(450, shunt2.getTargetV(), 0.1);

--- a/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreIT.java
+++ b/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreIT.java
@@ -2518,11 +2518,19 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
 
             assertEquals("networkTestCase", readNetwork.getId());
 
-            List<Bus> buses = readNetwork.getBusBreakerView().getBusStream().collect(Collectors.toList());
+            // FIXME workaround for network bus/breaker view impl not yet implemented in network store
+            //List<Bus> buses = readNetwork.getBusBreakerView().getBusStream().collect(Collectors.toList());
+            List<Bus> buses = readNetwork.getVoltageLevelStream()
+                    .filter(vl -> vl.getTopologyKind() == TopologyKind.BUS_BREAKER)
+                    .flatMap(vl -> vl.getBusBreakerView().getBusStream())
+                    .collect(Collectors.toList());
             assertEquals(2, buses.size());
 
-            Bus bus1 = readNetwork.getBusBreakerView().getBus("BUS5");
-            Bus bus2 = readNetwork.getBusBreakerView().getBus("BUS6");
+            // FIXME workaround for network bus/breaker view impl not yet implemented in network store
+            //Bus bus1 = readNetwork.getBusBreakerView().getBus("BUS5");
+            //Bus bus2 = readNetwork.getBusBreakerView().getBus("BUS6");
+            Bus bus1 = readNetwork.getVoltageLevel("VL5").getBusBreakerView().getBus("BUS5");
+            Bus bus2 = readNetwork.getVoltageLevel("VL6").getBusBreakerView().getBus("BUS6");
 
             assertNotNull(bus1);
             assertNotNull(bus2);
@@ -2549,7 +2557,9 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
             Map<UUID, String> networkIds = service.getNetworkIds();
             Network readNetwork = service.getNetwork(networkIds.keySet().stream().findFirst().get());
 
-            Bus bus1 = readNetwork.getBusBreakerView().getBus("BUS5");
+            // FIXME workaround for network bus/breaker view impl not yet implemented in network store
+            //Bus bus1 = readNetwork.getBusBreakerView().getBus("BUS5");
+            Bus bus1 = readNetwork.getVoltageLevel("VL5").getBusBreakerView().getBus("BUS5");
 
             assertTrue(bus1.isFictitious());
             assertTrue(Double.isNaN(bus1.getV()));

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/ConfiguredBusAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/ConfiguredBusAttributes.java
@@ -55,6 +55,7 @@ public class ConfiguredBusAttributes extends AbstractAttributes implements Ident
         this.voltageLevelId = other.voltageLevelId;
         this.v = other.v;
         this.angle = other.angle;
+        this.fictitious = other.fictitious;
         this.properties = other.properties;
     }
 

--- a/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreRepository.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreRepository.java
@@ -85,6 +85,7 @@ public class NetworkStoreRepository {
         psInsertNetwork = session.prepare(insertInto(KEYSPACE_IIDM, "network")
                 .value("uuid", bindMarker())
                 .value("id", bindMarker())
+                .value("fictitious", bindMarker())
                 .value("properties", bindMarker())
                 .value("caseDate", bindMarker())
                 .value("forecastDistance", bindMarker())
@@ -95,6 +96,7 @@ public class NetworkStoreRepository {
                 .value(CIM_CHARACTERISTICS, bindMarker()));
         psUpdateNetwork = session.prepare(update(KEYSPACE_IIDM, "network")
                 .with(set("id", bindMarker()))
+                .and(set("fictitious", bindMarker()))
                 .and(set("properties", bindMarker()))
                 .and(set("caseDate", bindMarker()))
                 .and(set("forecastDistance", bindMarker()))
@@ -109,6 +111,7 @@ public class NetworkStoreRepository {
                 .value("networkUuid", bindMarker())
                 .value("id", bindMarker())
                 .value("name", bindMarker())
+                .value("fictitious", bindMarker())
                 .value("properties", bindMarker())
                 .value("country", bindMarker())
                 .value("tso", bindMarker())
@@ -119,6 +122,7 @@ public class NetworkStoreRepository {
                 .value("id", bindMarker())
                 .value("substationId", bindMarker())
                 .value("name", bindMarker())
+                .value("fictitious", bindMarker())
                 .value("properties", bindMarker())
                 .value("nominalV", bindMarker())
                 .value("lowVoltageLimit", bindMarker())
@@ -132,6 +136,7 @@ public class NetworkStoreRepository {
                 .value(SLACK_TERMINAL, bindMarker()));
         psUpdateVoltageLevel = session.prepare(update(KEYSPACE_IIDM, "voltageLevel")
                 .with(set("name", bindMarker()))
+                .and(set("fictitious", bindMarker()))
                 .and(set("properties", bindMarker()))
                 .and(set("nominalV", bindMarker()))
                 .and(set("lowVoltageLimit", bindMarker()))
@@ -152,6 +157,7 @@ public class NetworkStoreRepository {
                 .value("id", bindMarker())
                 .value("voltageLevelId", bindMarker())
                 .value("name", bindMarker())
+                .value("fictitious", bindMarker())
                 .value("properties", bindMarker())
                 .value("node", bindMarker())
                 .value("energySource", bindMarker())
@@ -174,6 +180,7 @@ public class NetworkStoreRepository {
                 .value("coordinatedReactiveControl", bindMarker()));
         psUpdateGenerator = session.prepare(update(KEYSPACE_IIDM, "generator")
                 .with(set("name", bindMarker()))
+                .and(set("fictitious", bindMarker()))
                 .and(set("properties", bindMarker()))
                 .and(set("node", bindMarker()))
                 .and(set("energySource", bindMarker()))
@@ -203,6 +210,7 @@ public class NetworkStoreRepository {
                 .value("id", bindMarker())
                 .value("voltageLevelId", bindMarker())
                 .value("name", bindMarker())
+                .value("fictitious", bindMarker())
                 .value("properties", bindMarker())
                 .value("node", bindMarker())
                 .value("minP", bindMarker())
@@ -218,6 +226,7 @@ public class NetworkStoreRepository {
                 .value(CONNECTABLE_BUS, bindMarker()));
         psUpdateBattery = session.prepare(update(KEYSPACE_IIDM, "battery")
                 .with(set("name", bindMarker()))
+                .and(set("fictitious", bindMarker()))
                 .and(set("properties", bindMarker()))
                 .and(set("node", bindMarker()))
                 .and(set("minP", bindMarker()))
@@ -240,6 +249,7 @@ public class NetworkStoreRepository {
                 .value("id", bindMarker())
                 .value("voltageLevelId", bindMarker())
                 .value("name", bindMarker())
+                .value("fictitious", bindMarker())
                 .value("properties", bindMarker())
                 .value("node", bindMarker())
                 .value("loadType", bindMarker())
@@ -253,6 +263,7 @@ public class NetworkStoreRepository {
                 .value(LOAD_DETAIL, bindMarker()));
         psUpdateLoad = session.prepare(update(KEYSPACE_IIDM, "load")
                 .with(set("name", bindMarker()))
+                .and(set("fictitious", bindMarker()))
                 .and(set("properties", bindMarker()))
                 .and(set("node", bindMarker()))
                 .and(set("loadType", bindMarker()))
@@ -273,6 +284,7 @@ public class NetworkStoreRepository {
                 .value("id", bindMarker())
                 .value("voltageLevelId", bindMarker())
                 .value("name", bindMarker())
+                .value("fictitious", bindMarker())
                 .value("properties", bindMarker())
                 .value("node", bindMarker())
                 .value(LINEAR_MODEL, bindMarker())
@@ -289,6 +301,7 @@ public class NetworkStoreRepository {
                 .value("targetDeadband", bindMarker()));
         psUpdateShuntCompensator = session.prepare(update(KEYSPACE_IIDM, "shuntCompensator")
                 .with(set("name", bindMarker()))
+                .and(set("fictitious", bindMarker()))
                 .and(set("properties", bindMarker()))
                 .and(set("node", bindMarker()))
                 .and(set(LINEAR_MODEL, bindMarker()))
@@ -312,6 +325,7 @@ public class NetworkStoreRepository {
                 .value("id", bindMarker())
                 .value("voltageLevelId", bindMarker())
                 .value("name", bindMarker())
+                .value("fictitious", bindMarker())
                 .value("properties", bindMarker())
                 .value("node", bindMarker())
                 .value("lossFactor", bindMarker())
@@ -327,6 +341,7 @@ public class NetworkStoreRepository {
                 .value(CONNECTABLE_BUS, bindMarker()));
         psUpdateVscConverterStation = session.prepare(update(KEYSPACE_IIDM, "vscConverterStation")
                 .with(set("name", bindMarker()))
+                .and(set("fictitious", bindMarker()))
                 .and(set("properties", bindMarker()))
                 .and(set("node", bindMarker()))
                 .and(set("lossFactor", bindMarker()))
@@ -349,6 +364,7 @@ public class NetworkStoreRepository {
                 .value("id", bindMarker())
                 .value("voltageLevelId", bindMarker())
                 .value("name", bindMarker())
+                .value("fictitious", bindMarker())
                 .value("properties", bindMarker())
                 .value("node", bindMarker())
                 .value("powerFactor", bindMarker())
@@ -360,6 +376,7 @@ public class NetworkStoreRepository {
                 .value(CONNECTABLE_BUS, bindMarker()));
         psUpdateLccConverterStation = session.prepare(update(KEYSPACE_IIDM, "lccConverterStation")
                 .with(set("name", bindMarker()))
+                .and(set("fictitious", bindMarker()))
                 .and(set("properties", bindMarker()))
                 .and(set("node", bindMarker()))
                 .and(set("powerFactor", bindMarker()))
@@ -378,6 +395,7 @@ public class NetworkStoreRepository {
                 .value("id", bindMarker())
                 .value("voltageLevelId", bindMarker())
                 .value("name", bindMarker())
+                .value("fictitious", bindMarker())
                 .value("properties", bindMarker())
                 .value("node", bindMarker())
                 .value("bMin", bindMarker())
@@ -394,6 +412,7 @@ public class NetworkStoreRepository {
                 .value("voltagePerReactivePowerControl", bindMarker()));
         psUpdateStaticVarCompensator = session.prepare(update(KEYSPACE_IIDM, "staticVarCompensator")
                 .with(set("name", bindMarker()))
+                .and(set("fictitious", bindMarker()))
                 .and(set("properties", bindMarker()))
                 .and(set("node", bindMarker()))
                 .and(set("bMin", bindMarker()))
@@ -417,6 +436,7 @@ public class NetworkStoreRepository {
                 .value("id", bindMarker())
                 .value("voltageLevelId", bindMarker())
                 .value("name", bindMarker())
+                .value("fictitious", bindMarker())
                 .value("properties", bindMarker())
                 .value("node", bindMarker())
                 .value("position", bindMarker()));
@@ -456,6 +476,7 @@ public class NetworkStoreRepository {
                 .value("voltageLevelId1", bindMarker())
                 .value("voltageLevelId2", bindMarker())
                 .value("name", bindMarker())
+                .value("fictitious", bindMarker())
                 .value("properties", bindMarker())
                 .value("node1", bindMarker())
                 .value("node2", bindMarker())
@@ -483,6 +504,7 @@ public class NetworkStoreRepository {
                 .with(set("voltageLevelId1", bindMarker()))
                 .and(set("voltageLevelId2", bindMarker()))
                 .and(set("name", bindMarker()))
+                .and(set("fictitious", bindMarker()))
                 .and(set("properties", bindMarker()))
                 .and(set("node1", bindMarker()))
                 .and(set("node2", bindMarker()))
@@ -516,6 +538,7 @@ public class NetworkStoreRepository {
                 .value("voltageLevelId2", bindMarker())
                 .value("voltageLevelId3", bindMarker())
                 .value("name", bindMarker())
+                .value("fictitious", bindMarker())
                 .value("properties", bindMarker())
                 .value("node1", bindMarker())
                 .value("node2", bindMarker())
@@ -568,6 +591,7 @@ public class NetworkStoreRepository {
                 .and(set("voltageLevelId2", bindMarker()))
                 .and(set("voltageLevelId3", bindMarker()))
                 .and(set("name", bindMarker()))
+                .and(set("fictitious", bindMarker()))
                 .and(set("properties", bindMarker()))
                 .and(set("node1", bindMarker()))
                 .and(set("node2", bindMarker()))
@@ -624,6 +648,7 @@ public class NetworkStoreRepository {
                 .value("voltageLevelId1", bindMarker())
                 .value("voltageLevelId2", bindMarker())
                 .value("name", bindMarker())
+                .value("fictitious", bindMarker())
                 .value("properties", bindMarker())
                 .value("node1", bindMarker())
                 .value("node2", bindMarker())
@@ -650,6 +675,7 @@ public class NetworkStoreRepository {
                 .with(set("voltageLevelId1", bindMarker()))
                 .and(set("voltageLevelId2", bindMarker()))
                 .and(set("name", bindMarker()))
+                .and(set("fictitious", bindMarker()))
                 .and(set("properties", bindMarker()))
                 .and(set("node1", bindMarker()))
                 .and(set("node2", bindMarker()))
@@ -679,6 +705,7 @@ public class NetworkStoreRepository {
                 .value("networkUuid", bindMarker())
                 .value("id", bindMarker())
                 .value("name", bindMarker())
+                .value("fictitious", bindMarker())
                 .value("properties", bindMarker())
                 .value("r", bindMarker())
                 .value("convertersMode", bindMarker())
@@ -689,6 +716,7 @@ public class NetworkStoreRepository {
                 .value("converterStationId2", bindMarker()));
         psUpdateHvdcLine = session.prepare(update(KEYSPACE_IIDM, "hvdcLine")
                 .with(set("name", bindMarker()))
+                .and(set("fictitious", bindMarker()))
                 .and(set("properties", bindMarker()))
                 .and(set("r", bindMarker()))
                 .and(set("convertersMode", bindMarker()))
@@ -705,6 +733,7 @@ public class NetworkStoreRepository {
                 .value("id", bindMarker())
                 .value("voltageLevelId", bindMarker())
                 .value("name", bindMarker())
+                .value("fictitious", bindMarker())
                 .value("properties", bindMarker())
                 .value("node", bindMarker())
                 .value("p0", bindMarker())
@@ -723,6 +752,7 @@ public class NetworkStoreRepository {
                 .value(CONNECTABLE_BUS, bindMarker()));
         psUpdateDanglingLine = session.prepare(update(KEYSPACE_IIDM, "danglingLine")
                 .with(set("name", bindMarker()))
+                .and(set("fictitious", bindMarker()))
                 .and(set("properties", bindMarker()))
                 .and(set("node", bindMarker()))
                 .and(set("p0", bindMarker()))
@@ -748,11 +778,13 @@ public class NetworkStoreRepository {
                 .value("id", bindMarker())
                 .value("voltageLevelId", bindMarker())
                 .value("name", bindMarker())
+                .value("fictitious", bindMarker())
                 .value("properties", bindMarker())
                 .value("v", bindMarker())
                 .value("angle", bindMarker()));
         psUpdateConfiguredBus = session.prepare(update(KEYSPACE_IIDM, "configuredBus")
                 .with(set("name", bindMarker()))
+                .and(set("fictitious", bindMarker()))
                 .and(set("properties", bindMarker()))
                 .and(set("v", bindMarker()))
                 .and(set("angle", bindMarker()))
@@ -777,15 +809,16 @@ public class NetworkStoreRepository {
 
     public List<Resource<NetworkAttributes>> getNetworks() {
         ResultSet resultSet = session.execute(select("uuid",
-                                                     "id",
-                                                     "properties",
-                                                     "caseDate",
-                                                     "forecastDistance",
-                                                     "sourceFormat",
-                                                     "connectedComponentsValid",
-                                                     "synchronousComponentsValid",
-                                                     CGMES_SV_METADATA,
-                                                     CIM_CHARACTERISTICS)
+                "id",
+                "properties",
+                "caseDate",
+                "forecastDistance",
+                "sourceFormat",
+                "connectedComponentsValid",
+                "synchronousComponentsValid",
+                CGMES_SV_METADATA,
+                CIM_CHARACTERISTICS,
+                "fictitious")
                 .from(KEYSPACE_IIDM, "network"));
         List<Resource<NetworkAttributes>> resources = new ArrayList<>();
         for (Row row : resultSet) {
@@ -801,6 +834,7 @@ public class NetworkStoreRepository {
                             .synchronousComponentsValid(row.getBool(7))
                             .cgmesSvMetadata(row.get(8, CgmesSvMetadataAttributes.class))
                             .cimCharacteristics(row.get(9, CimCharacteristicsAttributes.class))
+                            .fictitious(row.getBool(10))
                             .build())
                     .build());
         }
@@ -809,14 +843,15 @@ public class NetworkStoreRepository {
 
     public Optional<Resource<NetworkAttributes>> getNetwork(UUID uuid) {
         ResultSet resultSet = session.execute(select("id",
-                                                     "properties",
-                                                     "caseDate",
-                                                     "forecastDistance",
-                                                     "sourceFormat",
-                                                     "connectedComponentsValid",
-                                                     "synchronousComponentsValid",
-                                                     CGMES_SV_METADATA,
-                                                     CIM_CHARACTERISTICS)
+                "properties",
+                "caseDate",
+                "forecastDistance",
+                "sourceFormat",
+                "connectedComponentsValid",
+                "synchronousComponentsValid",
+                CGMES_SV_METADATA,
+                CIM_CHARACTERISTICS,
+                "fictitious")
                 .from(KEYSPACE_IIDM, "network")
                 .where(eq("uuid", uuid)));
         Row one = resultSet.one();
@@ -833,6 +868,7 @@ public class NetworkStoreRepository {
                             .synchronousComponentsValid(one.getBool(6))
                             .cgmesSvMetadata(one.get(7, CgmesSvMetadataAttributes.class))
                             .cimCharacteristics(one.get(8, CimCharacteristicsAttributes.class))
+                            .fictitious(one.getBool(9))
                             .build())
                     .build());
         }
@@ -846,6 +882,7 @@ public class NetworkStoreRepository {
                 batch.add(unsetNullValues(psInsertNetwork.bind(
                         resource.getAttributes().getUuid(),
                         resource.getId(),
+                        resource.getAttributes().isFictitious(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getCaseDate().toDate(),
                         resource.getAttributes().getForecastDistance(),
@@ -854,7 +891,7 @@ public class NetworkStoreRepository {
                         resource.getAttributes().isSynchronousComponentsValid(),
                         resource.getAttributes().getCgmesSvMetadata(),
                         resource.getAttributes().getCimCharacteristics()
-                        )));
+                )));
             }
             session.execute(batch);
         }
@@ -866,6 +903,7 @@ public class NetworkStoreRepository {
             for (Resource<NetworkAttributes> resource : subresources) {
                 batch.add(unsetNullValues(psUpdateNetwork.bind(
                         resource.getId(),
+                        resource.getAttributes().isFictitious(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getCaseDate().toDate(),
                         resource.getAttributes().getForecastDistance(),
@@ -906,7 +944,7 @@ public class NetworkStoreRepository {
     // substation
 
     public List<Resource<SubstationAttributes>> getSubstations(UUID networkUuid) {
-        ResultSet resultSet = session.execute(select("id", "name", "properties", "country", "tso", "entsoeArea").from(KEYSPACE_IIDM, "substation")
+        ResultSet resultSet = session.execute(select("id", "name", "properties", "country", "tso", "entsoeArea", "fictitious").from(KEYSPACE_IIDM, "substation")
                 .where(eq("networkUuid", networkUuid)));
         List<Resource<SubstationAttributes>> resources = new ArrayList<>();
         for (Row row : resultSet) {
@@ -918,6 +956,7 @@ public class NetworkStoreRepository {
                             .country(row.getString(3) != null ? Country.valueOf(row.getString(3)) : null)
                             .tso(row.getString(4))
                             .entsoeArea(row.get(5, EntsoeAreaAttributes.class))
+                            .fictitious(row.getBool(6))
                             .build())
                     .build());
         }
@@ -926,10 +965,11 @@ public class NetworkStoreRepository {
 
     public Optional<Resource<SubstationAttributes>> getSubstation(UUID networkUuid, String substationId) {
         ResultSet resultSet = session.execute(select("name",
-                                                     "properties",
-                                                     "country",
-                                                     "tso",
-                                                     "entsoeArea")
+                "properties",
+                "country",
+                "tso",
+                "entsoeArea",
+                "fictitious")
                 .from(KEYSPACE_IIDM, "substation")
                 .where(eq("networkUuid", networkUuid)).and(eq("id", substationId)));
         Row one = resultSet.one();
@@ -942,6 +982,7 @@ public class NetworkStoreRepository {
                             .country(one.getString(2) != null ? Country.valueOf(one.getString(2)) : null)
                             .tso(one.getString(3))
                             .entsoeArea(one.get(4, EntsoeAreaAttributes.class))
+                            .fictitious(one.getBool(5))
                             .build())
                     .build());
         }
@@ -956,11 +997,12 @@ public class NetworkStoreRepository {
                         networkUuid,
                         resource.getId(),
                         resource.getAttributes().getName(),
+                        resource.getAttributes().isFictitious(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getCountry() != null ? resource.getAttributes().getCountry().toString() : null,
                         resource.getAttributes().getTso(),
                         resource.getAttributes().getEntsoeArea()
-                        )));
+                )));
             }
             session.execute(batch);
         }
@@ -981,6 +1023,7 @@ public class NetworkStoreRepository {
                         resource.getId(),
                         resource.getAttributes().getSubstationId(),
                         resource.getAttributes().getName(),
+                        resource.getAttributes().isFictitious(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getNominalV(),
                         resource.getAttributes().getLowVoltageLimit(),
@@ -992,7 +1035,7 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getBusToCalculatedBus(),
                         resource.getAttributes().isCalculatedBusesValid(),
                         resource.getAttributes().getSlackTerminal()
-                        )));
+                )));
             }
             session.execute(batch);
         }
@@ -1004,6 +1047,7 @@ public class NetworkStoreRepository {
             for (Resource<VoltageLevelAttributes> resource : subresources) {
                 batch.add(unsetNullValues(psUpdateVoltageLevel.bind(
                         resource.getAttributes().getName(),
+                        resource.getAttributes().isFictitious(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getNominalV(),
                         resource.getAttributes().getLowVoltageLimit(),
@@ -1026,18 +1070,19 @@ public class NetworkStoreRepository {
 
     public List<Resource<VoltageLevelAttributes>> getVoltageLevels(UUID networkUuid, String substationId) {
         ResultSet resultSet = session.execute(select("id",
-                                                     "name",
-                                                     "properties",
-                                                     "nominalV",
-                                                     "lowVoltageLimit",
-                                                     "highVoltageLimit",
-                                                     "topologyKind",
-                                                     "internalConnections",
-                                                     "calculatedBuses",
-                                                     "nodeToCalculatedBus",
-                                                     "busToCalculatedBus",
-                                                     "calculatedBusesValid",
-                                                     SLACK_TERMINAL)
+                "name",
+                "properties",
+                "nominalV",
+                "lowVoltageLimit",
+                "highVoltageLimit",
+                "topologyKind",
+                "internalConnections",
+                "calculatedBuses",
+                "nodeToCalculatedBus",
+                "busToCalculatedBus",
+                "calculatedBusesValid",
+                "fictitious",
+                SLACK_TERMINAL)
                 .from(KEYSPACE_IIDM, "voltageLevelBySubstation")
                 .where(eq("networkUuid", networkUuid)).and(eq("substationId", substationId)));
         List<Resource<VoltageLevelAttributes>> resources = new ArrayList<>();
@@ -1057,7 +1102,8 @@ public class NetworkStoreRepository {
                             .nodeToCalculatedBus(row.isNull(9) ? null : row.getMap(9, Integer.class, Integer.class))
                             .busToCalculatedBus(row.isNull(10) ? null : row.getMap(10, String.class, Integer.class))
                             .calculatedBusesValid(row.getBool(11))
-                            .slackTerminal(row.get(12, TerminalRefAttributes.class))
+                            .fictitious(row.getBool(12))
+                            .slackTerminal(row.get(13, TerminalRefAttributes.class))
                             .build())
                     .build());
         }
@@ -1066,18 +1112,19 @@ public class NetworkStoreRepository {
 
     public Optional<Resource<VoltageLevelAttributes>> getVoltageLevel(UUID networkUuid, String voltageLevelId) {
         ResultSet resultSet = session.execute(select("substationId",
-                                                     "name",
-                                                     "properties",
-                                                     "nominalV",
-                                                     "lowVoltageLimit",
-                                                     "highVoltageLimit",
-                                                     "topologyKind",
-                                                     "internalConnections",
-                                                     "calculatedBuses",
-                                                     "nodeToCalculatedBus",
-                                                     "busToCalculatedBus",
-                                                     "calculatedBusesValid",
-                                                     SLACK_TERMINAL)
+                "name",
+                "properties",
+                "nominalV",
+                "lowVoltageLimit",
+                "highVoltageLimit",
+                "topologyKind",
+                "internalConnections",
+                "calculatedBuses",
+                "nodeToCalculatedBus",
+                "busToCalculatedBus",
+                "calculatedBusesValid",
+                "fictitious",
+                SLACK_TERMINAL)
                 .from(KEYSPACE_IIDM, "voltageLevel")
                 .where(eq("networkUuid", networkUuid)).and(eq("id", voltageLevelId)));
         Row one = resultSet.one();
@@ -1097,7 +1144,8 @@ public class NetworkStoreRepository {
                             .nodeToCalculatedBus(one.isNull(9) ? null : one.getMap(9, Integer.class, Integer.class))
                             .busToCalculatedBus(one.isNull(10) ? null : one.getMap(10, String.class, Integer.class))
                             .calculatedBusesValid(one.getBool(11))
-                            .slackTerminal(one.get(12, TerminalRefAttributes.class))
+                            .fictitious(one.getBool(12))
+                            .slackTerminal(one.get(13, TerminalRefAttributes.class))
                             .build())
                     .build());
         }
@@ -1106,19 +1154,20 @@ public class NetworkStoreRepository {
 
     public List<Resource<VoltageLevelAttributes>> getVoltageLevels(UUID networkUuid) {
         ResultSet resultSet = session.execute(select("id",
-                                                     "substationId",
-                                                     "name",
-                                                     "properties",
-                                                     "nominalV",
-                                                     "lowVoltageLimit",
-                                                     "highVoltageLimit",
-                                                     "topologyKind",
-                                                     "internalConnections",
-                                                     "calculatedBuses",
-                                                     "nodeToCalculatedBus",
-                                                     "busToCalculatedBus",
-                                                     "calculatedBusesValid",
-                                                     SLACK_TERMINAL)
+                "substationId",
+                "name",
+                "properties",
+                "nominalV",
+                "lowVoltageLimit",
+                "highVoltageLimit",
+                "topologyKind",
+                "internalConnections",
+                "calculatedBuses",
+                "nodeToCalculatedBus",
+                "busToCalculatedBus",
+                "calculatedBusesValid",
+                "fictitious",
+                SLACK_TERMINAL)
                 .from(KEYSPACE_IIDM, "voltageLevel")
                 .where(eq("networkUuid", networkUuid)));
         List<Resource<VoltageLevelAttributes>> resources = new ArrayList<>();
@@ -1138,7 +1187,8 @@ public class NetworkStoreRepository {
                             .nodeToCalculatedBus(row.isNull(10) ? null : row.getMap(10, Integer.class, Integer.class))
                             .busToCalculatedBus(row.isNull(11) ? null : row.getMap(11, String.class, Integer.class))
                             .calculatedBusesValid(row.getBool(12))
-                            .slackTerminal(row.get(13, TerminalRefAttributes.class))
+                            .fictitious(row.getBool(13))
+                            .slackTerminal(row.get(14, TerminalRefAttributes.class))
                             .build())
                     .build());
         }
@@ -1161,6 +1211,7 @@ public class NetworkStoreRepository {
                         resource.getId(),
                         resource.getAttributes().getVoltageLevelId(),
                         resource.getAttributes().getName(),
+                        resource.getAttributes().isFictitious(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getNode(),
                         resource.getAttributes().getEnergySource().toString(),
@@ -1188,27 +1239,28 @@ public class NetworkStoreRepository {
 
     public Optional<Resource<GeneratorAttributes>> getGenerator(UUID networkUuid, String generatorId) {
         ResultSet resultSet = session.execute(select("voltageLevelId",
-                                                     "name",
-                                                     "properties",
-                                                     "node",
-                                                     "energySource",
-                                                     "minP",
-                                                     "maxP",
-                                                     "voltageRegulatorOn",
-                                                     "targetP",
-                                                     "targetQ",
-                                                     "targetV",
-                                                     "ratedS",
-                                                     "p",
-                                                     "q",
-                                                     "position",
-                                                     "minMaxReactiveLimits",
-                                                     "reactiveCapabilityCurve",
-                                                     "bus",
-                                                     CONNECTABLE_BUS,
-                                                     "activePowerControl",
-                                                     REGULATING_TERMINAL,
-                                                     "coordinatedReactiveControl")
+                "name",
+                "properties",
+                "node",
+                "energySource",
+                "minP",
+                "maxP",
+                "voltageRegulatorOn",
+                "targetP",
+                "targetQ",
+                "targetV",
+                "ratedS",
+                "p",
+                "q",
+                "position",
+                "minMaxReactiveLimits",
+                "reactiveCapabilityCurve",
+                "bus",
+                CONNECTABLE_BUS,
+                "activePowerControl",
+                REGULATING_TERMINAL,
+                "coordinatedReactiveControl",
+                "fictitious")
                 .from(KEYSPACE_IIDM, "generator")
                 .where(eq("networkUuid", networkUuid)).and(eq("id", generatorId)));
         Row one = resultSet.one();
@@ -1239,6 +1291,7 @@ public class NetworkStoreRepository {
                             .activePowerControl(one.get(19, ActivePowerControlAttributes.class))
                             .regulatingTerminal(one.get(20, TerminalRefAttributes.class))
                             .coordinatedReactiveControl(one.get(21, CoordinatedReactiveControlAttributes.class))
+                            .fictitious(one.getBool(22))
                             .build())
                     .build());
         }
@@ -1247,28 +1300,29 @@ public class NetworkStoreRepository {
 
     public List<Resource<GeneratorAttributes>> getGenerators(UUID networkUuid) {
         ResultSet resultSet = session.execute(select("id",
-                                                     "voltageLevelId",
-                                                     "name",
-                                                     "properties",
-                                                     "node",
-                                                     "energySource",
-                                                     "minP",
-                                                     "maxP",
-                                                     "voltageRegulatorOn",
-                                                     "targetP",
-                                                     "targetQ",
-                                                     "targetV",
-                                                     "ratedS",
-                                                     "p",
-                                                     "q",
-                                                     "position",
-                                                     "minMaxReactiveLimits",
-                                                     "reactiveCapabilityCurve",
-                                                     "bus",
-                                                     CONNECTABLE_BUS,
-                                                     "activePowerControl",
-                                                     REGULATING_TERMINAL,
-                                                     "coordinatedReactiveControl")
+                "voltageLevelId",
+                "name",
+                "properties",
+                "node",
+                "energySource",
+                "minP",
+                "maxP",
+                "voltageRegulatorOn",
+                "targetP",
+                "targetQ",
+                "targetV",
+                "ratedS",
+                "p",
+                "q",
+                "position",
+                "minMaxReactiveLimits",
+                "reactiveCapabilityCurve",
+                "bus",
+                CONNECTABLE_BUS,
+                "activePowerControl",
+                REGULATING_TERMINAL,
+                "coordinatedReactiveControl",
+                "fictitious")
                 .from(KEYSPACE_IIDM, "generator")
                 .where(eq("networkUuid", networkUuid)));
         List<Resource<GeneratorAttributes>> resources = new ArrayList<>();
@@ -1299,6 +1353,7 @@ public class NetworkStoreRepository {
                             .activePowerControl(row.get(20, ActivePowerControlAttributes.class))
                             .regulatingTerminal(row.get(21, TerminalRefAttributes.class))
                             .coordinatedReactiveControl(row.get(22, CoordinatedReactiveControlAttributes.class))
+                            .fictitious(row.getBool(23))
                             .build())
                     .build());
         }
@@ -1307,27 +1362,27 @@ public class NetworkStoreRepository {
 
     public List<Resource<GeneratorAttributes>> getVoltageLevelGenerators(UUID networkUuid, String voltageLevelId) {
         ResultSet resultSet = session.execute(select("id",
-                                                     "name",
-                                                     "properties",
-                                                     "node",
-                                                     "energySource",
-                                                     "minP",
-                                                     "maxP",
-                                                     "voltageRegulatorOn",
-                                                     "targetP",
-                                                     "targetQ",
-                                                     "targetV",
-                                                     "ratedS",
-                                                     "p",
-                                                     "q",
-                                                     "position",
-                                                     "minMaxReactiveLimits",
-                                                     "reactiveCapabilityCurve",
-                                                     "bus",
-                                                     CONNECTABLE_BUS,
-                                                     "activePowerControl",
-                                                     REGULATING_TERMINAL,
-                                                     "coordinatedReactiveControl")
+                "name",
+                "properties",
+                "node",
+                "energySource",
+                "minP",
+                "maxP",
+                "voltageRegulatorOn",
+                "targetP",
+                "targetQ",
+                "targetV",
+                "ratedS",
+                "p",
+                "q",
+                "position",
+                "minMaxReactiveLimits",
+                "reactiveCapabilityCurve",
+                "bus",
+                CONNECTABLE_BUS,
+                "activePowerControl",
+                REGULATING_TERMINAL,
+                "coordinatedReactiveControl")
                 .from(KEYSPACE_IIDM, "generatorByVoltageLevel")
                 .where(eq("networkUuid", networkUuid)).and(eq("voltageLevelId", voltageLevelId)));
         List<Resource<GeneratorAttributes>> resources = new ArrayList<>();
@@ -1371,6 +1426,7 @@ public class NetworkStoreRepository {
                 ReactiveLimitsAttributes reactiveLimits = resource.getAttributes().getReactiveLimits();
                 batch.add(unsetNullValues(psUpdateGenerator.bind(
                         resource.getAttributes().getName(),
+                        resource.getAttributes().isFictitious(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getNode(),
                         resource.getAttributes().getEnergySource().toString(),
@@ -1416,6 +1472,7 @@ public class NetworkStoreRepository {
                         resource.getId(),
                         resource.getAttributes().getVoltageLevelId(),
                         resource.getAttributes().getName(),
+                        resource.getAttributes().isFictitious(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getNode(),
                         resource.getAttributes().getMinP(),
@@ -1449,7 +1506,8 @@ public class NetworkStoreRepository {
                 "minMaxReactiveLimits",
                 "reactiveCapabilityCurve",
                 "bus",
-                CONNECTABLE_BUS)
+                CONNECTABLE_BUS,
+                "fictitious")
                 .from(KEYSPACE_IIDM, "battery")
                 .where(eq("networkUuid", networkUuid)).and(eq("id", batteryId)));
         Row one = resultSet.one();
@@ -1473,6 +1531,7 @@ public class NetworkStoreRepository {
                             .reactiveLimits(minMaxReactiveLimitsAttributes != null ? minMaxReactiveLimitsAttributes : reactiveCapabilityCurveAttributes)
                             .bus(one.getString(13))
                             .connectableBus(one.getString(14))
+                            .fictitious(one.getBool(15))
                             .build())
                     .build());
         }
@@ -1495,7 +1554,8 @@ public class NetworkStoreRepository {
                 "minMaxReactiveLimits",
                 "reactiveCapabilityCurve",
                 "bus",
-                CONNECTABLE_BUS)
+                CONNECTABLE_BUS,
+                "fictitious")
                 .from(KEYSPACE_IIDM, "battery")
                 .where(eq("networkUuid", networkUuid)));
         List<Resource<BatteryAttributes>> resources = new ArrayList<>();
@@ -1519,6 +1579,7 @@ public class NetworkStoreRepository {
                             .reactiveLimits(minMaxReactiveLimitsAttributes != null ? minMaxReactiveLimitsAttributes : reactiveCapabilityCurveAttributes)
                             .bus(row.getString(14))
                             .connectableBus(row.getString(15))
+                            .fictitious(row.getBool(16))
                             .build())
                     .build());
         }
@@ -1540,7 +1601,8 @@ public class NetworkStoreRepository {
                 "minMaxReactiveLimits",
                 "reactiveCapabilityCurve",
                 "bus",
-                CONNECTABLE_BUS)
+                CONNECTABLE_BUS,
+                "fictitious")
                 .from(KEYSPACE_IIDM, "batteryByVoltageLevel")
                 .where(eq("networkUuid", networkUuid)).and(eq("voltageLevelId", voltageLevelId)));
         List<Resource<BatteryAttributes>> resources = new ArrayList<>();
@@ -1564,6 +1626,7 @@ public class NetworkStoreRepository {
                             .reactiveLimits(minMaxReactiveLimitsAttributes != null ? minMaxReactiveLimitsAttributes : reactiveCapabilityCurveAttributes)
                             .bus(row.getString(13))
                             .connectableBus(row.getString(14))
+                            .fictitious(row.getBool(15))
                             .build())
                     .build());
         }
@@ -1577,6 +1640,7 @@ public class NetworkStoreRepository {
                 ReactiveLimitsAttributes reactiveLimits = resource.getAttributes().getReactiveLimits();
                 batch.add(unsetNullValues(psUpdateBattery.bind(
                         resource.getAttributes().getName(),
+                        resource.getAttributes().isFictitious(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getNode(),
                         resource.getAttributes().getMinP(),
@@ -1614,6 +1678,7 @@ public class NetworkStoreRepository {
                         resource.getId(),
                         resource.getAttributes().getVoltageLevelId(),
                         resource.getAttributes().getName(),
+                        resource.getAttributes().isFictitious(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getNode(),
                         resource.getAttributes().getLoadType().toString(),
@@ -1625,7 +1690,7 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getBus(),
                         resource.getAttributes().getConnectableBus(),
                         resource.getAttributes().getLoadDetail()
-                        )));
+                )));
             }
             session.execute(batch);
         }
@@ -1633,18 +1698,19 @@ public class NetworkStoreRepository {
 
     public Optional<Resource<LoadAttributes>> getLoad(UUID networkUuid, String loadId) {
         ResultSet resultSet = session.execute(select("voltageLevelId",
-                                                     "name",
-                                                     "properties",
-                                                     "node",
-                                                     "loadType",
-                                                     "p0",
-                                                     "q0",
-                                                     "p",
-                                                     "q",
-                                                     "position",
-                                                     "bus",
-                                                     CONNECTABLE_BUS,
-                                                     LOAD_DETAIL)
+                "name",
+                "properties",
+                "node",
+                "loadType",
+                "p0",
+                "q0",
+                "p",
+                "q",
+                "position",
+                "bus",
+                CONNECTABLE_BUS,
+                LOAD_DETAIL,
+                "fictitious")
                 .from(KEYSPACE_IIDM, "load")
                 .where(eq("networkUuid", networkUuid)).and(eq("id", loadId)));
         Row one = resultSet.one();
@@ -1665,6 +1731,7 @@ public class NetworkStoreRepository {
                             .bus(one.getString(10))
                             .connectableBus(one.getString(11))
                             .loadDetail(one.get(12, LoadDetailAttributes.class))
+                            .fictitious(one.getBool(13))
                             .build())
                     .build());
         }
@@ -1673,19 +1740,20 @@ public class NetworkStoreRepository {
 
     public List<Resource<LoadAttributes>> getLoads(UUID networkUuid) {
         ResultSet resultSet = session.execute(select("id",
-                                                     "voltageLevelId",
-                                                     "name",
-                                                     "properties",
-                                                     "node",
-                                                     "loadType",
-                                                     "p0",
-                                                     "q0",
-                                                     "p",
-                                                     "q",
-                                                     "position",
-                                                     "bus",
-                                                     CONNECTABLE_BUS,
-                                                     LOAD_DETAIL)
+                "voltageLevelId",
+                "name",
+                "properties",
+                "node",
+                "loadType",
+                "p0",
+                "q0",
+                "p",
+                "q",
+                "position",
+                "bus",
+                CONNECTABLE_BUS,
+                LOAD_DETAIL,
+                "fictitious")
                 .from(KEYSPACE_IIDM, "load")
                 .where(eq("networkUuid", networkUuid)));
         List<Resource<LoadAttributes>> resources = new ArrayList<>();
@@ -1706,6 +1774,7 @@ public class NetworkStoreRepository {
                             .bus(row.getString(11))
                             .connectableBus(row.getString(12))
                             .loadDetail(row.get(13, LoadDetailAttributes.class))
+                            .fictitious(row.getBool(14))
                             .build())
                     .build());
         }
@@ -1714,18 +1783,19 @@ public class NetworkStoreRepository {
 
     public List<Resource<LoadAttributes>> getVoltageLevelLoads(UUID networkUuid, String voltageLevelId) {
         ResultSet resultSet = session.execute(select("id",
-                                                     "name",
-                                                     "properties",
-                                                     "node",
-                                                     "loadType",
-                                                     "p0",
-                                                     "q0",
-                                                     "p",
-                                                     "q",
-                                                     "position",
-                                                     "bus",
-                                                     CONNECTABLE_BUS,
-                                                     LOAD_DETAIL)
+                "name",
+                "properties",
+                "node",
+                "loadType",
+                "p0",
+                "q0",
+                "p",
+                "q",
+                "position",
+                "bus",
+                CONNECTABLE_BUS,
+                LOAD_DETAIL,
+                "fictitious")
                 .from(KEYSPACE_IIDM, "loadByVoltageLevel")
                 .where(eq("networkUuid", networkUuid)).and(eq("voltageLevelId", voltageLevelId)));
         List<Resource<LoadAttributes>> resources = new ArrayList<>();
@@ -1746,6 +1816,7 @@ public class NetworkStoreRepository {
                             .bus(row.getString(10))
                             .connectableBus(row.getString(11))
                             .loadDetail(row.get(12, LoadDetailAttributes.class))
+                            .fictitious(row.getBool(13))
                             .build())
                     .build());
         }
@@ -1758,6 +1829,7 @@ public class NetworkStoreRepository {
             for (Resource<LoadAttributes> resource : subresources) {
                 batch.add(unsetNullValues(psUpdateLoad.bind(
                         resource.getAttributes().getName(),
+                        resource.getAttributes().isFictitious(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getNode(),
                         resource.getAttributes().getLoadType().toString(),
@@ -1794,6 +1866,7 @@ public class NetworkStoreRepository {
                         resource.getId(),
                         resource.getAttributes().getVoltageLevelId(),
                         resource.getAttributes().getName(),
+                        resource.getAttributes().isFictitious(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getNode(),
                         shuntCompensatorModel.getType() == ShuntCompensatorModelType.LINEAR ? shuntCompensatorModel : null,
@@ -1808,7 +1881,7 @@ public class NetworkStoreRepository {
                         resource.getAttributes().isVoltageRegulatorOn(),
                         resource.getAttributes().getTargetV(),
                         resource.getAttributes().getTargetDeadband()
-                        )));
+                )));
             }
             session.execute(batch);
         }
@@ -1816,21 +1889,22 @@ public class NetworkStoreRepository {
 
     public Optional<Resource<ShuntCompensatorAttributes>> getShuntCompensator(UUID networkUuid, String shuntCompensatorId) {
         ResultSet resultSet = session.execute(select("voltageLevelId",
-                                                     "name",
-                                                     "properties",
-                                                     "node",
-                                                     LINEAR_MODEL,
-                                                     NON_LINEAR_MODEL,
-                                                     SECTION_COUNT,
-                                                     "p",
-                                                     "q",
-                                                     "position",
-                                                     "bus",
-                                                     CONNECTABLE_BUS,
-                                                     REGULATING_TERMINAL,
-                                                     "voltageRegulatorOn",
-                                                     "targetV",
-                                                     "targetDeadband")
+                "name",
+                "properties",
+                "node",
+                LINEAR_MODEL,
+                NON_LINEAR_MODEL,
+                SECTION_COUNT,
+                "p",
+                "q",
+                "position",
+                "bus",
+                CONNECTABLE_BUS,
+                REGULATING_TERMINAL,
+                "voltageRegulatorOn",
+                "targetV",
+                "targetDeadband",
+                "fictitious")
                 .from(KEYSPACE_IIDM, "shuntCompensator")
                 .where(eq("networkUuid", networkUuid)).and(eq("id", shuntCompensatorId)));
         Row row = resultSet.one();
@@ -1855,6 +1929,7 @@ public class NetworkStoreRepository {
                             .voltageRegulatorOn(row.getBool(13))
                             .targetV(row.getDouble(14))
                             .targetDeadband(row.getDouble(15))
+                            .fictitious(row.getBool(16))
                             .build())
                     .build());
         }
@@ -1863,22 +1938,23 @@ public class NetworkStoreRepository {
 
     public List<Resource<ShuntCompensatorAttributes>> getShuntCompensators(UUID networkUuid) {
         ResultSet resultSet = session.execute(select("id",
-                                                     "voltageLevelId",
-                                                     "name",
-                                                     "properties",
-                                                     "node",
-                                                     LINEAR_MODEL,
-                                                     NON_LINEAR_MODEL,
-                                                     SECTION_COUNT,
-                                                     "p",
-                                                     "q",
-                                                     "position",
-                                                     "bus",
-                                                     CONNECTABLE_BUS,
-                                                     REGULATING_TERMINAL,
-                                                     "voltageRegulatorOn",
-                                                     "targetV",
-                                                     "targetDeadband")
+                "voltageLevelId",
+                "name",
+                "properties",
+                "node",
+                LINEAR_MODEL,
+                NON_LINEAR_MODEL,
+                SECTION_COUNT,
+                "p",
+                "q",
+                "position",
+                "bus",
+                CONNECTABLE_BUS,
+                REGULATING_TERMINAL,
+                "voltageRegulatorOn",
+                "targetV",
+                "targetDeadband",
+                "fictitious")
                 .from(KEYSPACE_IIDM, "shuntCompensator")
                 .where(eq("networkUuid", networkUuid)));
         List<Resource<ShuntCompensatorAttributes>> resources = new ArrayList<>();
@@ -1903,6 +1979,7 @@ public class NetworkStoreRepository {
                             .voltageRegulatorOn(row.getBool(14))
                             .targetV(row.getDouble(15))
                             .targetDeadband(row.getDouble(16))
+                            .fictitious(row.getBool(17))
                             .build())
                     .build());
         }
@@ -1911,21 +1988,22 @@ public class NetworkStoreRepository {
 
     public List<Resource<ShuntCompensatorAttributes>> getVoltageLevelShuntCompensators(UUID networkUuid, String voltageLevelId) {
         ResultSet resultSet = session.execute(select("id",
-                                                     "name",
-                                                     "properties",
-                                                     "node",
-                                                     LINEAR_MODEL,
-                                                     NON_LINEAR_MODEL,
-                                                     SECTION_COUNT,
-                                                     "p",
-                                                     "q",
-                                                     "position",
-                                                     "bus",
-                                                     CONNECTABLE_BUS,
-                                                     REGULATING_TERMINAL,
-                                                     "voltageRegulatorOn",
-                                                     "targetV",
-                                                     "targetDeadband")
+                "name",
+                "properties",
+                "node",
+                LINEAR_MODEL,
+                NON_LINEAR_MODEL,
+                SECTION_COUNT,
+                "p",
+                "q",
+                "position",
+                "bus",
+                CONNECTABLE_BUS,
+                REGULATING_TERMINAL,
+                "voltageRegulatorOn",
+                "targetV",
+                "targetDeadband",
+                "fictitious")
                 .from(KEYSPACE_IIDM, "shuntCompensatorByVoltageLevel")
                 .where(eq("networkUuid", networkUuid)).and(eq("voltageLevelId", voltageLevelId)));
         List<Resource<ShuntCompensatorAttributes>> resources = new ArrayList<>();
@@ -1950,6 +2028,7 @@ public class NetworkStoreRepository {
                             .voltageRegulatorOn(row.getBool(13))
                             .targetV(row.getDouble(14))
                             .targetDeadband(row.getDouble(15))
+                            .fictitious(row.getBool(16))
                             .build())
                     .build());
         }
@@ -1963,6 +2042,7 @@ public class NetworkStoreRepository {
                 ShuntCompensatorModelAttributes shuntCompensatorModel = resource.getAttributes().getModel();
                 batch.add(unsetNullValues(psUpdateShuntCompensator.bind(
                         resource.getAttributes().getName(),
+                        resource.getAttributes().isFictitious(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getNode(),
                         shuntCompensatorModel.getType() == ShuntCompensatorModelType.LINEAR ? shuntCompensatorModel : null,
@@ -2002,6 +2082,7 @@ public class NetworkStoreRepository {
                         resource.getId(),
                         resource.getAttributes().getVoltageLevelId(),
                         resource.getAttributes().getName(),
+                        resource.getAttributes().isFictitious(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getNode(),
                         resource.getAttributes().getLossFactor(),
@@ -2036,7 +2117,8 @@ public class NetworkStoreRepository {
                 "q",
                 "position",
                 "bus",
-                CONNECTABLE_BUS)
+                CONNECTABLE_BUS,
+                "fictitious")
                 .from(KEYSPACE_IIDM, "vscConverterStation")
                 .where(eq("networkUuid", networkUuid)).and(eq("id", vscConverterStationId)));
         Row row = resultSet.one();
@@ -2060,6 +2142,7 @@ public class NetworkStoreRepository {
                             .position(row.get(12, ConnectablePositionAttributes.class))
                             .bus(row.getString(13))
                             .connectableBus(row.getString(14))
+                            .fictitious(row.getBool(15))
                             .build())
                     .build());
         }
@@ -2082,7 +2165,8 @@ public class NetworkStoreRepository {
                 "q",
                 "position",
                 "bus",
-                CONNECTABLE_BUS)
+                CONNECTABLE_BUS,
+                "fictitious")
                 .from(KEYSPACE_IIDM, "vscConverterStation")
                 .where(eq("networkUuid", networkUuid)));
         List<Resource<VscConverterStationAttributes>> resources = new ArrayList<>();
@@ -2106,6 +2190,7 @@ public class NetworkStoreRepository {
                             .position(row.get(13, ConnectablePositionAttributes.class))
                             .bus(row.getString(14))
                             .connectableBus(row.getString(15))
+                            .fictitious(row.getBool(16))
                             .build())
                     .build());
         }
@@ -2127,7 +2212,8 @@ public class NetworkStoreRepository {
                 "q",
                 "position",
                 "bus",
-                CONNECTABLE_BUS)
+                CONNECTABLE_BUS,
+                "fictitious")
                 .from(KEYSPACE_IIDM, "vscConverterStationByVoltageLevel")
                 .where(eq("networkUuid", networkUuid)).and(eq("voltageLevelId", voltageLevelId)));
         List<Resource<VscConverterStationAttributes>> resources = new ArrayList<>();
@@ -2151,6 +2237,7 @@ public class NetworkStoreRepository {
                             .position(row.get(12, ConnectablePositionAttributes.class))
                             .bus(row.getString(13))
                             .connectableBus(row.getString(14))
+                            .fictitious(row.getBool(15))
                             .build())
                     .build());
         }
@@ -2164,6 +2251,7 @@ public class NetworkStoreRepository {
                 ReactiveLimitsAttributes reactiveLimits = resource.getAttributes().getReactiveLimits();
                 batch.add(unsetNullValues(psUpdateVscConverterStation.bind(
                         resource.getAttributes().getName(),
+                        resource.getAttributes().isFictitious(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getNode(),
                         resource.getAttributes().getLossFactor(),
@@ -2201,6 +2289,7 @@ public class NetworkStoreRepository {
                         resource.getId(),
                         resource.getAttributes().getVoltageLevelId(),
                         resource.getAttributes().getName(),
+                        resource.getAttributes().isFictitious(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getNode(),
                         resource.getAttributes().getPowerFactor(),
@@ -2227,7 +2316,8 @@ public class NetworkStoreRepository {
                 "q",
                 "position",
                 "bus",
-                CONNECTABLE_BUS)
+                CONNECTABLE_BUS,
+                "fictitious")
                 .from(KEYSPACE_IIDM, "lccConverterStation")
                 .where(eq("networkUuid", networkUuid)).and(eq("id", lccConverterStationId)));
         Row row = resultSet.one();
@@ -2246,6 +2336,7 @@ public class NetworkStoreRepository {
                             .position(row.get(8, ConnectablePositionAttributes.class))
                             .bus(row.getString(9))
                             .connectableBus(row.getString(10))
+                            .fictitious(row.getBool(11))
                             .build())
                     .build());
         }
@@ -2264,7 +2355,8 @@ public class NetworkStoreRepository {
                 "q",
                 "position",
                 "bus",
-                CONNECTABLE_BUS)
+                CONNECTABLE_BUS,
+                "fictitious")
                 .from(KEYSPACE_IIDM, "lccConverterStation")
                 .where(eq("networkUuid", networkUuid)));
         List<Resource<LccConverterStationAttributes>> resources = new ArrayList<>();
@@ -2283,6 +2375,7 @@ public class NetworkStoreRepository {
                             .position(row.get(9, ConnectablePositionAttributes.class))
                             .bus(row.getString(10))
                             .connectableBus(row.getString(11))
+                            .fictitious(row.getBool(12))
                             .build())
                     .build());
         }
@@ -2300,7 +2393,8 @@ public class NetworkStoreRepository {
                 "q",
                 "position",
                 "bus",
-                CONNECTABLE_BUS)
+                CONNECTABLE_BUS,
+                "fictitious")
                 .from(KEYSPACE_IIDM, "lccConverterStationByVoltageLevel")
                 .where(eq("networkUuid", networkUuid)).and(eq("voltageLevelId", voltageLevelId)));
         List<Resource<LccConverterStationAttributes>> resources = new ArrayList<>();
@@ -2319,6 +2413,7 @@ public class NetworkStoreRepository {
                             .position(row.get(8, ConnectablePositionAttributes.class))
                             .bus(row.getString(9))
                             .connectableBus(row.getString(10))
+                            .fictitious(row.getBool(11))
                             .build())
                     .build());
         }
@@ -2331,6 +2426,7 @@ public class NetworkStoreRepository {
             for (Resource<LccConverterStationAttributes> resource : subresources) {
                 batch.add(unsetNullValues(psUpdateLccConverterStation.bind(
                         resource.getAttributes().getName(),
+                        resource.getAttributes().isFictitious(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getNode(),
                         resource.getAttributes().getPowerFactor(),
@@ -2364,6 +2460,7 @@ public class NetworkStoreRepository {
                         resource.getId(),
                         resource.getAttributes().getVoltageLevelId(),
                         resource.getAttributes().getName(),
+                        resource.getAttributes().isFictitious(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getNode(),
                         resource.getAttributes().getBmin(),
@@ -2400,7 +2497,8 @@ public class NetworkStoreRepository {
                 "bus",
                 CONNECTABLE_BUS,
                 REGULATING_TERMINAL,
-                "voltagePerReactivePowerControl")
+                "voltagePerReactivePowerControl",
+                "fictitious")
                 .from(KEYSPACE_IIDM, "staticVarCompensator")
                 .where(eq("networkUuid", networkUuid)).and(eq("id", staticVarCompensatorId)));
         Row row = resultSet.one();
@@ -2424,6 +2522,7 @@ public class NetworkStoreRepository {
                             .connectableBus(row.getString(13))
                             .regulatingTerminal(row.get(14, TerminalRefAttributes.class))
                             .voltagePerReactiveControl(row.get(15, VoltagePerReactivePowerControlAttributes.class))
+                            .fictitious(row.getBool(16))
                             .build())
                     .build());
         }
@@ -2447,7 +2546,8 @@ public class NetworkStoreRepository {
                 "bus",
                 CONNECTABLE_BUS,
                 REGULATING_TERMINAL,
-                "voltagePerReactivePowerControl")
+                "voltagePerReactivePowerControl",
+                "fictitious")
                 .from(KEYSPACE_IIDM, "staticVarCompensator")
                 .where(eq("networkUuid", networkUuid)));
         List<Resource<StaticVarCompensatorAttributes>> resources = new ArrayList<>();
@@ -2471,6 +2571,7 @@ public class NetworkStoreRepository {
                             .connectableBus(row.getString(14))
                             .regulatingTerminal(row.get(15, TerminalRefAttributes.class))
                             .voltagePerReactiveControl(row.get(16, VoltagePerReactivePowerControlAttributes.class))
+                            .fictitious(row.getBool(17))
                             .build())
                     .build());
         }
@@ -2493,7 +2594,8 @@ public class NetworkStoreRepository {
                 "bus",
                 CONNECTABLE_BUS,
                 REGULATING_TERMINAL,
-                "voltagePerReactivePowerControl")
+                "voltagePerReactivePowerControl",
+                "fictitious")
                 .from(KEYSPACE_IIDM, "staticVarCompensatorByVoltageLevel")
                 .where(eq("networkUuid", networkUuid)).and(eq("voltageLevelId", voltageLevelId)));
         List<Resource<StaticVarCompensatorAttributes>> resources = new ArrayList<>();
@@ -2517,6 +2619,7 @@ public class NetworkStoreRepository {
                             .connectableBus(row.getString(13))
                             .regulatingTerminal(row.get(14, TerminalRefAttributes.class))
                             .voltagePerReactiveControl(row.get(15, VoltagePerReactivePowerControlAttributes.class))
+                            .fictitious(row.getBool(16))
                             .build())
                     .build());
         }
@@ -2529,6 +2632,7 @@ public class NetworkStoreRepository {
             for (Resource<StaticVarCompensatorAttributes> resource : subresources) {
                 batch.add(unsetNullValues(psUpdateStaticVarCompensator.bind(
                         resource.getAttributes().getName(),
+                        resource.getAttributes().isFictitious(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getNode(),
                         resource.getAttributes().getBmin(),
@@ -2567,10 +2671,11 @@ public class NetworkStoreRepository {
                         resource.getId(),
                         resource.getAttributes().getVoltageLevelId(),
                         resource.getAttributes().getName(),
+                        resource.getAttributes().isFictitious(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getNode(),
                         resource.getAttributes().getPosition()
-                        )));
+                )));
             }
             session.execute(batch);
         }
@@ -2578,10 +2683,11 @@ public class NetworkStoreRepository {
 
     public Optional<Resource<BusbarSectionAttributes>> getBusbarSection(UUID networkUuid, String busbarSectionId) {
         ResultSet resultSet = session.execute(select("voltageLevelId",
-                                                     "name",
-                                                     "properties",
-                                                     "node",
-                                                     "position")
+                "name",
+                "properties",
+                "node",
+                "position",
+                "fictitious")
                 .from(KEYSPACE_IIDM, "busbarSection")
                 .where(eq("networkUuid", networkUuid)).and(eq("id", busbarSectionId)));
         Row row = resultSet.one();
@@ -2594,6 +2700,7 @@ public class NetworkStoreRepository {
                             .properties(row.getMap(2, String.class, String.class))
                             .node(row.getInt(3))
                             .position(row.get(4, BusbarSectionPositionAttributes.class))
+                            .fictitious(row.getBool(5))
                             .build())
                     .build());
         }
@@ -2602,11 +2709,12 @@ public class NetworkStoreRepository {
 
     public List<Resource<BusbarSectionAttributes>> getBusbarSections(UUID networkUuid) {
         ResultSet resultSet = session.execute(select("id",
-                                                     "voltageLevelId",
-                                                     "name",
-                                                     "properties",
-                                                     "node",
-                                                     "position")
+                "voltageLevelId",
+                "name",
+                "properties",
+                "node",
+                "position",
+                "fictitious")
                 .from(KEYSPACE_IIDM, "busbarSection")
                 .where(eq("networkUuid", networkUuid)));
         List<Resource<BusbarSectionAttributes>> resources = new ArrayList<>();
@@ -2619,6 +2727,7 @@ public class NetworkStoreRepository {
                             .properties(row.getMap(3, String.class, String.class))
                             .node(row.getInt(4))
                             .position(row.get(5, BusbarSectionPositionAttributes.class))
+                            .fictitious(row.getBool(6))
                             .build())
                     .build());
         }
@@ -2627,10 +2736,11 @@ public class NetworkStoreRepository {
 
     public List<Resource<BusbarSectionAttributes>> getVoltageLevelBusbarSections(UUID networkUuid, String voltageLevelId) {
         ResultSet resultSet = session.execute(select("id",
-                                                     "name",
-                                                     "properties",
-                                                     "node",
-                                                     "position")
+                "name",
+                "properties",
+                "node",
+                "position",
+                "fictitious")
                 .from(KEYSPACE_IIDM, "busbarSectionByVoltageLevel")
                 .where(eq("networkUuid", networkUuid)).and(eq("voltageLevelId", voltageLevelId)));
         List<Resource<BusbarSectionAttributes>> resources = new ArrayList<>();
@@ -2643,6 +2753,7 @@ public class NetworkStoreRepository {
                             .properties(row.getMap(2, String.class, String.class))
                             .node(row.getInt(3))
                             .position(row.get(4, BusbarSectionPositionAttributes.class))
+                            .fictitious(row.getBool(5))
                             .build())
                     .build());
         }
@@ -2682,16 +2793,16 @@ public class NetworkStoreRepository {
 
     public Optional<Resource<SwitchAttributes>> getSwitch(UUID networkUuid, String switchId) {
         ResultSet resultSet = session.execute(select("voltageLevelId",
-                                                     "name",
-                                                     "properties",
-                                                     "kind",
-                                                     "node1",
-                                                     "node2",
-                                                     "open",
-                                                     "retained",
-                                                     "fictitious",
-                                                     "bus1",
-                                                     "bus2")
+                "name",
+                "properties",
+                "kind",
+                "node1",
+                "node2",
+                "open",
+                "retained",
+                "fictitious",
+                "bus1",
+                "bus2")
                 .from(KEYSPACE_IIDM, "switch")
                 .where(eq("networkUuid", networkUuid)).and(eq("id", switchId)));
         Row row = resultSet.one();
@@ -2718,17 +2829,17 @@ public class NetworkStoreRepository {
 
     public List<Resource<SwitchAttributes>> getSwitches(UUID networkUuid) {
         ResultSet resultSet = session.execute(select("id",
-                                                     "voltageLevelId",
-                                                     "name",
-                                                     "properties",
-                                                     "kind",
-                                                     "node1",
-                                                     "node2",
-                                                     "open",
-                                                     "retained",
-                                                     "fictitious",
-                                                     "bus1",
-                                                     "bus2")
+                "voltageLevelId",
+                "name",
+                "properties",
+                "kind",
+                "node1",
+                "node2",
+                "open",
+                "retained",
+                "fictitious",
+                "bus1",
+                "bus2")
                 .from(KEYSPACE_IIDM, "switch")
                 .where(eq("networkUuid", networkUuid)));
         List<Resource<SwitchAttributes>> resources = new ArrayList<>();
@@ -2755,16 +2866,16 @@ public class NetworkStoreRepository {
 
     public List<Resource<SwitchAttributes>> getVoltageLevelSwitches(UUID networkUuid, String voltageLevelId) {
         ResultSet resultSet = session.execute(select("id",
-                                                     "name",
-                                                     "properties",
-                                                     "kind",
-                                                     "node1",
-                                                     "node2",
-                                                     "open",
-                                                     "retained",
-                                                     "fictitious",
-                                                     "bus1",
-                                                     "bus2")
+                "name",
+                "properties",
+                "kind",
+                "node1",
+                "node2",
+                "open",
+                "retained",
+                "fictitious",
+                "bus1",
+                "bus2")
                 .from(KEYSPACE_IIDM, "switchByVoltageLevel")
                 .where(eq("networkUuid", networkUuid)).and(eq("voltageLevelId", voltageLevelId)));
         List<Resource<SwitchAttributes>> resources = new ArrayList<>();
@@ -2830,6 +2941,7 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getVoltageLevelId1(),
                         resource.getAttributes().getVoltageLevelId2(),
                         resource.getAttributes().getName(),
+                        resource.getAttributes().isFictitious(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getNode1(),
                         resource.getAttributes().getNode2(),
@@ -2853,7 +2965,7 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getConnectableBus2(),
                         resource.getAttributes().getCurrentLimits1(),
                         resource.getAttributes().getCurrentLimits2()
-                        )));
+                )));
             }
             session.execute(batch);
         }
@@ -2861,31 +2973,32 @@ public class NetworkStoreRepository {
 
     public Optional<Resource<TwoWindingsTransformerAttributes>> getTwoWindingsTransformer(UUID networkUuid, String twoWindingsTransformerId) {
         ResultSet resultSet = session.execute(select("voltageLevelId1",
-                                                     "voltageLevelId2",
-                                                     "name",
-                                                     "properties",
-                                                     "node1",
-                                                     "node2",
-                                                     "r",
-                                                     "x",
-                                                     "g",
-                                                     "b",
-                                                     "ratedU1",
-                                                     "ratedU2",
-                                                     "p1",
-                                                     "q1",
-                                                     "p2",
-                                                     "q2",
-                                                     "position1",
-                                                     "position2",
-                                                     "phaseTapChanger",
-                                                     "ratioTapChanger",
-                                                     "bus1",
-                                                     "bus2",
-                                                     "connectableBus1",
-                                                     "connectableBus2",
-                                                     "currentLimits1",
-                                                     "currentLimits2")
+                "voltageLevelId2",
+                "name",
+                "properties",
+                "node1",
+                "node2",
+                "r",
+                "x",
+                "g",
+                "b",
+                "ratedU1",
+                "ratedU2",
+                "p1",
+                "q1",
+                "p2",
+                "q2",
+                "position1",
+                "position2",
+                "phaseTapChanger",
+                "ratioTapChanger",
+                "bus1",
+                "bus2",
+                "connectableBus1",
+                "connectableBus2",
+                "currentLimits1",
+                "currentLimits2",
+                "fictitious")
                 .from(KEYSPACE_IIDM, "twoWindingsTransformer")
                 .where(eq("networkUuid", networkUuid)).and(eq("id", twoWindingsTransformerId)));
         Row one = resultSet.one();
@@ -2919,6 +3032,7 @@ public class NetworkStoreRepository {
                             .connectableBus2(one.getString(23))
                             .currentLimits1(one.get(24, CurrentLimitsAttributes.class))
                             .currentLimits2(one.get(25, CurrentLimitsAttributes.class))
+                            .fictitious(one.getBool(26))
                             .build())
                     .build());
         }
@@ -2927,32 +3041,33 @@ public class NetworkStoreRepository {
 
     public List<Resource<TwoWindingsTransformerAttributes>> getTwoWindingsTransformers(UUID networkUuid) {
         ResultSet resultSet = session.execute(select("id",
-                                                     "voltageLevelId1",
-                                                     "voltageLevelId2",
-                                                     "name",
-                                                     "properties",
-                                                     "node1",
-                                                     "node2",
-                                                     "r",
-                                                     "x",
-                                                     "g",
-                                                     "b",
-                                                     "ratedU1",
-                                                     "ratedU2",
-                                                     "p1",
-                                                     "q1",
-                                                     "p2",
-                                                     "q2",
-                                                     "position1",
-                                                     "position2",
-                                                     "phaseTapChanger",
-                                                     "ratioTapChanger",
-                                                     "bus1",
-                                                     "bus2",
-                                                     "connectableBus1",
-                                                     "connectableBus2",
-                                                     "currentLimits1",
-                                                     "currentLimits2")
+                "voltageLevelId1",
+                "voltageLevelId2",
+                "name",
+                "properties",
+                "node1",
+                "node2",
+                "r",
+                "x",
+                "g",
+                "b",
+                "ratedU1",
+                "ratedU2",
+                "p1",
+                "q1",
+                "p2",
+                "q2",
+                "position1",
+                "position2",
+                "phaseTapChanger",
+                "ratioTapChanger",
+                "bus1",
+                "bus2",
+                "connectableBus1",
+                "connectableBus2",
+                "currentLimits1",
+                "currentLimits2",
+                "fictitious")
                 .from(KEYSPACE_IIDM, "twoWindingsTransformer")
                 .where(eq("networkUuid", networkUuid)));
         List<Resource<TwoWindingsTransformerAttributes>> resources = new ArrayList<>();
@@ -2986,6 +3101,7 @@ public class NetworkStoreRepository {
                             .connectableBus2(row.getString(24))
                             .currentLimits1(row.get(25, CurrentLimitsAttributes.class))
                             .currentLimits2(row.get(26, CurrentLimitsAttributes.class))
+                            .fictitious(row.getBool(27))
                             .build())
                     .build());
         }
@@ -2994,31 +3110,32 @@ public class NetworkStoreRepository {
 
     private List<Resource<TwoWindingsTransformerAttributes>> getVoltageLevelTwoWindingsTransformers(UUID networkUuid, Branch.Side side, String voltageLevelId) {
         ResultSet resultSet = session.execute(select("id",
-                                                     "voltageLevelId" + (side == Branch.Side.ONE ? 2 : 1),
-                                                     "name",
-                                                     "properties",
-                                                     "node1",
-                                                     "node2",
-                                                     "r",
-                                                     "x",
-                                                     "g",
-                                                     "b",
-                                                     "ratedU1",
-                                                     "ratedU2",
-                                                     "p1",
-                                                     "q1",
-                                                     "p2",
-                                                     "q2",
-                                                     "position1",
-                                                     "position2",
-                                                     "phaseTapChanger",
-                                                     "ratioTapChanger",
-                                                     "bus1",
-                                                     "bus2",
-                                                     "connectableBus1",
-                                                     "connectableBus2",
-                                                     "currentLimits1",
-                                                     "currentLimits2")
+                "voltageLevelId" + (side == Branch.Side.ONE ? 2 : 1),
+                "name",
+                "properties",
+                "node1",
+                "node2",
+                "r",
+                "x",
+                "g",
+                "b",
+                "ratedU1",
+                "ratedU2",
+                "p1",
+                "q1",
+                "p2",
+                "q2",
+                "position1",
+                "position2",
+                "phaseTapChanger",
+                "ratioTapChanger",
+                "bus1",
+                "bus2",
+                "connectableBus1",
+                "connectableBus2",
+                "currentLimits1",
+                "currentLimits2",
+                "fictitious")
                 .from(KEYSPACE_IIDM, "twoWindingsTransformerByVoltageLevel" + (side == Branch.Side.ONE ? 1 : 2))
                 .where(eq("networkUuid", networkUuid)).and(eq("voltageLevelId" + (side == Branch.Side.ONE ? 1 : 2), voltageLevelId)));
         List<Resource<TwoWindingsTransformerAttributes>> resources = new ArrayList<>();
@@ -3052,6 +3169,7 @@ public class NetworkStoreRepository {
                             .connectableBus2(row.getString(23))
                             .currentLimits1(row.get(24, CurrentLimitsAttributes.class))
                             .currentLimits2(row.get(25, CurrentLimitsAttributes.class))
+                            .fictitious(row.getBool(26))
                             .build())
                     .build());
         }
@@ -3075,6 +3193,7 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getVoltageLevelId1(),
                         resource.getAttributes().getVoltageLevelId2(),
                         resource.getAttributes().getName(),
+                        resource.getAttributes().isFictitious(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getNode1(),
                         resource.getAttributes().getNode2(),
@@ -3123,6 +3242,7 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getLeg2().getVoltageLevelId(),
                         resource.getAttributes().getLeg3().getVoltageLevelId(),
                         resource.getAttributes().getName(),
+                        resource.getAttributes().isFictitious(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getLeg1().getNode(),
                         resource.getAttributes().getLeg2().getNode(),
@@ -3227,7 +3347,8 @@ public class NetworkStoreRepository {
                 "connectableBus3",
                 "ratedS1",
                 "ratedS2",
-                "ratedS3")
+                "ratedS3",
+                "fictitious")
                 .from(KEYSPACE_IIDM, "threeWindingsTransformer")
                 .where(eq("networkUuid", networkUuid)).and(eq("id", threeWindingsTransformerId)));
         Row one = resultSet.one();
@@ -3295,6 +3416,7 @@ public class NetworkStoreRepository {
                             .position1(one.get(36, ConnectablePositionAttributes.class))
                             .position2(one.get(37, ConnectablePositionAttributes.class))
                             .position3(one.get(38, ConnectablePositionAttributes.class))
+                            .fictitious(one.getBool(51))
                             .build())
                     .build());
         }
@@ -3353,7 +3475,8 @@ public class NetworkStoreRepository {
                 "connectableBus3",
                 "ratedS1",
                 "ratedS2",
-                "ratedS3")
+                "ratedS3",
+                "fictitious")
                 .from(KEYSPACE_IIDM, "threeWindingsTransformer")
                 .where(eq("networkUuid", networkUuid)));
         List<Resource<ThreeWindingsTransformerAttributes>> resources = new ArrayList<>();
@@ -3421,6 +3544,7 @@ public class NetworkStoreRepository {
                             .position1(row.get(37, ConnectablePositionAttributes.class))
                             .position2(row.get(38, ConnectablePositionAttributes.class))
                             .position3(row.get(39, ConnectablePositionAttributes.class))
+                            .fictitious(row.getBool(52))
                             .build())
                     .build());
         }
@@ -3478,7 +3602,8 @@ public class NetworkStoreRepository {
                 "connectableBus3",
                 "ratedS1",
                 "ratedS2",
-                "ratedS3")
+                "ratedS3",
+                "fictitious")
                 .from(KEYSPACE_IIDM, "threeWindingsTransformerByVoltageLevel" + (side == ThreeWindingsTransformer.Side.ONE ? 1 : (side == ThreeWindingsTransformer.Side.TWO ? 2 : 3)))
                 .where(eq("networkUuid", networkUuid)).and(eq("voltageLevelId" + (side == ThreeWindingsTransformer.Side.ONE ? 1 : (side == ThreeWindingsTransformer.Side.TWO ? 2 : 3)), voltageLevelId)));
         List<Resource<ThreeWindingsTransformerAttributes>> resources = new ArrayList<>();
@@ -3546,6 +3671,7 @@ public class NetworkStoreRepository {
                             .position1(row.get(36, ConnectablePositionAttributes.class))
                             .position2(row.get(37, ConnectablePositionAttributes.class))
                             .position3(row.get(38, ConnectablePositionAttributes.class))
+                            .fictitious(row.getBool(51))
                             .build())
                     .build());
         }
@@ -3571,6 +3697,7 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getLeg2().getVoltageLevelId(),
                         resource.getAttributes().getLeg3().getVoltageLevelId(),
                         resource.getAttributes().getName(),
+                        resource.getAttributes().isFictitious(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getLeg1().getNode(),
                         resource.getAttributes().getLeg2().getNode(),
@@ -3642,6 +3769,7 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getVoltageLevelId1(),
                         resource.getAttributes().getVoltageLevelId2(),
                         resource.getAttributes().getName(),
+                        resource.getAttributes().isFictitious(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getNode1(),
                         resource.getAttributes().getNode2(),
@@ -3672,30 +3800,31 @@ public class NetworkStoreRepository {
 
     public Optional<Resource<LineAttributes>> getLine(UUID networkUuid, String lineId) {
         ResultSet resultSet = session.execute(select("voltageLevelId1",
-                                                     "voltageLevelId2",
-                                                     "name",
-                                                     "properties",
-                                                     "node1",
-                                                     "node2",
-                                                     "r",
-                                                     "x",
-                                                     "g1",
-                                                     "b1",
-                                                     "g2",
-                                                     "b2",
-                                                     "p1",
-                                                     "q1",
-                                                     "p2",
-                                                     "q2",
-                                                     "position1",
-                                                     "position2",
-                                                     "bus1",
-                                                     "bus2",
-                                                     "connectableBus1",
-                                                     "connectableBus2",
-                                                     "mergedXnode",
-                                                     "currentLimits1",
-                                                     "currentLimits2")
+                "voltageLevelId2",
+                "name",
+                "properties",
+                "node1",
+                "node2",
+                "r",
+                "x",
+                "g1",
+                "b1",
+                "g2",
+                "b2",
+                "p1",
+                "q1",
+                "p2",
+                "q2",
+                "position1",
+                "position2",
+                "bus1",
+                "bus2",
+                "connectableBus1",
+                "connectableBus2",
+                "mergedXnode",
+                "currentLimits1",
+                "currentLimits2",
+                "fictitious")
                 .from(KEYSPACE_IIDM, "line")
                 .where(eq("networkUuid", networkUuid)).and(eq("id", lineId)));
         Row one = resultSet.one();
@@ -3728,6 +3857,7 @@ public class NetworkStoreRepository {
                             .mergedXnode(one.get(22, MergedXnodeAttributes.class))
                             .currentLimits1(one.get(23, CurrentLimitsAttributes.class))
                             .currentLimits2(one.get(24, CurrentLimitsAttributes.class))
+                            .fictitious(one.getBool(25))
                             .build())
                     .build());
         }
@@ -3736,31 +3866,32 @@ public class NetworkStoreRepository {
 
     public List<Resource<LineAttributes>> getLines(UUID networkUuid) {
         ResultSet resultSet = session.execute(select("id",
-                                                     "voltageLevelId1",
-                                                     "voltageLevelId2",
-                                                     "name",
-                                                     "properties",
-                                                     "node1",
-                                                     "node2",
-                                                     "r",
-                                                     "x",
-                                                     "g1",
-                                                     "b1",
-                                                     "g2",
-                                                     "b2",
-                                                     "p1",
-                                                     "q1",
-                                                     "p2",
-                                                     "q2",
-                                                     "position1",
-                                                     "position2",
-                                                     "bus1",
-                                                     "bus2",
-                                                     "connectableBus1",
-                                                     "connectableBus2",
-                                                     "mergedXnode",
-                                                     "currentLimits1",
-                                                     "currentLimits2")
+                "voltageLevelId1",
+                "voltageLevelId2",
+                "name",
+                "properties",
+                "node1",
+                "node2",
+                "r",
+                "x",
+                "g1",
+                "b1",
+                "g2",
+                "b2",
+                "p1",
+                "q1",
+                "p2",
+                "q2",
+                "position1",
+                "position2",
+                "bus1",
+                "bus2",
+                "connectableBus1",
+                "connectableBus2",
+                "mergedXnode",
+                "currentLimits1",
+                "currentLimits2",
+                "fictitious")
                 .from(KEYSPACE_IIDM, "line")
                 .where(eq("networkUuid", networkUuid)));
         List<Resource<LineAttributes>> resources = new ArrayList<>();
@@ -3793,6 +3924,7 @@ public class NetworkStoreRepository {
                             .mergedXnode(row.get(23, MergedXnodeAttributes.class))
                             .currentLimits1(row.get(24, CurrentLimitsAttributes.class))
                             .currentLimits2(row.get(25, CurrentLimitsAttributes.class))
+                            .fictitious(row.getBool(26))
                             .build())
                     .build());
         }
@@ -3801,30 +3933,31 @@ public class NetworkStoreRepository {
 
     private List<Resource<LineAttributes>> getVoltageLevelLines(UUID networkUuid, Branch.Side side, String voltageLevelId) {
         ResultSet resultSet = session.execute(select("id",
-                                                     "voltageLevelId" + (side == Branch.Side.ONE ? 2 : 1),
-                                                     "name",
-                                                     "properties",
-                                                     "node1",
-                                                     "node2",
-                                                     "r",
-                                                     "x",
-                                                     "g1",
-                                                     "b1",
-                                                     "g2",
-                                                     "b2",
-                                                     "p1",
-                                                     "q1",
-                                                     "p2",
-                                                     "q2",
-                                                     "position1",
-                                                     "position2",
-                                                     "bus1",
-                                                     "bus2",
-                                                     "connectableBus1",
-                                                     "connectableBus2",
-                                                     "mergedXnode",
-                                                     "currentLimits1",
-                                                     "currentLimits2")
+                "voltageLevelId" + (side == Branch.Side.ONE ? 2 : 1),
+                "name",
+                "properties",
+                "node1",
+                "node2",
+                "r",
+                "x",
+                "g1",
+                "b1",
+                "g2",
+                "b2",
+                "p1",
+                "q1",
+                "p2",
+                "q2",
+                "position1",
+                "position2",
+                "bus1",
+                "bus2",
+                "connectableBus1",
+                "connectableBus2",
+                "mergedXnode",
+                "currentLimits1",
+                "currentLimits2",
+                "fictitious")
                 .from(KEYSPACE_IIDM, "lineByVoltageLevel" + (side == Branch.Side.ONE ? 1 : 2))
                 .where(eq("networkUuid", networkUuid)).and(eq("voltageLevelId" + (side == Branch.Side.ONE ? 1 : 2), voltageLevelId)));
         List<Resource<LineAttributes>> resources = new ArrayList<>();
@@ -3857,6 +3990,7 @@ public class NetworkStoreRepository {
                             .mergedXnode(row.get(22, MergedXnodeAttributes.class))
                             .currentLimits1(row.get(23, CurrentLimitsAttributes.class))
                             .currentLimits2(row.get(24, CurrentLimitsAttributes.class))
+                            .fictitious(row.getBool(25))
                             .build())
                     .build());
         }
@@ -3866,9 +4000,9 @@ public class NetworkStoreRepository {
     public List<Resource<LineAttributes>> getVoltageLevelLines(UUID networkUuid, String voltageLevelId) {
         return ImmutableList.<Resource<LineAttributes>>builder().addAll(
                 ImmutableSet.<Resource<LineAttributes>>builder()
-                .addAll(getVoltageLevelLines(networkUuid, Branch.Side.ONE, voltageLevelId))
-                .addAll(getVoltageLevelLines(networkUuid, Branch.Side.TWO, voltageLevelId))
-                .build())
+                        .addAll(getVoltageLevelLines(networkUuid, Branch.Side.ONE, voltageLevelId))
+                        .addAll(getVoltageLevelLines(networkUuid, Branch.Side.TWO, voltageLevelId))
+                        .build())
                 .build();
     }
 
@@ -3880,6 +4014,7 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getVoltageLevelId1(),
                         resource.getAttributes().getVoltageLevelId2(),
                         resource.getAttributes().getName(),
+                        resource.getAttributes().isFictitious(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getNode1(),
                         resource.getAttributes().getNode2(),
@@ -3926,7 +4061,8 @@ public class NetworkStoreRepository {
                 "activePowerSetpoint",
                 "maxP",
                 "converterStationId1",
-                "converterStationId2")
+                "converterStationId2",
+                "fictitious")
                 .from(KEYSPACE_IIDM, "hvdcLine")
                 .where(eq("networkUuid", networkUuid)));
         List<Resource<HvdcLineAttributes>> resources = new ArrayList<>();
@@ -3943,6 +4079,7 @@ public class NetworkStoreRepository {
                             .maxP(row.getDouble(7))
                             .converterStationId1(row.getString(8))
                             .converterStationId2(row.getString(9))
+                            .fictitious(row.getBool(10))
                             .build())
                     .build());
         }
@@ -3958,7 +4095,8 @@ public class NetworkStoreRepository {
                 "activePowerSetpoint",
                 "maxP",
                 "converterStationId1",
-                "converterStationId2")
+                "converterStationId2",
+                "fictitious")
                 .from(KEYSPACE_IIDM, "hvdcLine")
                 .where(eq("networkUuid", networkUuid)).and(eq("id", hvdcLineId)));
         Row one = resultSet.one();
@@ -3975,6 +4113,7 @@ public class NetworkStoreRepository {
                             .maxP(one.getDouble(6))
                             .converterStationId1(one.getString(7))
                             .converterStationId2(one.getString(8))
+                            .fictitious(one.getBool(9))
                             .build())
                     .build());
         }
@@ -3989,6 +4128,7 @@ public class NetworkStoreRepository {
                         networkUuid,
                         resource.getId(),
                         resource.getAttributes().getName(),
+                        resource.getAttributes().isFictitious(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getR(),
                         resource.getAttributes().getConvertersMode().toString(),
@@ -4009,6 +4149,7 @@ public class NetworkStoreRepository {
             for (Resource<HvdcLineAttributes> resource : subresources) {
                 batch.add(unsetNullValues(psUpdateHvdcLine.bind(
                         resource.getAttributes().getName(),
+                        resource.getAttributes().isFictitious(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getR(),
                         resource.getAttributes().getConvertersMode().toString(),
@@ -4050,7 +4191,8 @@ public class NetworkStoreRepository {
                 "q",
                 "position",
                 "bus",
-                CONNECTABLE_BUS)
+                CONNECTABLE_BUS,
+                "fictitious")
                 .from(KEYSPACE_IIDM, "danglingLine")
                 .where(eq("networkUuid", networkUuid)));
         List<Resource<DanglingLineAttributes>> resources = new ArrayList<>();
@@ -4076,6 +4218,7 @@ public class NetworkStoreRepository {
                             .position(row.get(16, ConnectablePositionAttributes.class))
                             .bus(row.getString(17))
                             .connectableBus(row.getString(18))
+                            .fictitious(row.getBool(19))
                             .build())
                     .build());
         }
@@ -4100,7 +4243,8 @@ public class NetworkStoreRepository {
                 "q",
                 "position",
                 "bus",
-                CONNECTABLE_BUS)
+                CONNECTABLE_BUS,
+                "fictitious")
                 .from(KEYSPACE_IIDM, "danglingLine")
                 .where(eq("networkUuid", networkUuid)).and(eq("id", danglingLineId)));
         Row one = resultSet.one();
@@ -4126,6 +4270,7 @@ public class NetworkStoreRepository {
                             .position(one.get(15, ConnectablePositionAttributes.class))
                             .bus(one.getString(16))
                             .connectableBus(one.getString(17))
+                            .fictitious(one.getBool(18))
                             .build())
                     .build());
         }
@@ -4150,7 +4295,8 @@ public class NetworkStoreRepository {
                 "q",
                 "position",
                 "bus",
-                CONNECTABLE_BUS)
+                CONNECTABLE_BUS,
+                "fictitious")
                 .from(KEYSPACE_IIDM, "danglingLineByVoltageLevel")
                 .where(eq("networkUuid", networkUuid)).and(eq("voltageLevelId", voltageLevelId)));
         List<Resource<DanglingLineAttributes>> resources = new ArrayList<>();
@@ -4176,6 +4322,7 @@ public class NetworkStoreRepository {
                             .position(row.get(15, ConnectablePositionAttributes.class))
                             .bus(row.getString(16))
                             .connectableBus(row.getString(17))
+                            .fictitious(row.getBool(18))
                             .build())
                     .build());
         }
@@ -4191,6 +4338,7 @@ public class NetworkStoreRepository {
                         resource.getId(),
                         resource.getAttributes().getVoltageLevelId(),
                         resource.getAttributes().getName(),
+                        resource.getAttributes().isFictitious(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getNode(),
                         resource.getAttributes().getP0(),
@@ -4223,6 +4371,7 @@ public class NetworkStoreRepository {
             for (Resource<DanglingLineAttributes> resource : subresources) {
                 batch.add(unsetNullValues(psUpdateDanglingLine.bind(
                         resource.getAttributes().getName(),
+                        resource.getAttributes().isFictitious(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getNode(),
                         resource.getAttributes().getP0(),
@@ -4259,6 +4408,7 @@ public class NetworkStoreRepository {
                         resource.getId(),
                         resource.getAttributes().getVoltageLevelId(),
                         resource.getAttributes().getName(),
+                        resource.getAttributes().isFictitious(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getV(),
                         resource.getAttributes().getAngle()
@@ -4273,7 +4423,8 @@ public class NetworkStoreRepository {
                 "name",
                 "properties",
                 "v",
-                "angle")
+                "angle",
+                "fictitious")
                 .from(KEYSPACE_IIDM, "configuredBus")
                 .where(eq("networkUuid", networkUuid)).and(eq("id", busId)));
         Row row = resultSet.one();
@@ -4286,6 +4437,7 @@ public class NetworkStoreRepository {
                             .properties(row.getMap(2, String.class, String.class))
                             .v(row.getDouble(3))
                             .angle(row.getDouble(4))
+                            .fictitious(row.getBool(5))
                             .build())
                     .build());
         }
@@ -4298,7 +4450,8 @@ public class NetworkStoreRepository {
                 "voltageLevelId",
                 "v",
                 "angle",
-                "properties")
+                "properties",
+                "fictitious")
                 .from(KEYSPACE_IIDM, "configuredBus")
                 .where(eq("networkUuid", networkUuid)));
         List<Resource<ConfiguredBusAttributes>> resources = new ArrayList<>();
@@ -4312,6 +4465,7 @@ public class NetworkStoreRepository {
                             .v(row.getDouble(3))
                             .angle(row.getDouble(4))
                             .properties(row.getMap(5, String.class, String.class))
+                            .fictitious(row.getBool(6))
                             .build())
                     .build());
         }
@@ -4323,6 +4477,7 @@ public class NetworkStoreRepository {
                 "name",
                 "v",
                 "angle",
+                "fictitious",
                 "properties")
                 .from(KEYSPACE_IIDM, "configuredBusByVoltageLevel")
                 .where(eq("networkUuid", networkUuid)).and(eq("voltageLevelId", voltageLevelId)));
@@ -4336,7 +4491,8 @@ public class NetworkStoreRepository {
                             .voltageLevelId(voltageLevelId)
                             .v(row.getDouble(2))
                             .angle(row.getDouble(3))
-                            .properties(row.getMap(4, String.class, String.class))
+                            .fictitious(row.getBool(4))
+                            .properties(row.getMap(5, String.class, String.class))
                             .build())
                     .build());
         }
@@ -4349,6 +4505,7 @@ public class NetworkStoreRepository {
             for (Resource<ConfiguredBusAttributes> resource : subresources) {
                 batch.add(unsetNullValues(psUpdateConfiguredBus.bind(
                         resource.getAttributes().getName(),
+                        resource.getAttributes().isFictitious(),
                         resource.getAttributes().getProperties(),
                         resource.getAttributes().getV(),
                         resource.getAttributes().getAngle(),

--- a/network-store-server/src/main/resources/iidm.cql
+++ b/network-store-server/src/main/resources/iidm.cql
@@ -13,6 +13,7 @@ CREATE TYPE IF NOT EXISTS iidm.cimCharacteristics (
 CREATE TABLE IF NOT EXISTS iidm.network (
     uuid uuid,
     id text,
+    fictitious boolean,
     properties frozen<map<text, text>>,
     caseDate timestamp,
     forecastDistance int,
@@ -32,6 +33,7 @@ CREATE TABLE IF NOT EXISTS iidm.substation (
     networkUuid uuid,
     id text,
     name text,
+    fictitious boolean,
     properties frozen<map<text, text>>,
     country text,
     tso text,
@@ -70,6 +72,7 @@ CREATE TABLE IF NOT EXISTS iidm.voltageLevel (
     id text,
     substationId text,
     name text,
+    fictitious boolean,
     properties frozen<map<text, text>>,
     nominalV double,
     lowVoltageLimit double,
@@ -85,7 +88,7 @@ CREATE TABLE IF NOT EXISTS iidm.voltageLevel (
 );
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS iidm.voltageLevelBySubstation AS
-    SELECT networkUuid, id, substationId, name, properties, nominalV, lowVoltageLimit, highVoltageLimit, topologyKind, internalConnections, calculatedBuses, nodeToCalculatedBus, busToCalculatedBus, calculatedBusesValid, slackTerminal
+    SELECT networkUuid, id, substationId, name, fictitious, properties, nominalV, lowVoltageLimit, highVoltageLimit, topologyKind, internalConnections, calculatedBuses, nodeToCalculatedBus, busToCalculatedBus, calculatedBusesValid, slackTerminal
     FROM iidm.voltageLevel
     WHERE networkUuid IS NOT NULL AND id IS NOT NULL AND substationId IS NOT NULL
     PRIMARY KEY (networkUuid, substationId, id);
@@ -149,6 +152,7 @@ CREATE TABLE IF NOT EXISTS iidm.generator (
     id text,
     voltageLevelId text,
     name text,
+    fictitious boolean,
     properties frozen<map<text, text>>,
     node int,
     energySource text,
@@ -173,7 +177,7 @@ CREATE TABLE IF NOT EXISTS iidm.generator (
 );
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS iidm.generatorByVoltageLevel AS
-    SELECT networkUuid, id, voltageLevelId, name, properties, node, energySource, minP, maxP, voltageRegulatorOn, targetP, targetQ, targetV, ratedS, p, q, position, minMaxReactiveLimits, reactiveCapabilityCurve, bus, connectableBus, activePowerControl, regulatingTerminal, coordinatedReactiveControl
+    SELECT networkUuid, id, voltageLevelId, name, fictitious, properties, node, energySource, minP, maxP, voltageRegulatorOn, targetP, targetQ, targetV, ratedS, p, q, position, minMaxReactiveLimits, reactiveCapabilityCurve, bus, connectableBus, activePowerControl, regulatingTerminal, coordinatedReactiveControl
     FROM iidm.generator
     WHERE networkUuid IS NOT NULL AND id IS NOT NULL AND voltageLevelId IS NOT NULL
         PRIMARY KEY (networkUuid, voltageLevelId, id);
@@ -183,6 +187,7 @@ CREATE TABLE IF NOT EXISTS iidm.battery (
     id text,
     voltageLevelId text,
     name text,
+    fictitious boolean,
     properties frozen<map<text, text>>,
     node int,
     minP double,
@@ -200,7 +205,7 @@ CREATE TABLE IF NOT EXISTS iidm.battery (
 );
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS iidm.batteryByVoltageLevel AS
-    SELECT networkUuid, id, voltageLevelId, name, properties, node, minP, maxP, p0, q0, p, q, position, minMaxReactiveLimits, reactiveCapabilityCurve, bus, connectableBus
+    SELECT networkUuid, id, voltageLevelId, name, fictitious, properties, node, minP, maxP, p0, q0, p, q, position, minMaxReactiveLimits, reactiveCapabilityCurve, bus, connectableBus
     FROM iidm.battery
     WHERE networkUuid IS NOT NULL AND id IS NOT NULL AND voltageLevelId IS NOT NULL
         PRIMARY KEY (networkUuid, voltageLevelId, id);
@@ -217,6 +222,7 @@ CREATE TABLE IF NOT EXISTS iidm.load (
     id text,
     voltageLevelId text,
     name text,
+    fictitious boolean,
     properties frozen<map<text, text>>,
     node int,
     loadType text,
@@ -232,7 +238,7 @@ CREATE TABLE IF NOT EXISTS iidm.load (
 );
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS iidm.loadByVoltageLevel AS
-    SELECT networkUuid, id, voltageLevelId, name, properties, node, loadType, p0, q0, p, q, position, bus, connectableBus, loadDetail
+    SELECT networkUuid, id, voltageLevelId, name, fictitious, properties, node, loadType, p0, q0, p, q, position, bus, connectableBus, loadDetail
     FROM iidm.load
     WHERE networkUuid IS NOT NULL AND id IS NOT NULL AND voltageLevelId IS NOT NULL
         PRIMARY KEY (networkUuid, voltageLevelId, id);
@@ -257,6 +263,7 @@ CREATE TABLE IF NOT EXISTS iidm.shuntCompensator (
     id text,
     voltageLevelId text,
     name text,
+    fictitious boolean,
     properties frozen<map<text, text>>,
     node int,
     linearModel iidm.shuntCompensatorLinearModel,
@@ -275,7 +282,7 @@ CREATE TABLE IF NOT EXISTS iidm.shuntCompensator (
 );
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS iidm.shuntCompensatorByVoltageLevel AS
-SELECT networkUuid, id, voltageLevelId, name, properties, node, linearModel, nonLinearModel, sectionCount, p, q, position, bus, connectableBus, regulatingTerminal, voltageRegulatorOn, targetV, targetDeadband
+SELECT networkUuid, id, voltageLevelId, name, fictitious, properties, node, linearModel, nonLinearModel, sectionCount, p, q, position, bus, connectableBus, regulatingTerminal, voltageRegulatorOn, targetV, targetDeadband
 FROM iidm.shuntCompensator
 WHERE networkUuid IS NOT NULL AND id IS NOT NULL AND voltageLevelId IS NOT NULL
     PRIMARY KEY (networkUuid, voltageLevelId, id);
@@ -285,6 +292,7 @@ CREATE TABLE IF NOT EXISTS iidm.vscConverterStation (
     id text,
     voltageLevelId text,
     name text,
+    fictitious boolean,
     properties frozen<map<text, text>>,
     node int,
     lossFactor float,
@@ -302,7 +310,7 @@ CREATE TABLE IF NOT EXISTS iidm.vscConverterStation (
 );
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS iidm.vscConverterStationByVoltageLevel AS
-SELECT networkUuid, id, voltageLevelId, name, properties, node, lossFactor, voltageRegulatorOn, reactivePowerSetPoint, voltageSetPoint, minMaxReactiveLimits, reactiveCapabilityCurve, p, q, position, bus, connectableBus
+SELECT networkUuid, id, voltageLevelId, name, fictitious, properties, node, lossFactor, voltageRegulatorOn, reactivePowerSetPoint, voltageSetPoint, minMaxReactiveLimits, reactiveCapabilityCurve, p, q, position, bus, connectableBus
 FROM iidm.vscConverterStation
 WHERE networkUuid IS NOT NULL AND id IS NOT NULL AND voltageLevelId IS NOT NULL
     PRIMARY KEY (networkUuid, voltageLevelId, id);
@@ -312,6 +320,7 @@ CREATE TABLE IF NOT EXISTS iidm.lccConverterStation (
     id text,
     voltageLevelId text,
     name text,
+    fictitious boolean,
     properties frozen<map<text, text>>,
     node int,
     powerFactor float,
@@ -325,7 +334,7 @@ CREATE TABLE IF NOT EXISTS iidm.lccConverterStation (
 );
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS iidm.lccConverterStationByVoltageLevel AS
-SELECT networkUuid, id, voltageLevelId, name, properties, node, powerFactor, lossFactor, p, q, position, bus, connectableBus
+SELECT networkUuid, id, voltageLevelId, name, fictitious, properties, node, powerFactor, lossFactor, p, q, position, bus, connectableBus
 FROM iidm.lccConverterStation
 WHERE networkUuid IS NOT NULL AND id IS NOT NULL AND voltageLevelId IS NOT NULL
     PRIMARY KEY (networkUuid, voltageLevelId, id);
@@ -339,6 +348,7 @@ CREATE TABLE IF NOT EXISTS iidm.staticVarCompensator (
     id text,
     voltageLevelId text,
     name text,
+    fictitious boolean,
     properties frozen<map<text, text>>,
     node int,
     bMin double,
@@ -357,7 +367,7 @@ CREATE TABLE IF NOT EXISTS iidm.staticVarCompensator (
 );
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS iidm.staticVarCompensatorByVoltageLevel AS
-SELECT networkUuid, id, voltageLevelId, name, properties, node, bMin, bMax, voltageSetPoint, reactivePowerSetPoint, regulationMode, p, q, position, bus, connectableBus, regulatingTerminal, voltagePerReactivePowerControl
+SELECT networkUuid, id, voltageLevelId, name, fictitious, properties, node, bMin, bMax, voltageSetPoint, reactivePowerSetPoint, regulationMode, p, q, position, bus, connectableBus, regulatingTerminal, voltagePerReactivePowerControl
 FROM iidm.staticVarCompensator
 WHERE networkUuid IS NOT NULL AND id IS NOT NULL AND voltageLevelId IS NOT NULL
     PRIMARY KEY (networkUuid, voltageLevelId, id);
@@ -372,6 +382,7 @@ CREATE TABLE IF NOT EXISTS iidm.busbarSection (
     id text,
     voltageLevelId text,
     name text,
+    fictitious boolean,
     properties frozen<map<text, text>>,
     node int,
     position iidm.busbarSectionPosition,
@@ -379,7 +390,7 @@ CREATE TABLE IF NOT EXISTS iidm.busbarSection (
 );
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS iidm.busbarSectionByVoltageLevel AS
-    SELECT networkUuid, id, voltageLevelId, name, properties, node, position
+    SELECT networkUuid, id, voltageLevelId, name, fictitious, properties, node, position
     FROM iidm.busbarSection
     WHERE networkUuid IS NOT NULL AND id IS NOT NULL AND voltageLevelId IS NOT NULL
         PRIMARY KEY (networkUuid, voltageLevelId, id);
@@ -452,6 +463,7 @@ CREATE TABLE IF NOT EXISTS iidm.twoWindingsTransformer (
     voltageLevelId1 text,
     voltageLevelId2 text,
     name text,
+    fictitious boolean,
     properties frozen<map<text, text>>,
     node1 int,
     node2 int,
@@ -479,13 +491,13 @@ CREATE TABLE IF NOT EXISTS iidm.twoWindingsTransformer (
 );
 
 CREATE MATERIALIZED VIEW iidm.twoWindingsTransformerByVoltageLevel1 AS
-SELECT networkUuid, id, voltageLevelId1, voltageLevelId2, name, properties, node1, node2, r, x, g, b, ratedU1, ratedU2, p1, q1, p2, q2, position1, position2, phaseTapChanger, ratioTapChanger, bus1, bus2, connectableBus1, connectableBus2, currentLimits1, currentLimits2
+SELECT networkUuid, id, voltageLevelId1, voltageLevelId2, name, fictitious, properties, node1, node2, r, x, g, b, ratedU1, ratedU2, p1, q1, p2, q2, position1, position2, phaseTapChanger, ratioTapChanger, bus1, bus2, connectableBus1, connectableBus2, currentLimits1, currentLimits2
 FROM iidm.twoWindingsTransformer
 WHERE networkUuid IS NOT NULL AND id IS NOT NULL AND voltageLevelId1 IS NOT NULL
     PRIMARY KEY (networkUuid, voltageLevelId1, id);
 
 CREATE MATERIALIZED VIEW iidm.twoWindingsTransformerByVoltageLevel2 AS
-SELECT networkUuid, id, voltageLevelId1, voltageLevelId2, name, properties, node1, node2, r, x, g, b, ratedU1, ratedU2, p1, q1, p2, q2, position1, position2, phaseTapChanger, ratioTapChanger, bus1, bus2, connectableBus1, connectableBus2, currentLimits1, currentLimits2
+SELECT networkUuid, id, voltageLevelId1, voltageLevelId2, name, fictitious, properties, node1, node2, r, x, g, b, ratedU1, ratedU2, p1, q1, p2, q2, position1, position2, phaseTapChanger, ratioTapChanger, bus1, bus2, connectableBus1, connectableBus2, currentLimits1, currentLimits2
 FROM iidm.twoWindingsTransformer
 WHERE networkUuid IS NOT NULL AND id IS NOT NULL AND voltageLevelId2 IS NOT NULL
     PRIMARY KEY (networkUuid, voltageLevelId2, id);
@@ -500,6 +512,7 @@ CREATE TABLE IF NOT EXISTS iidm.threeWindingsTransformer (
     node2 int,
     node3 int,
     name text,
+    fictitious boolean,
     properties frozen<map<text, text>>,
     ratedU0 double,
     p1 double,
@@ -548,19 +561,19 @@ CREATE TABLE IF NOT EXISTS iidm.threeWindingsTransformer (
 );
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS iidm.threeWindingsTransformerByVoltageLevel1 AS
-SELECT networkUuid, id, voltageLevelId1, voltageLevelId2, voltageLevelId3, name, properties, node1, node2, node3, ratedU0, p1, q1, r1, x1, g1, b1, ratedU1, ratedS1, phaseTapChanger1, ratioTapChanger1, p2, q2, r2, x2, g2, b2, phaseTapChanger2, ratioTapChanger2, ratedU2, ratedS2, p3, q3, r3, x3, g3, b3, phaseTapChanger3, ratioTapChanger3, ratedU3, ratedS3, position1, position2, position3, currentLimits1, currentLimits2, currentLimits3, bus1, connectableBus1, bus2, connectableBus2, bus3, connectableBus3
+SELECT networkUuid, id, voltageLevelId1, voltageLevelId2, voltageLevelId3, name, fictitious, properties, node1, node2, node3, ratedU0, p1, q1, r1, x1, g1, b1, ratedU1, ratedS1, phaseTapChanger1, ratioTapChanger1, p2, q2, r2, x2, g2, b2, phaseTapChanger2, ratioTapChanger2, ratedU2, ratedS2, p3, q3, r3, x3, g3, b3, phaseTapChanger3, ratioTapChanger3, ratedU3, ratedS3, position1, position2, position3, currentLimits1, currentLimits2, currentLimits3, bus1, connectableBus1, bus2, connectableBus2, bus3, connectableBus3
 FROM iidm.threeWindingsTransformer
 WHERE networkUuid IS NOT NULL AND id IS NOT NULL AND voltageLevelId1 IS NOT NULL
     PRIMARY KEY (networkUuid, voltageLevelId1, id);
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS iidm.threeWindingsTransformerByVoltageLevel2 AS
-SELECT networkUuid, id, voltageLevelId1, voltageLevelId2, voltageLevelId3, name, properties, node1, node2, node3, ratedU0, p1, q1, r1, x1, g1, b1, ratedU1, ratedS1, phaseTapChanger1, ratioTapChanger1, p2, q2, r2, x2, g2, b2, ratedU2, ratedS2, phaseTapChanger2, ratioTapChanger2, p3, q3, r3, x3, g3, b3, ratedU3, ratedS3, phaseTapChanger3, ratioTapChanger3, position1, position2, position3, currentLimits1, currentLimits2, currentLimits3, bus1, connectableBus1, bus2, connectableBus2, bus3, connectableBus3
+SELECT networkUuid, id, voltageLevelId1, voltageLevelId2, voltageLevelId3, name, fictitious, properties, node1, node2, node3, ratedU0, p1, q1, r1, x1, g1, b1, ratedU1, ratedS1, phaseTapChanger1, ratioTapChanger1, p2, q2, r2, x2, g2, b2, ratedU2, ratedS2, phaseTapChanger2, ratioTapChanger2, p3, q3, r3, x3, g3, b3, ratedU3, ratedS3, phaseTapChanger3, ratioTapChanger3, position1, position2, position3, currentLimits1, currentLimits2, currentLimits3, bus1, connectableBus1, bus2, connectableBus2, bus3, connectableBus3
 FROM iidm.threeWindingsTransformer
 WHERE networkUuid IS NOT NULL AND id IS NOT NULL AND voltageLevelId2 IS NOT NULL
     PRIMARY KEY (networkUuid, voltageLevelId2, id);
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS iidm.threeWindingsTransformerByVoltageLevel3 AS
-SELECT networkUuid, id, voltageLevelId1, voltageLevelId2, voltageLevelId3, name, properties, node1, node2, node3, ratedU0, p1, q1, r1, x1, g1, b1, ratedU1, ratedS1, phaseTapChanger1, ratioTapChanger1, p2, q2, r2, x2, g2, b2, ratedU2, ratedS2, phaseTapChanger2, ratioTapChanger2, p3, q3, r3, x3, g3, b3, ratedU3, ratedS3, phaseTapChanger3, ratioTapChanger3, position1, position2, position3, currentLimits1, currentLimits2, currentLimits3, bus1, connectableBus1, bus2, connectableBus2, bus3, connectableBus3
+SELECT networkUuid, id, voltageLevelId1, voltageLevelId2, voltageLevelId3, name, fictitious, properties, node1, node2, node3, ratedU0, p1, q1, r1, x1, g1, b1, ratedU1, ratedS1, phaseTapChanger1, ratioTapChanger1, p2, q2, r2, x2, g2, b2, ratedU2, ratedS2, phaseTapChanger2, ratioTapChanger2, p3, q3, r3, x3, g3, b3, ratedU3, ratedS3, phaseTapChanger3, ratioTapChanger3, position1, position2, position3, currentLimits1, currentLimits2, currentLimits3, bus1, connectableBus1, bus2, connectableBus2, bus3, connectableBus3
 FROM iidm.threeWindingsTransformer
 WHERE networkUuid IS NOT NULL AND id IS NOT NULL AND voltageLevelId3 IS NOT NULL
     PRIMARY KEY (networkUuid, voltageLevelId3, id);
@@ -571,6 +584,7 @@ CREATE TABLE IF NOT EXISTS iidm.line (
     voltageLevelId1 text,
     voltageLevelId2 text,
     name text,
+    fictitious boolean,
     properties frozen<map<text, text>>,
     node1 int,
     node2 int,
@@ -597,13 +611,13 @@ CREATE TABLE IF NOT EXISTS iidm.line (
 );
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS iidm.lineByVoltageLevel1 AS
-SELECT networkUuid, id, voltageLevelId1, voltageLevelId2, name, properties, node1, node2, r, x, g1, b1, g2, b2, p1, q1, p2, q2, position1, position2, bus1, bus2, connectableBus1, connectableBus2, mergedXnode, currentLimits1, currentLimits2
+SELECT networkUuid, id, voltageLevelId1, voltageLevelId2, name, fictitious, properties, node1, node2, r, x, g1, b1, g2, b2, p1, q1, p2, q2, position1, position2, bus1, bus2, connectableBus1, connectableBus2, mergedXnode, currentLimits1, currentLimits2
 FROM iidm.line
 WHERE networkUuid IS NOT NULL AND id IS NOT NULL AND voltageLevelId1 IS NOT NULL
     PRIMARY KEY (networkUuid, voltageLevelId1, id);
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS iidm.lineByVoltageLevel2 AS
-SELECT networkUuid, id, voltageLevelId1, voltageLevelId2, name, properties, node1, node2, r, x, g1, b1, g2, b2, p1, q1, p2, q2, position1, position2, bus1, bus2, connectableBus1, connectableBus2, mergedXnode, currentLimits1, currentLimits2
+SELECT networkUuid, id, voltageLevelId1, voltageLevelId2, name, fictitious, properties, node1, node2, r, x, g1, b1, g2, b2, p1, q1, p2, q2, position1, position2, bus1, bus2, connectableBus1, connectableBus2, mergedXnode, currentLimits1, currentLimits2
 FROM iidm.line
 WHERE networkUuid IS NOT NULL AND id IS NOT NULL AND voltageLevelId2 IS NOT NULL
     PRIMARY KEY (networkUuid, voltageLevelId2, id);
@@ -612,6 +626,7 @@ CREATE TABLE IF NOT EXISTS iidm.hvdcLine (
     networkUuid uuid,
     id text,
     name text,
+    fictitious boolean,
     properties frozen<map<text, text>>,
     r double,
     convertersMode text,
@@ -639,6 +654,7 @@ CREATE TABLE IF NOT EXISTS iidm.danglingLine (
     id text,
     voltageLevelId text,
     name text,
+    fictitious boolean,
     properties frozen<map<text, text>>,
     node int,
     p0 double,
@@ -659,7 +675,7 @@ CREATE TABLE IF NOT EXISTS iidm.danglingLine (
 );
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS iidm.danglingLineByVoltageLevel AS
-SELECT networkUuid, id, voltageLevelId, name, properties, node, p0, q0, r, x, g, b, generation, ucteXNodeCode, currentLimits, p, q, position, bus, connectableBus
+SELECT networkUuid, id, voltageLevelId, name, fictitious, properties, node, p0, q0, r, x, g, b, generation, ucteXNodeCode, currentLimits, p, q, position, bus, connectableBus
 FROM iidm.danglingLine
 WHERE networkUuid IS NOT NULL AND id IS NOT NULL AND voltageLevelId IS NOT NULL
     PRIMARY KEY (networkUuid, voltageLevelId, id);
@@ -669,6 +685,7 @@ CREATE TABLE IF NOT EXISTS iidm.configuredBus (
     id text,
     voltageLevelId text,
     name text,
+    fictitious boolean,
     properties frozen<map<text, text>>,
     v double,
     angle double,
@@ -676,7 +693,7 @@ CREATE TABLE IF NOT EXISTS iidm.configuredBus (
 );
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS iidm.configuredBusByVoltageLevel AS
-SELECT networkUuid, id, voltageLevelId, name, properties, v, angle
+SELECT networkUuid, id, voltageLevelId, name, fictitious, properties, v, angle
 FROM iidm.configuredBus
 WHERE networkUuid IS NOT NULL AND id IS NOT NULL AND voltageLevelId IS NOT NULL
 PRIMARY KEY (networkUuid, voltageLevelId, id);


### PR DESCRIPTION
Signed-off-by: Slimane AMAR <slimane.amar@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug


**What is the current behavior?** *(You can also link to an open issue here)*
The  'fictitious'  attribute is not store to Cassandra for some resources


**What is the new behavior (if this is a feature change)?**
The  'fictitious'  attribute is now store to Cassandra for all resources


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*
No

**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
