### PR TITLE
Improve bus equipment visitor performance

### DIFF
--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/CalculatedBus.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/CalculatedBus.java
@@ -206,7 +206,7 @@ public final class CalculatedBus implements BaseBus {
     public Collection<Terminal> getConnectedTerminals() {
         return getAttributes().getVertices().stream()
                 .map(v -> {
-                    Connectable c = (Connectable) index.getIdentifiable(v.getId());
+                    Connectable<?> c = index.getConnectable(v.getId(), v.getConnectableType());
                     switch (c.getType()) {
                         case LINE:
                         case TWO_WINDINGS_TRANSFORMER:
@@ -214,7 +214,7 @@ public final class CalculatedBus implements BaseBus {
                         case THREE_WINDINGS_TRANSFORMER:
                             return ((ThreeWindingsTransformerImpl) c).getTerminal(ThreeWindingsTransformer.Side.valueOf(v.getSide()));
                         default:
-                            return (Terminal) c.getTerminals().get(0);
+                            return c.getTerminals().get(0);
                     }
                 })
                 .collect(Collectors.toList());

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkObjectIndex.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkObjectIndex.java
@@ -749,6 +749,43 @@ public class NetworkObjectIndex {
                 .build();
     }
 
+    public Connectable<?> getConnectable(String connectableId, ConnectableType connectableType) {
+        switch (connectableType) {
+            case BUSBAR_SECTION:
+                return getBusbarSection(connectableId).orElse(null);
+            case LINE:
+                return getLine(connectableId).orElse(null);
+            case TWO_WINDINGS_TRANSFORMER:
+                return getTwoWindingsTransformer(connectableId).orElse(null);
+            case THREE_WINDINGS_TRANSFORMER:
+                return getThreeWindingsTransformer(connectableId).orElse(null);
+            case GENERATOR:
+                return getGenerator(connectableId).orElse(null);
+            case BATTERY:
+                return getBattery(connectableId).orElse(null);
+            case LOAD:
+                return getLoad(connectableId).orElse(null);
+            case SHUNT_COMPENSATOR:
+                return getShuntCompensator(connectableId).orElse(null);
+            case DANGLING_LINE:
+                return getDanglingLine(connectableId).orElse(null);
+            case STATIC_VAR_COMPENSATOR:
+                return getStaticVarCompensator(connectableId).orElse(null);
+            case HVDC_CONVERTER_STATION:
+                return getHvdcConverterStation(connectableId).orElse(null);
+            default:
+                throw new IllegalStateException("Unexpected connectable type:" + connectableType);
+        }
+    }
+
+    /**
+     * WARNING!!!!!!!!!!!!!!!!!!
+     * This method should be used used with caution as it does not fit well with NONE mode pre-loading.
+     * As it tries to search for an unknown typed element id in all per element cache and that most of the time
+     * the element won't be in the cache (think case where we try to get an generator, for sure we won't find it
+     * in load, shunt and all the other cache type) and consequently we end up with a lot of request to the server to search
+     * for something that does not exist.
+     */
     public Identifiable<?> getIdentifiable(String id) {
         Objects.requireNonNull(id);
         if (network.getId().equals(id)) {


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Performance improvement


**What is the current behavior?** *(You can also link to an open issue here)*
We have poor performance with pre loading set to none and when we visit equipment connected to a bus.


**What is the new behavior (if this is a feature change)?**
Performance has been improve by avoiding using getIdentifiable method but typed getConnectable one. We avoid avoid a lot a equipment search request to the server.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
