### PR TITLE
Addition of BranchStatus extension and its storage.

### DIFF
--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractBranchImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractBranchImpl.java
@@ -310,6 +310,7 @@ public abstract class AbstractBranchImpl<T extends Branch<T>, U extends BranchAt
     }
 
     public Branch setBranchStatus(BranchStatus.Status branchStatus) {
+        Objects.requireNonNull(branchStatus);
         String oldValue = resource.getAttributes().getBranchStatus();
         resource.getAttributes().setBranchStatus(branchStatus.name());
         updateResource();

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractBranchImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractBranchImpl.java
@@ -10,6 +10,8 @@ import com.powsybl.commons.extensions.Extension;
 import com.powsybl.iidm.network.*;
 import com.powsybl.network.store.iidm.impl.ConnectablePositionAdderImpl.ConnectablePositionCreator;
 import com.powsybl.network.store.model.*;
+import com.powsybl.sld.iidm.extensions.BranchStatus;
+import com.powsybl.sld.iidm.extensions.BranchStatusImpl;
 import com.powsybl.sld.iidm.extensions.ConnectablePosition;
 import com.powsybl.sld.iidm.extensions.ConnectablePosition.Feeder;
 
@@ -303,6 +305,16 @@ public abstract class AbstractBranchImpl<T extends Branch<T>, U extends BranchAt
         throw new UnsupportedOperationException("TODO");
     }
 
+    public BranchStatus.Status getBranchStatus() {
+        return BranchStatus.Status.valueOf(resource.getAttributes().getBranchStatus());
+    }
+
+    public Branch setBranchStatus(BranchStatus.Status branchStatus) {
+        resource.getAttributes().setBranchStatus(branchStatus.name());
+        updateResource();
+        return this;
+    }
+
     @Override
     public <E extends Extension<T>> void addExtension(Class<? super E> type, E extension) {
         if (type == ConnectablePosition.class) {
@@ -310,6 +322,9 @@ public abstract class AbstractBranchImpl<T extends Branch<T>, U extends BranchAt
             resource.getAttributes().setPosition1(connectablePositionExtension.getFeeder1().getConnectablePositionAttributes());
             resource.getAttributes().setPosition2(connectablePositionExtension.getFeeder2().getConnectablePositionAttributes());
             updateResource();
+        } else if (type == BranchStatus.class) {
+            BranchStatus branchStatus = (BranchStatus) extension;
+            setBranchStatus(branchStatus.getStatus());
         } else {
             super.addExtension(type, extension);
         }
@@ -340,11 +355,22 @@ public abstract class AbstractBranchImpl<T extends Branch<T>, U extends BranchAt
                 null);
     }
 
+    private <E extends Extension<T>> E createBranchStatusExtension() {
+        E extension = null;
+        String branchStatus = resource.getAttributes().getBranchStatus();
+        if (branchStatus != null) {
+            extension = (E) new BranchStatusImpl(this, BranchStatus.Status.valueOf(branchStatus));
+        }
+        return extension;
+    }
+
     @Override
     public <E extends Extension<T>> E getExtension(Class<? super E> type) {
         E extension;
         if (type == ConnectablePosition.class) {
             extension = (E) connectablePositionExtension;
+        } else if (type == BranchStatus.class) {
+            extension = (E) createBranchStatusExtension();
         } else {
             extension = super.getExtension(type);
         }
@@ -356,6 +382,8 @@ public abstract class AbstractBranchImpl<T extends Branch<T>, U extends BranchAt
         E extension;
         if (name.equals("position")) {
             extension = (E) connectablePositionExtension;
+        } else if (name.equals("branchStatus")) {
+            extension = (E) createBranchStatusExtension();
         } else {
             extension = super.getExtensionByName(name);
         }
@@ -367,6 +395,10 @@ public abstract class AbstractBranchImpl<T extends Branch<T>, U extends BranchAt
         Collection<E> extensions = super.getExtensions();
         if (connectablePositionExtension != null) {
             extensions.add((E) connectablePositionExtension);
+        }
+        E branchStatusExtension = createBranchStatusExtension();
+        if (branchStatusExtension != null) {
+            extensions.add(branchStatusExtension);
         }
         return extensions;
     }

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractBranchImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractBranchImpl.java
@@ -314,7 +314,7 @@ public abstract class AbstractBranchImpl<T extends Branch<T>, U extends BranchAt
         String oldValue = resource.getAttributes().getBranchStatus();
         resource.getAttributes().setBranchStatus(branchStatus.name());
         updateResource();
-        notifyUpdate("branchStatus", branchStatus.name(), oldValue != null ? oldValue : BranchStatus.Status.IN_OPERATION.name(), false);
+        notifyUpdate("branchStatus", oldValue != null ? oldValue : BranchStatus.Status.IN_OPERATION.name(), branchStatus.name(), false);
         return this;
     }
 

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractBranchImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractBranchImpl.java
@@ -310,8 +310,10 @@ public abstract class AbstractBranchImpl<T extends Branch<T>, U extends BranchAt
     }
 
     public Branch setBranchStatus(BranchStatus.Status branchStatus) {
+        String oldValue = resource.getAttributes().getBranchStatus();
         resource.getAttributes().setBranchStatus(branchStatus.name());
         updateResource();
+        notifyUpdate("branchStatus", branchStatus.name(), oldValue != null ? oldValue : BranchStatus.Status.IN_OPERATION.name(), false);
         return this;
     }
 

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/TerminalImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/TerminalImpl.java
@@ -150,7 +150,7 @@ public class TerminalImpl<U extends InjectionAttributes> implements Terminal, Va
     private boolean connectNodeBreaker(Resource<VoltageLevelAttributes> voltageLevelResource) {
         boolean done = false;
 
-        Graph<Integer, Edge> graph = NodeBreakerTopology.INSTANCE.buildGraph(index, voltageLevelResource, true);
+        Graph<Integer, Edge> graph = NodeBreakerTopology.INSTANCE.buildGraph(index, voltageLevelResource, true, true);
         Set<Integer> busbarSectionNodes = getBusbarSectionNodes(voltageLevelResource);
 
         // exclude open disconnectors and open fictitious breakers to be able to calculate a shortest path without this
@@ -214,7 +214,7 @@ public class TerminalImpl<U extends InjectionAttributes> implements Terminal, Va
         boolean done = false;
 
         // create a graph with only closed switches
-        Graph<Integer, Edge> graph = NodeBreakerTopology.INSTANCE.buildGraph(index, voltageLevelResource, false);
+        Graph<Integer, Edge> graph = NodeBreakerTopology.INSTANCE.buildGraph(index, voltageLevelResource, false, true);
         Set<Integer> busbarSectionNodes = getBusbarSectionNodes(voltageLevelResource);
 
         // inspect connectivity of graph without its non fictitious breakers to check if disconnection is possible

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/TerminalImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/TerminalImpl.java
@@ -173,7 +173,6 @@ public class TerminalImpl<U extends InjectionAttributes> implements Terminal, Va
                             switchAttributes.setOpen(false);
                             index.updateSwitchResource(switchAttributes.getResource());
                             closedSwitches.add(switchAttributes.getResource().getId());
-                            index.notifyUpdate(index.getSwitch(switchAttributes.getResource().getId()).get(), "open", true, false);
                             done = true;
                         }
                     }

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/ThreeWindingsTransformerImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/ThreeWindingsTransformerImpl.java
@@ -384,6 +384,7 @@ public class ThreeWindingsTransformerImpl extends AbstractIdentifiableImpl<Three
     }
 
     public ThreeWindingsTransformer setBranchStatus(BranchStatus.Status branchStatus) {
+        Objects.requireNonNull(branchStatus);
         resource.getAttributes().setBranchStatus(branchStatus.name());
         updateResource();
         return this;

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/extensions/BranchStatusAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/extensions/BranchStatusAdderImpl.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.network.store.iidm.impl.extensions;
+
+import com.powsybl.commons.extensions.AbstractExtensionAdder;
+import com.powsybl.iidm.network.Connectable;
+import com.powsybl.sld.iidm.extensions.BranchStatus;
+import com.powsybl.sld.iidm.extensions.BranchStatusAdder;
+
+/**
+ * @author Nicolas Noir <nicolas.noir at rte-france.com>
+ */
+public class BranchStatusAdderImpl<C extends Connectable<C>>
+        extends AbstractExtensionAdder<C, BranchStatus<C>> implements BranchStatusAdder<C> {
+
+    BranchStatus.Status status;
+
+    protected BranchStatusAdderImpl(C extendable) {
+        super(extendable);
+    }
+
+    @Override
+    protected BranchStatus<C> createExtension(C extendable) {
+        return new BranchStatusImpl<>(extendable, status);
+    }
+
+    @Override
+    public BranchStatusAdder withStatus(BranchStatus.Status branchStatus) {
+        this.status = branchStatus;
+        return this;
+    }
+
+}

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/extensions/BranchStatusAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/extensions/BranchStatusAdderImpl.java
@@ -17,7 +17,7 @@ import com.powsybl.sld.iidm.extensions.BranchStatusAdder;
 public class BranchStatusAdderImpl<C extends Connectable<C>>
         extends AbstractExtensionAdder<C, BranchStatus<C>> implements BranchStatusAdder<C> {
 
-    BranchStatus.Status status;
+    private BranchStatus.Status status = BranchStatus.Status.IN_OPERATION;
 
     protected BranchStatusAdderImpl(C extendable) {
         super(extendable);

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/extensions/BranchStatusAdderImplProvider.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/extensions/BranchStatusAdderImplProvider.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.network.store.iidm.impl.extensions;
+
+import com.google.auto.service.AutoService;
+import com.powsybl.commons.extensions.ExtensionAdderProvider;
+import com.powsybl.iidm.network.Connectable;
+import com.powsybl.sld.iidm.extensions.BranchStatus;
+
+/**
+ * @author Nicolas Noir <nicolas.noir at rte-france.com>
+ */
+@AutoService(ExtensionAdderProvider.class)
+public class BranchStatusAdderImplProvider<C extends Connectable<C>> implements
+        ExtensionAdderProvider<C, BranchStatus<C>, BranchStatusAdderImpl<C>> {
+
+    @Override
+    public String getImplementationName() {
+        return "NetworkStore";
+    }
+
+    @Override
+    public Class<BranchStatusAdderImpl> getAdderClass() {
+        return BranchStatusAdderImpl.class;
+    }
+
+    @Override
+    public BranchStatusAdderImpl<C> newAdder(C connectable) {
+        return new BranchStatusAdderImpl<>(connectable);
+    }
+
+}

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/extensions/BranchStatusImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/extensions/BranchStatusImpl.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.network.store.iidm.impl.extensions;
+
+import com.powsybl.commons.extensions.AbstractExtension;
+import com.powsybl.iidm.network.Connectable;
+import com.powsybl.sld.iidm.extensions.BranchStatus;
+
+/**
+ * @author Nicolas Noir <nicolas.noir at rte-france.com>
+ */
+public class BranchStatusImpl<C extends Connectable<C>> extends AbstractExtension<C> implements BranchStatus<C> {
+
+    private Status status;
+
+    public BranchStatusImpl(C branch) {
+        super(branch);
+    }
+
+    public BranchStatusImpl(C branch, Status branchStatus) {
+        super(branch);
+        this.status = branchStatus;
+    }
+
+    @Override
+    public Status getStatus() {
+        return status;
+    }
+
+    @Override
+    public BranchStatus setStatus(Status branchStatus) {
+        this.status = branchStatus;
+        return this;
+    }
+}

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/extensions/BranchStatusImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/extensions/BranchStatusImpl.java
@@ -10,12 +10,14 @@ import com.powsybl.commons.extensions.AbstractExtension;
 import com.powsybl.iidm.network.Connectable;
 import com.powsybl.sld.iidm.extensions.BranchStatus;
 
+import java.util.Objects;
+
 /**
  * @author Nicolas Noir <nicolas.noir at rte-france.com>
  */
 public class BranchStatusImpl<C extends Connectable<C>> extends AbstractExtension<C> implements BranchStatus<C> {
 
-    private Status status;
+    private Status status = Status.IN_OPERATION;
 
     public BranchStatusImpl(C branch) {
         super(branch);
@@ -23,7 +25,7 @@ public class BranchStatusImpl<C extends Connectable<C>> extends AbstractExtensio
 
     public BranchStatusImpl(C branch, Status branchStatus) {
         super(branch);
-        this.status = branchStatus;
+        this.status = Objects.requireNonNull(branchStatus);
     }
 
     @Override
@@ -33,7 +35,7 @@ public class BranchStatusImpl<C extends Connectable<C>> extends AbstractExtensio
 
     @Override
     public BranchStatus setStatus(Status branchStatus) {
-        this.status = branchStatus;
+        this.status = Objects.requireNonNull(branchStatus);
         return this;
     }
 }

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/BranchStatusExtensionTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/BranchStatusExtensionTest.java
@@ -32,6 +32,7 @@ public class BranchStatusExtensionTest {
         assertNull(line.getExtensionByName("branchStatus"));
         assertEquals(0, line.getExtensions().size());
 
+        assertThrows(NullPointerException.class, () -> line.newExtension(BranchStatusAdder.class).withStatus(null).add());
         line.newExtension(BranchStatusAdder.class).withStatus(BranchStatus.Status.PLANNED_OUTAGE).add();
 
         BranchStatus brs = line.getExtension(BranchStatus.class);
@@ -55,6 +56,7 @@ public class BranchStatusExtensionTest {
         assertNull(twt.getExtension(BranchStatus.class));
         assertEquals(0, twt.getExtensions().size());
 
+        assertThrows(NullPointerException.class, () -> twt.newExtension(BranchStatusAdder.class).withStatus(null).add());
         twt.newExtension(BranchStatusAdder.class).withStatus(BranchStatus.Status.FORCED_OUTAGE).add();
 
         BranchStatus brs = twt.getExtension(BranchStatus.class);
@@ -77,6 +79,7 @@ public class BranchStatusExtensionTest {
         assertNull(twt.getExtension(BranchStatus.class));
         assertEquals(0, twt.getExtensions().size());
 
+        assertThrows(NullPointerException.class, () -> twt.newExtension(BranchStatusAdder.class).withStatus(null).add());
         twt.newExtension(BranchStatusAdder.class).withStatus(BranchStatus.Status.IN_OPERATION).add();
 
         BranchStatus brs = twt.getExtension(BranchStatus.class);

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/BranchStatusExtensionTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/BranchStatusExtensionTest.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.network.store.iidm.impl;
+
+import com.powsybl.iidm.network.Line;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.ThreeWindingsTransformer;
+import com.powsybl.iidm.network.TwoWindingsTransformer;
+import com.powsybl.sld.iidm.extensions.BranchStatus;
+import com.powsybl.sld.iidm.extensions.BranchStatusAdder;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Nicolas Noir <nicolas.noir at rte-france.com>
+ */
+public class BranchStatusExtensionTest {
+
+    @Test
+    public void testLineBranchStatusExtension() {
+        Network network = CreateNetworksUtil.createNodeBreakerNetwokWithMultipleEquipments();
+
+        Line line = network.getLine("LINE1");
+        assertNotNull(line);
+
+        assertNull(line.getExtension(BranchStatus.class));
+        assertNull(line.getExtensionByName("branchStatus"));
+        assertEquals(0, line.getExtensions().size());
+
+        line.newExtension(BranchStatusAdder.class).withStatus(BranchStatus.Status.PLANNED_OUTAGE).add();
+
+        BranchStatus brs = line.getExtension(BranchStatus.class);
+        assertNotNull(brs);
+        assertEquals(BranchStatus.Status.PLANNED_OUTAGE, brs.getStatus());
+
+        brs = line.getExtensionByName("branchStatus");
+        assertNotNull(brs);
+        assertEquals(BranchStatus.Status.PLANNED_OUTAGE, brs.getStatus());
+
+        assertEquals(1, line.getExtensions().size());
+    }
+
+    @Test
+    public void testTwoWindingsTransformerBranchStatusExtension() {
+        Network network = CreateNetworksUtil.createNodeBreakerNetwokWithMultipleEquipments();
+
+        TwoWindingsTransformer twt = network.getTwoWindingsTransformer("TwoWT1");
+        assertNotNull(twt);
+
+        assertNull(twt.getExtension(BranchStatus.class));
+        assertEquals(0, twt.getExtensions().size());
+
+        twt.newExtension(BranchStatusAdder.class).withStatus(BranchStatus.Status.FORCED_OUTAGE).add();
+
+        BranchStatus brs = twt.getExtension(BranchStatus.class);
+        assertNotNull(brs);
+        assertEquals(BranchStatus.Status.FORCED_OUTAGE, brs.getStatus());
+        brs = twt.getExtensionByName("branchStatus");
+        assertNotNull(brs);
+        assertEquals(BranchStatus.Status.FORCED_OUTAGE, brs.getStatus());
+
+        assertEquals(1, twt.getExtensions().size());
+    }
+
+    @Test
+    public void testThreeWindingsTransformerBranchStatusExtension() {
+        Network network = CreateNetworksUtil.createNodeBreakerNetwokWithMultipleEquipments();
+
+        ThreeWindingsTransformer twt = network.getThreeWindingsTransformer("TWT1");
+        assertNotNull(twt);
+
+        assertNull(twt.getExtension(BranchStatus.class));
+        assertEquals(0, twt.getExtensions().size());
+
+        twt.newExtension(BranchStatusAdder.class).withStatus(BranchStatus.Status.IN_OPERATION).add();
+
+        BranchStatus brs = twt.getExtension(BranchStatus.class);
+        assertNotNull(brs);
+        assertEquals(BranchStatus.Status.IN_OPERATION, brs.getStatus());
+        brs = twt.getExtensionByName("branchStatus");
+        assertNotNull(brs);
+        assertEquals(BranchStatus.Status.IN_OPERATION, brs.getStatus());
+
+        assertEquals(1, twt.getExtensions().size());
+    }
+}

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/BranchAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/BranchAttributes.java
@@ -88,6 +88,10 @@ public interface BranchAttributes extends IdentifiableAttributes, Contained {
 
     void setActivePowerLimits2(LimitsAttributes activePowerLimits);
 
+    String getBranchStatus();
+
+    void setBranchStatus(String branchStatus);
+
     @JsonIgnore
     default Set<String> getContainerIds() {
         return ImmutableSet.<String>builder()

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/LineAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/LineAttributes.java
@@ -122,4 +122,7 @@ public class LineAttributes extends AbstractAttributes implements BranchAttribut
 
     @ApiModelProperty("Active power limit side 2")
     private LimitsAttributes activePowerLimits2;
+
+    @ApiModelProperty("Branch status")
+    private String branchStatus;
 }

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/ThreeWindingsTransformerAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/ThreeWindingsTransformerAttributes.java
@@ -89,6 +89,9 @@ public class ThreeWindingsTransformerAttributes extends AbstractAttributes imple
     @ApiModelProperty("Phase angle clock for leg 2 and 3")
     private ThreeWindingsTransformerPhaseAngleClockAttributes phaseAngleClock;
 
+    @ApiModelProperty("Branch status")
+    private String branchStatus;
+
     @Override
     @JsonIgnore
     public Set<String> getContainerIds() {

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/TwoWindingsTransformerAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/TwoWindingsTransformerAttributes.java
@@ -133,4 +133,6 @@ public class TwoWindingsTransformerAttributes extends AbstractAttributes impleme
     @ApiModelProperty("Active power limit side 2")
     private LimitsAttributes activePowerLimits2;
 
+    @ApiModelProperty("Branch status")
+    private String branchStatus;
 }

--- a/network-store-model/src/test/java/com/powsybl/network/store/model/ResourceTest.java
+++ b/network-store-model/src/test/java/com/powsybl/network/store/model/ResourceTest.java
@@ -148,6 +148,7 @@ public class ResourceTest {
                         .b1(1)
                         .g2(1)
                         .b2(1)
+                        .branchStatus("IN_OPERATION")
                         .build())
                 .build();
 
@@ -160,6 +161,8 @@ public class ResourceTest {
 
         resourceLine.getAttributes().setP1(100.0);
         assertEquals(100.0, resourceLine.getAttributes().getP1(), 0);
+
+        assertEquals("IN_OPERATION", resourceLine.getAttributes().getBranchStatus());
     }
 
     @Test
@@ -180,6 +183,7 @@ public class ResourceTest {
                         .g(1)
                         .ratedU1(1.)
                         .ratedU2(1.)
+                        .branchStatus("IN_OPERATION")
                         .build())
                 .build();
 
@@ -192,6 +196,8 @@ public class ResourceTest {
 
         resourceTransformer.getAttributes().setP1(100.0);
         assertEquals(100.0, resourceTransformer.getAttributes().getP1(), 0);
+
+        assertEquals("IN_OPERATION", resourceTransformer.getAttributes().getBranchStatus());
     }
 
     @Test
@@ -201,6 +207,7 @@ public class ResourceTest {
                 .attributes(ThreeWindingsTransformerAttributes.builder()
                         .name("id3WT")
                         .ratedU0(1)
+                        .branchStatus("IN_OPERATION")
                         .build())
                 .build();
 
@@ -220,6 +227,8 @@ public class ResourceTest {
         assertEquals(200., resourceTransformer.getAttributes().getP1(), 0);
         assertEquals(500., resourceTransformer.getAttributes().getQ2(), 0);
         assertEquals(700., resourceTransformer.getAttributes().getP3(), 0);
+
+        assertEquals("IN_OPERATION", resourceTransformer.getAttributes().getBranchStatus());
     }
 
     @Test

--- a/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreRepository.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreRepository.java
@@ -122,6 +122,7 @@ public class NetworkStoreRepository {
     private static final String CONFIGURED_BUS = "configuredBus";
     private static final String LOAD = "load";
     private static final String LINE = "line";
+    private static final String BRANCH_STATUS = "branchStatus";
 
     @PostConstruct
     void prepareStatements() {
@@ -634,7 +635,8 @@ public class NetworkStoreRepository {
                 .value(ACTIVE_POWER_LIMITS1, bindMarker())
                 .value(ACTIVE_POWER_LIMITS2, bindMarker())
                 .value(APPARENT_POWER_LIMITS1, bindMarker())
-                .value(APPARENT_POWER_LIMITS2, bindMarker()));
+                .value(APPARENT_POWER_LIMITS2, bindMarker())
+                .value(BRANCH_STATUS, bindMarker()));
         psUpdateTwoWindingsTransformer = session.prepare(update(TWO_WINDINGS_TRANSFORMER)
                 .with(set("voltageLevelId1", bindMarker()))
                 .and(set("voltageLevelId2", bindMarker()))
@@ -671,6 +673,7 @@ public class NetworkStoreRepository {
                 .and(set(ACTIVE_POWER_LIMITS2, bindMarker()))
                 .and(set(APPARENT_POWER_LIMITS1, bindMarker()))
                 .and(set(APPARENT_POWER_LIMITS2, bindMarker()))
+                .and(set(BRANCH_STATUS, bindMarker()))
                 .where(eq("networkUuid", bindMarker()))
                 .and(eq("id", bindMarker())));
 
@@ -737,7 +740,8 @@ public class NetworkStoreRepository {
                 .value(ACTIVE_POWER_LIMITS3, bindMarker())
                 .value(APPARENT_POWER_LIMITS1, bindMarker())
                 .value(APPARENT_POWER_LIMITS2, bindMarker())
-                .value(APPARENT_POWER_LIMITS3, bindMarker()));
+                .value(APPARENT_POWER_LIMITS3, bindMarker())
+                .value(BRANCH_STATUS, bindMarker()));
         psUpdateThreeWindingsTransformer = session.prepare(update(THREE_WINDINGS_TRANSFORMER)
                 .with(set("voltageLevelId1", bindMarker()))
                 .and(set("voltageLevelId2", bindMarker()))
@@ -800,6 +804,7 @@ public class NetworkStoreRepository {
                 .and(set(APPARENT_POWER_LIMITS1, bindMarker()))
                 .and(set(APPARENT_POWER_LIMITS2, bindMarker()))
                 .and(set(APPARENT_POWER_LIMITS3, bindMarker()))
+                .and(set(BRANCH_STATUS, bindMarker()))
                 .where(eq("networkUuid", bindMarker()))
                 .and(eq("id", bindMarker())));
 
@@ -837,7 +842,8 @@ public class NetworkStoreRepository {
                 .value(ACTIVE_POWER_LIMITS1, bindMarker())
                 .value(ACTIVE_POWER_LIMITS2, bindMarker())
                 .value(APPARENT_POWER_LIMITS1, bindMarker())
-                .value(APPARENT_POWER_LIMITS2, bindMarker()));
+                .value(APPARENT_POWER_LIMITS2, bindMarker())
+                .value(BRANCH_STATUS, bindMarker()));
         psUpdateLines = session.prepare(update(LINE)
                 .with(set("voltageLevelId1", bindMarker()))
                 .and(set("voltageLevelId2", bindMarker()))
@@ -871,6 +877,7 @@ public class NetworkStoreRepository {
                 .and(set(ACTIVE_POWER_LIMITS2, bindMarker()))
                 .and(set(APPARENT_POWER_LIMITS1, bindMarker()))
                 .and(set(APPARENT_POWER_LIMITS2, bindMarker()))
+                .and(set(BRANCH_STATUS, bindMarker()))
                 .where(eq("networkUuid", bindMarker()))
                 .and(eq("id", bindMarker())));
 
@@ -3439,7 +3446,8 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getActivePowerLimits1(),
                         resource.getAttributes().getActivePowerLimits2(),
                         resource.getAttributes().getApparentPowerLimits1(),
-                        resource.getAttributes().getApparentPowerLimits2()
+                        resource.getAttributes().getApparentPowerLimits2(),
+                        resource.getAttributes().getBranchStatus()
                 )));
             }
             session.execute(batch);
@@ -3481,7 +3489,8 @@ public class NetworkStoreRepository {
                 ACTIVE_POWER_LIMITS1,
                 ACTIVE_POWER_LIMITS2,
                 APPARENT_POWER_LIMITS1,
-                APPARENT_POWER_LIMITS2)
+                APPARENT_POWER_LIMITS2,
+                BRANCH_STATUS)
                 .from(TWO_WINDINGS_TRANSFORMER)
                 .where(eq("networkUuid", networkUuid)).and(eq("id", twoWindingsTransformerId)));
         Row one = resultSet.one();
@@ -3524,6 +3533,7 @@ public class NetworkStoreRepository {
                             .activePowerLimits2(one.get(32, LimitsAttributes.class))
                             .apparentPowerLimits1(one.get(33, LimitsAttributes.class))
                             .apparentPowerLimits1(one.get(34, LimitsAttributes.class))
+                            .branchStatus(one.getString(35))
                             .build())
                     .build());
         }
@@ -3566,7 +3576,8 @@ public class NetworkStoreRepository {
                 ACTIVE_POWER_LIMITS1,
                 ACTIVE_POWER_LIMITS2,
                 APPARENT_POWER_LIMITS1,
-                APPARENT_POWER_LIMITS2)
+                APPARENT_POWER_LIMITS2,
+                BRANCH_STATUS)
                 .from(TWO_WINDINGS_TRANSFORMER)
                 .where(eq("networkUuid", networkUuid)));
         List<Resource<TwoWindingsTransformerAttributes>> resources = new ArrayList<>();
@@ -3609,6 +3620,7 @@ public class NetworkStoreRepository {
                             .activePowerLimits2(row.get(33, LimitsAttributes.class))
                             .apparentPowerLimits1(row.get(34, LimitsAttributes.class))
                             .apparentPowerLimits2(row.get(35, LimitsAttributes.class))
+                            .branchStatus(row.getString(36))
                             .build())
                     .build());
         }
@@ -3650,7 +3662,8 @@ public class NetworkStoreRepository {
                 ACTIVE_POWER_LIMITS1,
                 ACTIVE_POWER_LIMITS2,
                 APPARENT_POWER_LIMITS1,
-                APPARENT_POWER_LIMITS2)
+                APPARENT_POWER_LIMITS2,
+                BRANCH_STATUS)
                 .from("twoWindingsTransformerByVoltageLevel" + (side == Branch.Side.ONE ? 1 : 2))
                 .where(eq("networkUuid", networkUuid)).and(eq("voltageLevelId" + (side == Branch.Side.ONE ? 1 : 2), voltageLevelId)));
         List<Resource<TwoWindingsTransformerAttributes>> resources = new ArrayList<>();
@@ -3693,6 +3706,7 @@ public class NetworkStoreRepository {
                             .activePowerLimits2(row.get(32, LimitsAttributes.class))
                             .apparentPowerLimits1(row.get(33, LimitsAttributes.class))
                             .apparentPowerLimits2(row.get(34, LimitsAttributes.class))
+                            .branchStatus(row.getString(35))
                             .build())
                     .build());
         }
@@ -3748,6 +3762,7 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getActivePowerLimits2(),
                         resource.getAttributes().getApparentPowerLimits1(),
                         resource.getAttributes().getApparentPowerLimits2(),
+                        resource.getAttributes().getBranchStatus(),
                         networkUuid,
                         resource.getId())
                 ));
@@ -3829,7 +3844,8 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getLeg3().getActivePowerLimitsAttributes(),
                         resource.getAttributes().getLeg1().getApparentPowerLimitsAttributes(),
                         resource.getAttributes().getLeg2().getApparentPowerLimitsAttributes(),
-                        resource.getAttributes().getLeg3().getApparentPowerLimitsAttributes()
+                        resource.getAttributes().getLeg3().getApparentPowerLimitsAttributes(),
+                        resource.getAttributes().getBranchStatus()
                 )));
             }
             session.execute(batch);
@@ -3897,7 +3913,8 @@ public class NetworkStoreRepository {
                 ACTIVE_POWER_LIMITS3,
                 APPARENT_POWER_LIMITS1,
                 APPARENT_POWER_LIMITS2,
-                APPARENT_POWER_LIMITS3)
+                APPARENT_POWER_LIMITS3,
+                BRANCH_STATUS)
                 .from(THREE_WINDINGS_TRANSFORMER)
                 .where(eq("networkUuid", networkUuid)).and(eq("id", threeWindingsTransformerId)));
         Row one = resultSet.one();
@@ -3975,6 +3992,7 @@ public class NetworkStoreRepository {
                             .aliasesWithoutType(one.getSet(52, String.class))
                             .aliasByType(one.getMap(53, String.class, String.class))
                             .phaseAngleClock(one.get(54, ThreeWindingsTransformerPhaseAngleClockAttributes.class))
+                            .branchStatus(one.getString(61))
                             .build())
                     .build());
         }
@@ -4043,7 +4061,8 @@ public class NetworkStoreRepository {
                 ACTIVE_POWER_LIMITS3,
                 APPARENT_POWER_LIMITS1,
                 APPARENT_POWER_LIMITS2,
-                APPARENT_POWER_LIMITS3)
+                APPARENT_POWER_LIMITS3,
+                BRANCH_STATUS)
                 .from(THREE_WINDINGS_TRANSFORMER)
                 .where(eq("networkUuid", networkUuid)));
         List<Resource<ThreeWindingsTransformerAttributes>> resources = new ArrayList<>();
@@ -4121,6 +4140,7 @@ public class NetworkStoreRepository {
                             .aliasesWithoutType(row.getSet(53, String.class))
                             .aliasByType(row.getMap(54, String.class, String.class))
                             .phaseAngleClock(row.get(55, ThreeWindingsTransformerPhaseAngleClockAttributes.class))
+                            .branchStatus(row.getString(62))
                             .build())
                     .build());
         }
@@ -4188,7 +4208,8 @@ public class NetworkStoreRepository {
                 ACTIVE_POWER_LIMITS3,
                 APPARENT_POWER_LIMITS1,
                 APPARENT_POWER_LIMITS2,
-                APPARENT_POWER_LIMITS3)
+                APPARENT_POWER_LIMITS3,
+                BRANCH_STATUS)
                 .from("threeWindingsTransformerByVoltageLevel" + (side == ThreeWindingsTransformer.Side.ONE ? 1 : (side == ThreeWindingsTransformer.Side.TWO ? 2 : 3)))
                 .where(eq("networkUuid", networkUuid)).and(eq("voltageLevelId" + (side == ThreeWindingsTransformer.Side.ONE ? 1 : (side == ThreeWindingsTransformer.Side.TWO ? 2 : 3)), voltageLevelId)));
         List<Resource<ThreeWindingsTransformerAttributes>> resources = new ArrayList<>();
@@ -4266,6 +4287,7 @@ public class NetworkStoreRepository {
                             .aliasesWithoutType(row.getSet(52, String.class))
                             .aliasByType(row.getMap(53, String.class, String.class))
                             .phaseAngleClock(row.get(54, ThreeWindingsTransformerPhaseAngleClockAttributes.class))
+                            .branchStatus(row.getString(61))
                             .build())
                     .build());
         }
@@ -4348,6 +4370,7 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getLeg1().getApparentPowerLimitsAttributes(),
                         resource.getAttributes().getLeg2().getApparentPowerLimitsAttributes(),
                         resource.getAttributes().getLeg3().getApparentPowerLimitsAttributes(),
+                        resource.getAttributes().getBranchStatus(),
                         networkUuid,
                         resource.getId())
                 ));
@@ -4400,7 +4423,8 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getActivePowerLimits1(),
                         resource.getAttributes().getActivePowerLimits2(),
                         resource.getAttributes().getApparentPowerLimits1(),
-                        resource.getAttributes().getApparentPowerLimits2()
+                        resource.getAttributes().getApparentPowerLimits2(),
+                        resource.getAttributes().getBranchStatus()
                 )));
             }
             session.execute(batch);
@@ -4439,7 +4463,8 @@ public class NetworkStoreRepository {
                 ACTIVE_POWER_LIMITS1,
                 ACTIVE_POWER_LIMITS2,
                 APPARENT_POWER_LIMITS1,
-                APPARENT_POWER_LIMITS2)
+                APPARENT_POWER_LIMITS2,
+                BRANCH_STATUS)
                 .from(LINE)
                 .where(eq("networkUuid", networkUuid)).and(eq("id", lineId)));
         Row one = resultSet.one();
@@ -4479,6 +4504,7 @@ public class NetworkStoreRepository {
                             .activePowerLimits2(one.get(29, LimitsAttributes.class))
                             .apparentPowerLimits1(one.get(30, LimitsAttributes.class))
                             .apparentPowerLimits2(one.get(31, LimitsAttributes.class))
+                            .branchStatus(one.getString(32))
                             .build())
                     .build());
         }
@@ -4518,7 +4544,8 @@ public class NetworkStoreRepository {
                 ACTIVE_POWER_LIMITS1,
                 ACTIVE_POWER_LIMITS2,
                 APPARENT_POWER_LIMITS1,
-                APPARENT_POWER_LIMITS2)
+                APPARENT_POWER_LIMITS2,
+                BRANCH_STATUS)
                 .from(LINE)
                 .where(eq("networkUuid", networkUuid)));
         List<Resource<LineAttributes>> resources = new ArrayList<>();
@@ -4558,6 +4585,7 @@ public class NetworkStoreRepository {
                             .activePowerLimits2(row.get(30, LimitsAttributes.class))
                             .apparentPowerLimits1(row.get(31, LimitsAttributes.class))
                             .apparentPowerLimits2(row.get(32, LimitsAttributes.class))
+                            .branchStatus(row.getString(33))
                             .build())
                     .build());
         }
@@ -4596,7 +4624,8 @@ public class NetworkStoreRepository {
                 ACTIVE_POWER_LIMITS1,
                 ACTIVE_POWER_LIMITS2,
                 APPARENT_POWER_LIMITS1,
-                APPARENT_POWER_LIMITS2)
+                APPARENT_POWER_LIMITS2,
+                BRANCH_STATUS)
                 .from("lineByVoltageLevel" + (side == Branch.Side.ONE ? 1 : 2))
                 .where(eq("networkUuid", networkUuid)).and(eq("voltageLevelId" + (side == Branch.Side.ONE ? 1 : 2), voltageLevelId)));
         List<Resource<LineAttributes>> resources = new ArrayList<>();
@@ -4636,6 +4665,7 @@ public class NetworkStoreRepository {
                             .activePowerLimits2(row.get(29, LimitsAttributes.class))
                             .apparentPowerLimits1(row.get(30, LimitsAttributes.class))
                             .apparentPowerLimits2(row.get(31, LimitsAttributes.class))
+                            .branchStatus(row.getString(32))
                             .build())
                     .build());
         }
@@ -4688,6 +4718,7 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getActivePowerLimits2(),
                         resource.getAttributes().getApparentPowerLimits1(),
                         resource.getAttributes().getApparentPowerLimits2(),
+                        resource.getAttributes().getBranchStatus(),
                         networkUuid,
                         resource.getId())
                 ));

--- a/network-store-server/src/main/resources/iidm.cql
+++ b/network-store-server/src/main/resources/iidm.cql
@@ -556,17 +556,18 @@ CREATE TABLE IF NOT EXISTS twoWindingsTransformer (
     apparentPowerLimits1 currentLimits,
     apparentPowerLimits2 currentLimits,
     phaseAngleClock twoWindingsTransformerPhaseAngleClock,
+    branchStatus text,
     PRIMARY KEY (networkUuid, id)
 );
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS twoWindingsTransformerByVoltageLevel1 AS
-SELECT networkUuid, id, voltageLevelId1, voltageLevelId2, name, fictitious, properties, aliasesWithoutType, aliasByType, node1, node2, r, x, g, b, ratedU1, ratedU2, ratedS, p1, q1, p2, q2, position1, position2, phaseTapChanger, ratioTapChanger, bus1, bus2, connectableBus1, connectableBus2, currentLimits1, currentLimits2, activePowerLimits1, activePowerLimits2, apparentPowerLimits1, apparentPowerLimits2, phaseAngleClock
+SELECT networkUuid, id, voltageLevelId1, voltageLevelId2, name, fictitious, properties, aliasesWithoutType, aliasByType, node1, node2, r, x, g, b, ratedU1, ratedU2, ratedS, p1, q1, p2, q2, position1, position2, phaseTapChanger, ratioTapChanger, bus1, bus2, connectableBus1, connectableBus2, currentLimits1, currentLimits2, activePowerLimits1, activePowerLimits2, apparentPowerLimits1, apparentPowerLimits2, phaseAngleClock, branchStatus
 FROM twoWindingsTransformer
 WHERE networkUuid IS NOT NULL AND id IS NOT NULL AND voltageLevelId1 IS NOT NULL
     PRIMARY KEY (networkUuid, voltageLevelId1, id);
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS twoWindingsTransformerByVoltageLevel2 AS
-SELECT networkUuid, id, voltageLevelId1, voltageLevelId2, name, fictitious, properties, aliasesWithoutType, aliasByType, node1, node2, r, x, g, b, ratedU1, ratedU2, ratedS, p1, q1, p2, q2, position1, position2, phaseTapChanger, ratioTapChanger, bus1, bus2, connectableBus1, connectableBus2, currentLimits1, currentLimits2, activePowerLimits1, activePowerLimits2, apparentPowerLimits1, apparentPowerLimits2, phaseAngleClock
+SELECT networkUuid, id, voltageLevelId1, voltageLevelId2, name, fictitious, properties, aliasesWithoutType, aliasByType, node1, node2, r, x, g, b, ratedU1, ratedU2, ratedS, p1, q1, p2, q2, position1, position2, phaseTapChanger, ratioTapChanger, bus1, bus2, connectableBus1, connectableBus2, currentLimits1, currentLimits2, activePowerLimits1, activePowerLimits2, apparentPowerLimits1, apparentPowerLimits2, phaseAngleClock, branchStatus
 FROM twoWindingsTransformer
 WHERE networkUuid IS NOT NULL AND id IS NOT NULL AND voltageLevelId2 IS NOT NULL
     PRIMARY KEY (networkUuid, voltageLevelId2, id);
@@ -635,23 +636,24 @@ CREATE TABLE IF NOT EXISTS threeWindingsTransformer (
     bus3 text,
     connectableBus3 text,
     phaseAngleClock threeWindingsTransformerPhaseAngleClock,
+    branchStatus text,
     PRIMARY KEY (networkUuid, id)
 );
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS threeWindingsTransformerByVoltageLevel1 AS
-SELECT networkUuid, id, voltageLevelId1, voltageLevelId2, voltageLevelId3, name, fictitious, properties, aliasesWithoutType, aliasByType, node1, node2, node3, ratedU0, p1, q1, r1, x1, g1, b1, ratedU1, ratedS1, phaseTapChanger1, ratioTapChanger1, p2, q2, r2, x2, g2, b2, phaseTapChanger2, ratioTapChanger2, ratedU2, ratedS2, p3, q3, r3, x3, g3, b3, phaseTapChanger3, ratioTapChanger3, ratedU3, ratedS3, position1, position2, position3, currentLimits1, currentLimits2, currentLimits3, activePowerLimits1, activePowerLimits2, activePowerLimits3, apparentPowerLimits1, apparentPowerLimits2, apparentPowerLimits3, bus1, connectableBus1, bus2, connectableBus2, bus3, connectableBus3, phaseAngleClock
+SELECT networkUuid, id, voltageLevelId1, voltageLevelId2, voltageLevelId3, name, fictitious, properties, aliasesWithoutType, aliasByType, node1, node2, node3, ratedU0, p1, q1, r1, x1, g1, b1, ratedU1, ratedS1, phaseTapChanger1, ratioTapChanger1, p2, q2, r2, x2, g2, b2, phaseTapChanger2, ratioTapChanger2, ratedU2, ratedS2, p3, q3, r3, x3, g3, b3, phaseTapChanger3, ratioTapChanger3, ratedU3, ratedS3, position1, position2, position3, currentLimits1, currentLimits2, currentLimits3, activePowerLimits1, activePowerLimits2, activePowerLimits3, apparentPowerLimits1, apparentPowerLimits2, apparentPowerLimits3, bus1, connectableBus1, bus2, connectableBus2, bus3, connectableBus3, phaseAngleClock, branchStatus
 FROM threeWindingsTransformer
 WHERE networkUuid IS NOT NULL AND id IS NOT NULL AND voltageLevelId1 IS NOT NULL
     PRIMARY KEY (networkUuid, voltageLevelId1, id);
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS threeWindingsTransformerByVoltageLevel2 AS
-SELECT networkUuid, id, voltageLevelId1, voltageLevelId2, voltageLevelId3, name, fictitious, properties, aliasesWithoutType, aliasByType, node1, node2, node3, ratedU0, p1, q1, r1, x1, g1, b1, ratedU1, ratedS1, phaseTapChanger1, ratioTapChanger1, p2, q2, r2, x2, g2, b2, ratedU2, ratedS2, phaseTapChanger2, ratioTapChanger2, p3, q3, r3, x3, g3, b3, ratedU3, ratedS3, phaseTapChanger3, ratioTapChanger3, position1, position2, position3, currentLimits1, currentLimits2, currentLimits3, activePowerLimits1, activePowerLimits2, activePowerLimits3, apparentPowerLimits1, apparentPowerLimits2, apparentPowerLimits3, bus1, connectableBus1, bus2, connectableBus2, bus3, connectableBus3, phaseAngleClock
+SELECT networkUuid, id, voltageLevelId1, voltageLevelId2, voltageLevelId3, name, fictitious, properties, aliasesWithoutType, aliasByType, node1, node2, node3, ratedU0, p1, q1, r1, x1, g1, b1, ratedU1, ratedS1, phaseTapChanger1, ratioTapChanger1, p2, q2, r2, x2, g2, b2, ratedU2, ratedS2, phaseTapChanger2, ratioTapChanger2, p3, q3, r3, x3, g3, b3, ratedU3, ratedS3, phaseTapChanger3, ratioTapChanger3, position1, position2, position3, currentLimits1, currentLimits2, currentLimits3, activePowerLimits1, activePowerLimits2, activePowerLimits3, apparentPowerLimits1, apparentPowerLimits2, apparentPowerLimits3, bus1, connectableBus1, bus2, connectableBus2, bus3, connectableBus3, phaseAngleClock, branchStatus
 FROM threeWindingsTransformer
 WHERE networkUuid IS NOT NULL AND id IS NOT NULL AND voltageLevelId2 IS NOT NULL
     PRIMARY KEY (networkUuid, voltageLevelId2, id);
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS threeWindingsTransformerByVoltageLevel3 AS
-SELECT networkUuid, id, voltageLevelId1, voltageLevelId2, voltageLevelId3, name, fictitious, properties, aliasesWithoutType, aliasByType, node1, node2, node3, ratedU0, p1, q1, r1, x1, g1, b1, ratedU1, ratedS1, phaseTapChanger1, ratioTapChanger1, p2, q2, r2, x2, g2, b2, ratedU2, ratedS2, phaseTapChanger2, ratioTapChanger2, p3, q3, r3, x3, g3, b3, ratedU3, ratedS3, phaseTapChanger3, ratioTapChanger3, position1, position2, position3, currentLimits1, currentLimits2, currentLimits3, activePowerLimits1, activePowerLimits2, activePowerLimits3, apparentPowerLimits1, apparentPowerLimits2, apparentPowerLimits3, bus1, connectableBus1, bus2, connectableBus2, bus3, connectableBus3, phaseAngleClock
+SELECT networkUuid, id, voltageLevelId1, voltageLevelId2, voltageLevelId3, name, fictitious, properties, aliasesWithoutType, aliasByType, node1, node2, node3, ratedU0, p1, q1, r1, x1, g1, b1, ratedU1, ratedS1, phaseTapChanger1, ratioTapChanger1, p2, q2, r2, x2, g2, b2, ratedU2, ratedS2, phaseTapChanger2, ratioTapChanger2, p3, q3, r3, x3, g3, b3, ratedU3, ratedS3, phaseTapChanger3, ratioTapChanger3, position1, position2, position3, currentLimits1, currentLimits2, currentLimits3, activePowerLimits1, activePowerLimits2, activePowerLimits3, apparentPowerLimits1, apparentPowerLimits2, apparentPowerLimits3, bus1, connectableBus1, bus2, connectableBus2, bus3, connectableBus3, phaseAngleClock, branchStatus
 FROM threeWindingsTransformer
 WHERE networkUuid IS NOT NULL AND id IS NOT NULL AND voltageLevelId3 IS NOT NULL
     PRIMARY KEY (networkUuid, voltageLevelId3, id);
@@ -691,17 +693,18 @@ CREATE TABLE IF NOT EXISTS line (
     activePowerLimits2 currentLimits,
     apparentPowerLimits1 currentLimits,
     apparentPowerLimits2 currentLimits,
+    branchStatus text,
     PRIMARY KEY (networkUuid, id)
 );
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS lineByVoltageLevel1 AS
-SELECT networkUuid, id, voltageLevelId1, voltageLevelId2, name, fictitious, properties, aliasesWithoutType, aliasByType, node1, node2, r, x, g1, b1, g2, b2, p1, q1, p2, q2, position1, position2, bus1, bus2, connectableBus1, connectableBus2, mergedXnode, currentLimits1, currentLimits2, activePowerLimits1, activePowerLimits2, apparentPowerLimits1, apparentPowerLimits2
+SELECT networkUuid, id, voltageLevelId1, voltageLevelId2, name, fictitious, properties, aliasesWithoutType, aliasByType, node1, node2, r, x, g1, b1, g2, b2, p1, q1, p2, q2, position1, position2, bus1, bus2, connectableBus1, connectableBus2, mergedXnode, currentLimits1, currentLimits2, activePowerLimits1, activePowerLimits2, apparentPowerLimits1, apparentPowerLimits2, branchStatus
 FROM line
 WHERE networkUuid IS NOT NULL AND id IS NOT NULL AND voltageLevelId1 IS NOT NULL
     PRIMARY KEY (networkUuid, voltageLevelId1, id);
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS lineByVoltageLevel2 AS
-SELECT networkUuid, id, voltageLevelId1, voltageLevelId2, name, fictitious, properties, aliasesWithoutType, aliasByType, node1, node2, r, x, g1, b1, g2, b2, p1, q1, p2, q2, position1, position2, bus1, bus2, connectableBus1, connectableBus2, mergedXnode, currentLimits1, currentLimits2, activePowerLimits1, activePowerLimits2, apparentPowerLimits1, apparentPowerLimits2
+SELECT networkUuid, id, voltageLevelId1, voltageLevelId2, name, fictitious, properties, aliasesWithoutType, aliasByType, node1, node2, r, x, g1, b1, g2, b2, p1, q1, p2, q2, position1, position2, bus1, bus2, connectableBus1, connectableBus2, mergedXnode, currentLimits1, currentLimits2, activePowerLimits1, activePowerLimits2, apparentPowerLimits1, apparentPowerLimits2, branchStatus
 FROM line
 WHERE networkUuid IS NOT NULL AND id IS NOT NULL AND voltageLevelId2 IS NOT NULL
     PRIMARY KEY (networkUuid, voltageLevelId2, id);


### PR DESCRIPTION
Signed-off-by: NOIR Nicolas ext <nicolas.noir@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
This PR introduces the new extension BranchStatus for Lines, Two windings transformers and Three windings transformers. This extension allows to define a specific status for these equipments whether they are in operation, locked-out or tripped and to store it in database.


**What is the current behavior?** *(You can also link to an open issue here)*
Currently, there is now status describing these specific states.


**What is the new behavior (if this is a feature change)?**
A new extension will contain this new specific status.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
