### PR TITLE
 Bug fix for bus/breaker vertices in a calculated bus (get only connected terminals)

### DIFF
--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/BusBreakerTopology.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/BusBreakerTopology.java
@@ -32,7 +32,7 @@ public class BusBreakerTopology extends AbstractTopology<String> {
 
     @Override
     public <U extends InjectionAttributes> String getInjectionNodeOrBus(Resource<U> resource) {
-        return resource.getAttributes().getConnectableBus();
+        return resource.getAttributes().getBus();
     }
 
     @Override

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/BusBreakerTerminalTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/BusBreakerTerminalTest.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.network.store.iidm.impl;
 
+import com.google.common.collect.Lists;
 import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.Bus;
 import com.powsybl.iidm.network.Network;
@@ -37,13 +38,15 @@ public class BusBreakerTerminalTest {
         assertEquals(gt.getBusView().getBus(), gt.getBusView().getConnectableBus());
         assertEquals(l1t.getBusView().getBus(), l1t.getBusView().getConnectableBus());
         assertEquals(5, vl1.getBusView().getBus("VL1_0").getConnectedTerminalCount());
+        assertEquals(5, Lists.newArrayList(vl1.getBusView().getBus("VL1_0").getConnectedTerminals()).size());
 
         assertTrue(gt.disconnect());
         assertFalse(gt.isConnected());
         assertNull(gt.getBusView().getBus());
         assertNotNull(gt.getBusView().getConnectableBus());
         assertEquals(vl1.getBusView().getBus("VL1_0"), gt.getBusView().getConnectableBus());
-        assertEquals(5, vl1.getBusView().getBus("VL1_0").getConnectedTerminalCount());
+        assertEquals(4, vl1.getBusView().getBus("VL1_0").getConnectedTerminalCount());
+        assertEquals(4, Lists.newArrayList(vl1.getBusView().getBus("VL1_0").getConnectedTerminals()).size());
 
         assertTrue(l1t.disconnect());
         assertFalse(l1t.isConnected());
@@ -57,6 +60,9 @@ public class BusBreakerTerminalTest {
         assertTrue(gt.connect());
         assertTrue(gt.isConnected());
         assertEquals(vl1.getBusView().getBus("VL1_0"), gt.getBusView().getConnectableBus());
+
+        assertEquals(5, vl1.getBusView().getBus("VL1_0").getConnectedTerminalCount());
+        assertEquals(5, Lists.newArrayList(vl1.getBusView().getBus("VL1_0").getConnectedTerminals()).size());
 
         gt.setP(100);
         l1t.setP(-50);
@@ -130,9 +136,7 @@ public class BusBreakerTerminalTest {
         Terminal l2t = network.getLine("L1").getTerminal2();
 
         Terminal.BusBreakerView gtbbv = gt.getBusBreakerView();
-        assertTrue(assertThrows(PowsyblException.class, () -> {
-            gtbbv.setConnectableBus("FOO");
-        }).getMessage().contains("FOO not found"));
+        assertTrue(assertThrows(PowsyblException.class, () -> gtbbv.setConnectableBus("FOO")).getMessage().contains("FOO not found"));
 
         gt.getBusBreakerView().setConnectableBus("B1");
         assertFalse(((VoltageLevelImpl) vl1).getResource().getAttributes().isCalculatedBusesValid());


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
Yes
Load flow calculation fails when a dangling line is disconnected in bus/breaker topology


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
When a calculation of buses is done for a  bus/breaker  VL, all terminals are used to create the vertices and not only the  connected terminals


**What is the new behavior (if this is a feature change)?**
When a calculation of buses is done for a  bus/breaker  VL, only connected terminals are used to create the vertices


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
No

