### PR TITLE
add_aliases_to_battery_attr_constructor

### DIFF
--- a/network-store-model/src/main/java/com/powsybl/network/store/model/BatteryAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/BatteryAttributes.java
@@ -83,6 +83,8 @@ public class BatteryAttributes extends AbstractAttributes implements InjectionAt
         this.name = other.name;
         this.fictitious = other.fictitious;
         this.properties = other.properties;
+        this.aliasesWithoutType = other.aliasesWithoutType;
+        this.aliasByType = other.aliasByType;
         this.node = other.node;
         this.bus = other.bus;
         this.connectableBus = other.connectableBus;


### PR DESCRIPTION
Signed-off-by: HOMER Etienne <etiennehomer@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem ?**


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Aliases are not taken in the constructor BatteryAttributes(BatteryAttributes other)


**What is the new behavior (if this is a feature change)?**
Aliases are copied in this constructor.

