### PR TITLE
maven: use versions from other projects when possible and cleanup a bit

### DIFF
--- a/network-store-iidm-impl/pom.xml
+++ b/network-store-iidm-impl/pom.xml
@@ -25,27 +25,22 @@
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-entsoe-util</artifactId>
-            <version>${powsybl-core.version}</version>
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-cgmes-conversion</artifactId>
-            <version>${powsybl-core.version}</version>
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-iidm-api</artifactId>
-            <version>${powsybl-core.version}</version>
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-iidm-extensions</artifactId>
-            <version>${powsybl-core.version}</version>
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-single-line-diagram-iidm-extensions</artifactId>
-            <version>${powsybl-single-line-diagram.version}</version>
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
@@ -72,26 +67,22 @@
         <dependency>
             <groupId>nl.jqno.equalsverifier</groupId>
             <artifactId>equalsverifier</artifactId>
-            <version>${equalsverifier.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-config-test</artifactId>
-            <version>${powsybl-core.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-iidm-test</artifactId>
-            <version>${powsybl-core.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-iidm-tck</artifactId>
-            <version>${powsybl-core.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/network-store-iidm-tck/pom.xml
+++ b/network-store-iidm-tck/pom.xml
@@ -39,33 +39,28 @@
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-iidm-xml-converter</artifactId>
-            <version>${powsybl-core.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-iidm-test</artifactId>
-            <version>${powsybl-core.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-commons</artifactId>
-            <version>${powsybl-core.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-iidm-tck</artifactId>
-            <version>${powsybl-core.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-config-test</artifactId>
-            <version>${powsybl-core.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -104,7 +99,6 @@
         <dependency>
             <groupId>com.github.nosan</groupId>
             <artifactId>embedded-cassandra-spring-test</artifactId>
-            <version>${embedded-cassandra.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -115,7 +109,6 @@
         <dependency>
             <groupId>com.google.jimfs</groupId>
             <artifactId>jimfs</artifactId>
-            <version>${jimfs.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/network-store-integration-test/pom.xml
+++ b/network-store-integration-test/pom.xml
@@ -26,26 +26,22 @@
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-iidm-xml-converter</artifactId>
-            <version>${powsybl-core.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-iidm-test</artifactId>
-            <version>${powsybl-core.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-cgmes-conformity</artifactId>
-            <version>${powsybl-core.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>powsybl-cgmes-model</artifactId>
-            <version>${powsybl-core.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
@@ -60,13 +56,11 @@
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-cgmes-conversion</artifactId>
-            <version>${powsybl-core.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-triple-store-impl-rdf4j</artifactId>
-            <version>${powsybl-core.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -100,7 +94,6 @@
         <dependency>
             <groupId>com.github.nosan</groupId>
             <artifactId>embedded-cassandra-spring-test</artifactId>
-            <version>${embedded-cassandra.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -111,7 +104,6 @@
         <dependency>
             <groupId>com.google.jimfs</groupId>
             <artifactId>jimfs</artifactId>
-            <version>${jimfs.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -126,14 +118,12 @@
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-tools</artifactId>
-            <version>${powsybl-core.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-ucte-converter</artifactId>
-            <version>${powsybl-core.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/network-store-model/pom.xml
+++ b/network-store-model/pom.xml
@@ -60,17 +60,14 @@
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-iidm-api</artifactId>
-            <version>${powsybl-core.version}</version>
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-tools</artifactId>
-            <version>${powsybl-core.version}</version>
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-cgmes-conversion</artifactId>
-            <version>${powsybl-core.version}</version>
         </dependency>
 
         <!-- test scope -->

--- a/network-store-server/pom.xml
+++ b/network-store-server/pom.xml
@@ -42,7 +42,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>${maven.jar.version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -107,7 +106,6 @@
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-config-classic</artifactId>
-            <version>${powsybl-core.version}</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
@@ -120,7 +118,6 @@
         <dependency>
             <groupId>com.github.nosan</groupId>
             <artifactId>embedded-cassandra-spring-test</artifactId>
-            <version>${embedded-cassandra.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/network-store-tools/pom.xml
+++ b/network-store-tools/pom.xml
@@ -26,12 +26,10 @@
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-iidm-converter-api</artifactId>
-            <version>${powsybl-core.version}</version>
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-tools</artifactId>
-            <version>${powsybl-core.version}</version>
         </dependency>
 
         <dependency>
@@ -43,7 +41,6 @@
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy</artifactId>
-            <version>${groovy.version}</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -54,21 +54,15 @@
         <cassandra-driver.version>3.7.2</cassandra-driver.version>
 
         <embedded-cassandra.version>3.0.3</embedded-cassandra.version>
-        <guava.version>29.0-jre</guava.version>
-        <jgrapht.version>1.4.0</jgrapht.version>
-        <jodatime.version>2.10.5</jodatime.version>
-        <jimfs.version>1.1</jimfs.version>
         <!-- 4.13.1 is incompatible with spring-boot-starter-test -->
         <junit.version>4.13</junit.version>
         <lombok.version>1.18.10</lombok.version>
+        <!-- downgrade of metrics-core needed for compatibility with cassandra-driver < 4 . To remove when we upgrade to >4 -->
         <metricscore.version>3.2.6</metricscore.version>
-        <mockito.version>3.2.4</mockito.version>
         <sirocco.version>1.0</sirocco.version>
-        <slf4j.version>1.7.30</slf4j.version>
         <springboot.version>2.2.9.RELEASE</springboot.version>
         <springfox.version>2.9.2</springfox.version>
         <swagger.version>1.6.0</swagger.version>
-        <groovy.version>2.5.8</groovy.version>
         <equalsverifier.version>3.5</equalsverifier.version>
 
         <powsybl-core.version>4.0.1</powsybl-core.version>
@@ -93,21 +87,55 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- Compilation dependencies -->
+            <!-- overrides of imports -->
             <dependency>
-              <groupId>com.datastax.cassandra</groupId>
-              <artifactId>cassandra-driver-extras</artifactId>
-              <version>${cassandra-driver.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>${guava.version}</version>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>${junit.version}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>io.dropwizard.metrics</groupId>
                 <artifactId>metrics-core</artifactId>
                 <version>${metricscore.version}</version>
+            </dependency>
+
+            <!-- imports -->
+            <dependency>
+                <groupId>com.powsybl</groupId>
+                <artifactId>powsybl-core</artifactId>
+                <version>${powsybl-core.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${springboot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <!-- project specific dependencies (also overrides imports, but separate for clarity) -->
+            <dependency>
+              <groupId>nl.jqno.equalsverifier</groupId>
+              <artifactId>equalsverifier</artifactId>
+              <version>${equalsverifier.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>com.powsybl</groupId>
+              <artifactId>powsybl-single-line-diagram-iidm-extensions</artifactId>
+              <version>${powsybl-single-line-diagram.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>com.github.nosan</groupId>
+              <artifactId>embedded-cassandra-spring-test</artifactId>
+              <version>${embedded-cassandra.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>com.datastax.cassandra</groupId>
+              <artifactId>cassandra-driver-extras</artifactId>
+              <version>${cassandra-driver.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.springfox</groupId>
@@ -130,7 +158,6 @@
                 <artifactId>springfox-swagger-ui</artifactId>
                 <version>${springfox.version}</version>
             </dependency>
-
             <dependency>
                 <groupId>io.swagger</groupId>
                 <artifactId>swagger-annotations</artifactId>
@@ -140,22 +167,6 @@
                 <groupId>io.swagger</groupId>
                 <artifactId>swagger-models</artifactId>
                 <version>${swagger.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>joda-time</groupId>
-                <artifactId>joda-time</artifactId>
-                <version>${jodatime.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jgrapht</groupId>
-                <artifactId>jgrapht-core</artifactId>
-                <version>${jgrapht.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-core</artifactId>
-                <version>${mockito.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.ow2.sirocco</groupId>
@@ -172,32 +183,6 @@
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>
                 <version>${lombok.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-dependencies</artifactId>
-                <version>${springboot.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>log4j-over-slf4j</artifactId>
-                <version>${slf4j.version}</version>
-            </dependency>
-
-            <!-- Test dependencies -->
-            <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>${junit.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-starter-test</artifactId>
-                <version>${springboot.version}</version>
-                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
the project has many definitions of versions of artifact that don't match with versions used by the 3rd party projects for compilation and test, so we risk having incompatibilities


**What is the new behavior (if this is a feature change)?**
Use versions from other projects when we don't care about one specific version


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
NO

This changes groovy 2 to groovy 3 among other things, hopefully it's ok