### PR TITLE
Fix concurrency issue

### DIFF
--- a/network-store-client/src/main/java/com/powsybl/network/store/client/RestClient.java
+++ b/network-store-client/src/main/java/com/powsybl/network/store/client/RestClient.java
@@ -10,6 +10,7 @@ import com.powsybl.commons.PowsyblException;
 import com.powsybl.network.store.model.IdentifiableAttributes;
 import com.powsybl.network.store.model.Resource;
 import com.powsybl.network.store.model.TopLevelDocument;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.*;
 import org.springframework.web.client.RestTemplate;
@@ -23,8 +24,8 @@ public class RestClient {
 
     private final RestTemplate restTemplate;
 
-    public RestClient(RestTemplate restTemplate) {
-        this.restTemplate = Objects.requireNonNull(restTemplate);
+    public RestClient(RestTemplateBuilder restTemplateBuilder) {
+        this.restTemplate = Objects.requireNonNull(restTemplateBuilder).errorHandler(new RestTemplateResponseErrorHandler()).build();
     }
 
     private <T extends IdentifiableAttributes> ResponseEntity<TopLevelDocument<T>> getDocument(String url, Object... uriVariables) {

--- a/network-store-client/src/main/java/com/powsybl/network/store/client/RestNetworkStoreClient.java
+++ b/network-store-client/src/main/java/com/powsybl/network/store/client/RestNetworkStoreClient.java
@@ -15,14 +15,10 @@ import com.powsybl.network.store.iidm.impl.ResourceUpdaterImpl;
 import com.powsybl.network.store.model.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.util.UriComponentsBuilder;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -39,8 +35,8 @@ public class RestNetworkStoreClient implements NetworkStoreClient {
 
     private ResourceUpdater resourceUpdater;
 
-    public RestNetworkStoreClient(RestTemplateBuilder restTemplateBuilder) {
-        restClient = new RestClient(restTemplateBuilder.errorHandler(new RestTemplateResponseErrorHandler()).build());
+    public RestNetworkStoreClient(RestClient restClient) {
+        this.restClient = Objects.requireNonNull(restClient);
         resourceUpdater = new ResourceUpdaterImpl(this);
     }
 

--- a/network-store-client/src/test/java/com/powsybl/network/store/client/CachedNetworkStoreClientTest.java
+++ b/network-store-client/src/test/java/com/powsybl/network/store/client/CachedNetworkStoreClientTest.java
@@ -40,12 +40,12 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
  * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
  */
 @RunWith(SpringRunner.class)
-@RestClientTest(RestNetworkStoreClient.class)
-@ContextConfiguration(classes = RestNetworkStoreClient.class)
+@RestClientTest(RestClient.class)
+@ContextConfiguration(classes = RestClient.class)
 public class CachedNetworkStoreClientTest {
 
     @Autowired
-    private RestNetworkStoreClient restStoreClient;
+    private RestClient restClient;
 
     @Autowired
     private MockRestServiceServer server;
@@ -55,8 +55,11 @@ public class CachedNetworkStoreClientTest {
 
     private ResourceUpdater resourceUpdater;
 
+    private RestNetworkStoreClient restStoreClient;
+
     @Before
     public void setUp() throws IOException {
+        restStoreClient = new RestNetworkStoreClient(restClient);
         resourceUpdater = new ResourceUpdaterImpl(restStoreClient);
     }
 

--- a/network-store-client/src/test/java/com/powsybl/network/store/client/PreloadingNetworkStoreClientTest.java
+++ b/network-store-client/src/test/java/com/powsybl/network/store/client/PreloadingNetworkStoreClientTest.java
@@ -39,12 +39,12 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
  * @author Etienne Homer <etienne.homer at rte-france.com>
  */
 @RunWith(SpringRunner.class)
-@RestClientTest(PreloadingNetworkStoreClientTest.class)
-@ContextConfiguration(classes = RestNetworkStoreClient.class)
+@RestClientTest(RestClient.class)
+@ContextConfiguration(classes = RestClient.class)
 public class PreloadingNetworkStoreClientTest {
 
     @Autowired
-    private RestNetworkStoreClient restStoreClient;
+    private RestClient restClient;
 
     @Autowired
     private MockRestServiceServer server;
@@ -52,12 +52,14 @@ public class PreloadingNetworkStoreClientTest {
     @Autowired
     private ObjectMapper objectMapper;
 
+    private RestNetworkStoreClient restStoreClient;
     private PreloadingNetworkStoreClient cachedClient;
     private ResourceUpdater resourceUpdater;
     private UUID networkUuid;
 
     @Before
     public void setUp() throws IOException {
+        restStoreClient = new RestNetworkStoreClient(restClient);
         cachedClient = new PreloadingNetworkStoreClient(new BufferedNetworkStoreClient(restStoreClient));
         resourceUpdater = new ResourceUpdaterImpl(cachedClient);
         networkUuid = UUID.fromString("7928181c-7977-4592-ba19-88027e4254e4");

--- a/network-store-client/src/test/java/com/powsybl/network/store/client/RestNetworkStoreClientTest.java
+++ b/network-store-client/src/test/java/com/powsybl/network/store/client/RestNetworkStoreClientTest.java
@@ -40,12 +40,12 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 @RunWith(SpringRunner.class)
-@RestClientTest(RestNetworkStoreClient.class)
-@ContextConfiguration(classes = RestNetworkStoreClient.class)
+@RestClientTest(RestClient.class)
+@ContextConfiguration(classes = RestClient.class)
 public class RestNetworkStoreClientTest {
 
     @Autowired
-    private RestNetworkStoreClient restStoreClient;
+    private RestClient restClient;
 
     @Autowired
     private MockRestServiceServer server;
@@ -57,6 +57,8 @@ public class RestNetworkStoreClientTest {
 
     @Before
     public void setUp() throws IOException {
+        resourceUpdater = new ResourceUpdaterImpl(new RestNetworkStoreClient(restClient));
+
         UUID networkUuid = UUID.fromString("7928181c-7977-4592-ba19-88027e4254e4");
         Resource<NetworkAttributes> n1 = Resource.networkBuilder()
                 .id("n1")
@@ -161,13 +163,11 @@ public class RestNetworkStoreClientTest {
         server.expect(requestTo("/networks/" + networkUuid + "/lines"))
                 .andExpect(method(GET))
                 .andRespond(withSuccess(linesJson, MediaType.APPLICATION_JSON));
-
-        resourceUpdater = new ResourceUpdaterImpl(restStoreClient);
     }
 
     @Test
     public void test() {
-        try (NetworkStoreService service = new NetworkStoreService(restStoreClient, PreloadingStrategy.NONE)) {
+        try (NetworkStoreService service = new NetworkStoreService(restClient, PreloadingStrategy.NONE)) {
             assertEquals(Collections.singletonMap(UUID.fromString("7928181c-7977-4592-ba19-88027e4254e4"), "n1"), service.getNetworkIds());
             Network network = service.getNetwork(UUID.fromString("7928181c-7977-4592-ba19-88027e4254e4"));
             assertEquals("n1", network.getId());

--- a/network-store-iidm-tck/src/test/java/com/powsybl/network/store/tck/cassandra/NetworkFactoryTestService.java
+++ b/network-store-iidm-tck/src/test/java/com/powsybl/network/store/tck/cassandra/NetworkFactoryTestService.java
@@ -30,7 +30,7 @@ public class NetworkFactoryTestService implements NetworkFactoryService {
     public NetworkFactory createNetworkFactory() {
         String networkStoreBaseUrl = PlatformConfig.defaultConfig().getModuleConfig("network-store")
                 .getStringProperty("base-url");
-        return new NetworkFactoryImpl(
-            () -> new RestNetworkStoreClient(NetworkStoreService.createRestTemplateBuilder(networkStoreBaseUrl)));
+        RestClient restClient = new RestClient(NetworkStoreService.createRestTemplateBuilder(networkStoreBaseUrl));
+        return new NetworkFactoryImpl(() -> new RestNetworkStoreClient(restClient));
     }
 }


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
When network store server is accessed concurrently we sometimes end up with such an exception:
```java
essing failed; nested exception is java.util.ConcurrentModificationException] with root cause

java.util.ConcurrentModificationException: null
	at java.base/java.util.HashMap.computeIfAbsent(HashMap.java:1134) ~[na:na]
	at com.powsybl.network.store.iidm.impl.CollectionCache.getResourcesByContainerId(CollectionCache.java:159) ~[powsybl-network-store-iidm-impl-1.0.0-SNAPSHOT.jar:na]
	at com.powsybl.network.store.iidm.impl.CollectionCache.lambda$addResource$5(CollectionCache.java:201) ~[powsybl-network-store-iidm-impl-1.0.0-SNAPSHOT.jar:na]
	at java.base/java.util.Collections$SingletonSet.forEach(Collections.java:4797) ~[na:na]
	at com.powsybl.network.store.iidm.impl.CollectionCache.addResource(CollectionCache.java:201) ~[powsybl-network-store-iidm-impl-1.0.0-SNAPSHOT.jar:na]
	at com.powsybl.network.store.iidm.impl.CollectionCache.updateResource(CollectionCache.java:222) ~[powsybl-network-store-iidm-impl-1.0.0-SNAPSHOT.jar:na]
	at com.powsybl.network.store.iidm.impl.CachedNetworkStoreClient.updateVoltageLevel(CachedNetworkStoreClient.java:254) ~[powsybl-network-store-iidm-impl-1.0.0-SNAPSHOT.jar:na]
	at com.powsybl.network.store.iidm.impl.ForwardingNetworkStoreClient.updateVoltageLevel(ForwardingNetworkStoreClient.java:18) ~[powsybl-network-store-iidm-impl-1.0.0-SNAPSHOT.jar:na]
	at com.powsybl.network.store.iidm.impl.ResourceUpdaterImpl.updateResource(ResourceUpdaterImpl.java:33) ~[powsybl-network-store-iidm-impl-1.0.0-SNAPSHOT.jar:na]
	at com.powsybl.network.store.model.AbstractAttributes.updateResource(AbstractAttributes.java:35) ~[powsybl-network-store-model-1.0.0-SNAPSHOT.jar:na]
	at com.powsybl.network.store.model.VoltageLevelAttributes$ByteBuddy$UE4slHL2.setCalculatedBuses(Unknown Source) ~[na:na]
	at com.powsybl.network.store.iidm.impl.AbstractTopology.getCalculatedBusAttributesList(AbstractTopology.java:341) ~[powsybl-network-store-iidm-impl-1.0.0-SNAPSHOT.jar:na]
	at com.powsybl.network.store.iidm.impl.AbstractTopology.calculateBus(AbstractTopology.java:371) ~[powsybl-network-store-iidm-impl-1.0.0-SNAPSHOT.jar:na]
	at com.powsybl.network.store.iidm.impl.TerminalBusViewImpl.getBus(TerminalBusViewImpl.java:40) ~[powsybl-network-store-iidm-impl-1.0.0-SNAPSHOT.jar:na]
	at com.powsybl.network.store.iidm.impl.TerminalImpl.isConnected(TerminalImpl.java:296) ~[powsybl-network-store-iidm-impl-1.0.0-SNAPSHOT.jar:na]
	at org.gridsuite.network.map.NetworkMapService.toMapData(NetworkMapService.java:140) ~[classes/:na]
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195) ~[na:na]
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1655) ~[na:na]
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484) ~[na:na]
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474) ~[na:na]
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913) ~[na:na]
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[na:na]
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578) ~[na:na]
	at org.gridsuite.network.map.NetworkMapService.getTwoWindingsTransformers(NetworkMapService.java:458) ~[classes/:na]
	at org.gridsuite.network.map.NetworkMapController.getTwoWindingsTransformers(NetworkMapController.java:77) ~[classes/:na]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:na]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:na]
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:na]
	at java.base/java.lang.reflect.Method.invoke(Method.java:566) ~[na:na]
	at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:190) ~[spring-web-5.2.8.RELEASE.jar:5.2.8.RELEASE]
	at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:138) ~[spring-web-5.2.8.RELEASE.jar:5.2.8.RELEASE]
	at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:105) ~[spring-webmvc-5.2.8.RELEASE.jar:5.2.8.RELEASE]
	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandlerMethod(RequestMappingHandlerAdapter.java:878) ~[spring-webmvc-5.2.8.RELEASE.jar:5.2.8.RELEASE]
	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:792) ~[spring-webmvc-5.2.8.RELEASE.jar:5.2.8.RELEASE]
	at org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:87) ~[spring-webmvc-5.2.8.RELEASE.jar:5.2.8.RELEASE]
	at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1040) ~[spring-webmvc-5.2.8.RELEASE.jar:5.2.8.RELEASE]
	at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:943) ~[spring-webmvc-5.2.8.RELEASE.jar:5.2.8.RELEASE]
	at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1006) ~[spring-webmvc-5.2.8.RELEASE.jar:5.2.8.RELEASE]
	at org.springframework.web.servlet.FrameworkServlet.doGet(FrameworkServlet.java:898) ~[spring-webmvc-5.2.8.RELEASE.jar:5.2.8.RELEASE]
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:626) ~[tomcat-embed-core-9.0.37.jar:4.0.FR]
	at org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:883) ~[spring-webmvc-5.2.8.RELEASE.jar:5.2.8.RELEASE]
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:733) ~[tomcat-embed-core-9.0.37.jar:4.0.FR]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:231) ~[tomcat-embed-core-9.0.37.jar:9.0.37]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166) ~[tomcat-embed-core-9.0.37.jar:9.0.37]
	at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:53) ~[tomcat-embed-websocket-9.0.37.jar:9.0.37]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193) ~[tomcat-embed-core-9.0.37.jar:9.0.37]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166) ~[tomcat-embed-core-9.0.37.jar:9.0.37]
	at org.springframework.web.filter.RequestContextFilter.doFilterInternal(RequestContextFilter.java:100) ~[spring-web-5.2.8.RELEASE.jar:5.2.8.RELEASE]
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:119) ~[spring-web-5.2.8.RELEASE.jar:5.2.8.RELEASE]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193) ~[tomcat-embed-core-9.0.37.jar:9.0.37]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166) ~[tomcat-embed-core-9.0.37.jar:9.0.37]
	at org.springframework.web.filter.FormContentFilter.doFilterInternal(FormContentFilter.java:93) ~[spring-web-5.2.8.RELEASE.jar:5.2.8.RELEASE]
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:119) ~[spring-web-5.2.8.RELEASE.jar:5.2.8.RELEASE]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193) ~[tomcat-embed-core-9.0.37.jar:9.0.37]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166) ~[tomcat-embed-core-9.0.37.jar:9.0.37]
	at org.springframework.boot.actuate.metrics.web.servlet.WebMvcMetricsFilter.doFilterInternal(WebMvcMetricsFilter.java:109) ~[spring-boot-actuator-2.2.9.RELEASE.jar:2.2.9.RELEASE]
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:119) ~[spring-web-5.2.8.RELEASE.jar:5.2.8.RELEASE]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193) ~[tomcat-embed-core-9.0.37.jar:9.0.37]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166) ~[tomcat-embed-core-9.0.37.jar:9.0.37]
	at org.springframework.web.filter.CharacterEncodingFilter.doFilterInternal(CharacterEncodingFilter.java:201) ~[spring-web-5.2.8.RELEASE.jar:5.2.8.RELEASE]
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:119) ~[spring-web-5.2.8.RELEASE.jar:5.2.8.RELEASE]
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193) ~[tomcat-embed-core-9.0.37.jar:9.0.37]
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166) ~[tomcat-embed-core-9.0.37.jar:9.0.37]
	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:202) ~[tomcat-embed-core-9.0.37.jar:9.0.37]
	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:96) ~[tomcat-embed-core-9.0.37.jar:9.0.37]
	at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:541) ~[tomcat-embed-core-9.0.37.jar:9.0.37]
	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:139) ~[tomcat-embed-core-9.0.37.jar:9.0.37]
	at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:92) ~[tomcat-embed-core-9.0.37.jar:9.0.37]
	at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:74) ~[tomcat-embed-core-9.0.37.jar:9.0.37]
	at org.apache.catalina.valves.RemoteIpValve.invoke(RemoteIpValve.java:747) ~[tomcat-embed-core-9.0.37.jar:9.0.37]
	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:343) ~[tomcat-embed-core-9.0.37.jar:9.0.37]
	at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:373) ~[tomcat-embed-core-9.0.37.jar:9.0.37]
	at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:65) ~[tomcat-embed-core-9.0.37.jar:9.0.37]
	at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:868) ~[tomcat-embed-core-9.0.37.jar:9.0.37]
	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1589) ~[tomcat-embed-core-9.0.37.jar:9.0.37]
	at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:49) ~[tomcat-embed-core-9.0.37.jar:9.0.37]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[na:na]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[na:na]
	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61) ~[tomcat-embed-core-9.0.37.jar:9.0.37]
	at java.base/java.lang.Thread.run(Thread.java:834) ~[na:na]
```

The problem is that `RestNetworkClientStore` is a singleton (so common instance for all requests) but is stateful (though resourceUpdater field).

**What is the new behavior (if this is a feature change)?**
A dedicated instance of `RestNetworkClientStore` is created for each request.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
