### PR TITLE
Fix network preloading performance issue

### DIFF
--- a/network-store-client/src/main/java/com/powsybl/network/store/client/PreloadingNetworkStoreClient.java
+++ b/network-store-client/src/main/java/com/powsybl/network/store/client/PreloadingNetworkStoreClient.java
@@ -28,7 +28,7 @@ public class PreloadingNetworkStoreClient extends AbstractForwardingNetworkStore
     private void loadToCache(ResourceType resourceType, UUID networkUuid) {
         switch (resourceType) {
             case NETWORK:
-                delegate.getNetwork(networkUuid);
+                delegate.getNetwork(networkUuid); // we only need to load the network with the specified UUID
                 break;
             case SUBSTATION:
                 delegate.getSubstations(networkUuid);

--- a/network-store-client/src/main/java/com/powsybl/network/store/client/PreloadingNetworkStoreClient.java
+++ b/network-store-client/src/main/java/com/powsybl/network/store/client/PreloadingNetworkStoreClient.java
@@ -28,7 +28,7 @@ public class PreloadingNetworkStoreClient extends AbstractForwardingNetworkStore
     private void loadToCache(ResourceType resourceType, UUID networkUuid) {
         switch (resourceType) {
             case NETWORK:
-                delegate.getNetworks();
+                delegate.getNetwork(networkUuid);
                 break;
             case SUBSTATION:
                 delegate.getSubstations(networkUuid);


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
When preloading collection is on, all network resources instances are preloaded not only the asked one.


**What is the new behavior (if this is a feature change)?**
Only the right network  resource instance is preloaded


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
