### PR TITLE
Fix lockout line in bus/breaker topology

### DIFF
--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/BranchToInjectionAttributesAdapter.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/BranchToInjectionAttributesAdapter.java
@@ -73,9 +73,13 @@ public class BranchToInjectionAttributesAdapter implements InjectionAttributes {
     @Override
     public void setBus(String bus) {
         if (side1) {
+            String oldValue = attributes.getBus1();
             attributes.setBus1(bus);
+            branch.notifyUpdate("bus1", oldValue, bus, true);
         } else {
+            String oldValue = attributes.getBus2();
             attributes.setBus2(bus);
+            branch.notifyUpdate("bus2", oldValue, bus, true);
         }
     }
 

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/TerminalImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/TerminalImpl.java
@@ -7,7 +7,10 @@
 package com.powsybl.network.store.iidm.impl;
 
 import com.powsybl.iidm.network.*;
-import com.powsybl.network.store.model.*;
+import com.powsybl.network.store.model.InjectionAttributes;
+import com.powsybl.network.store.model.Resource;
+import com.powsybl.network.store.model.SwitchAttributes;
+import com.powsybl.network.store.model.VoltageLevelAttributes;
 import org.jgrapht.Graph;
 import org.jgrapht.alg.connectivity.ConnectivityInspector;
 import org.jgrapht.alg.flow.EdmondsKarpMFImpl;
@@ -24,6 +27,8 @@ import java.util.stream.Collectors;
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public class TerminalImpl<U extends InjectionAttributes> implements Terminal, Validable {
+
+    private static final Set<ConnectableType> CONNECTABLE_WITH_SIDES_TYPES = Set.of(ConnectableType.LINE, ConnectableType.TWO_WINDINGS_TRANSFORMER, ConnectableType.THREE_WINDINGS_TRANSFORMER);
 
     private final NetworkObjectIndex index;
 
@@ -183,7 +188,7 @@ public class TerminalImpl<U extends InjectionAttributes> implements Terminal, Va
         }
 
         closedSwitches.stream().forEach(switchId ->
-            index.notifyUpdate(index.getSwitch(switchId).get(), "open", true, false)
+                index.notifyUpdate(index.getSwitch(switchId).get(), "open", true, false)
         );
 
         return done;
@@ -203,7 +208,8 @@ public class TerminalImpl<U extends InjectionAttributes> implements Terminal, Va
             if (attributes.getBus() == null) {
                 attributes.setBus(attributes.getConnectableBus());
                 index.updateResource(attributes.getResource());
-                if (!Set.of(ConnectableType.LINE, ConnectableType.TWO_WINDINGS_TRANSFORMER, ConnectableType.THREE_WINDINGS_TRANSFORMER).contains(getConnectable().getType())) {
+                // Notification for branches (with sides) is made in the injection attributes adapters (setBus)
+                if (!CONNECTABLE_WITH_SIDES_TYPES.contains(getConnectable().getType())) {
                     index.notifyUpdate(getConnectable(), "bus", null, attributes.getConnectableBus());
                 }
                 done = true;
@@ -307,7 +313,8 @@ public class TerminalImpl<U extends InjectionAttributes> implements Terminal, Va
             if (attributes.getBus() != null) {
                 attributes.setBus(null);
                 index.updateResource(attributes.getResource());
-                if (!Set.of(ConnectableType.LINE, ConnectableType.TWO_WINDINGS_TRANSFORMER, ConnectableType.THREE_WINDINGS_TRANSFORMER).contains(getConnectable().getType())) {
+                // Notification for branches (with sides) is made in the injection attributes adapters (setBus)
+                if (!CONNECTABLE_WITH_SIDES_TYPES.contains(getConnectable().getType())) {
                     index.notifyUpdate(getConnectable(), "bus", attributes.getConnectableBus(), null);
                 }
                 done = true;

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/TerminalImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/TerminalImpl.java
@@ -203,6 +203,9 @@ public class TerminalImpl<U extends InjectionAttributes> implements Terminal, Va
             if (attributes.getBus() == null) {
                 attributes.setBus(attributes.getConnectableBus());
                 index.updateResource(attributes.getResource());
+                if (!Set.of(ConnectableType.LINE, ConnectableType.TWO_WINDINGS_TRANSFORMER, ConnectableType.THREE_WINDINGS_TRANSFORMER).contains(getConnectable().getType())) {
+                    index.notifyUpdate(getConnectable(), "bus", null, attributes.getConnectableBus());
+                }
                 done = true;
             }
         }
@@ -304,6 +307,9 @@ public class TerminalImpl<U extends InjectionAttributes> implements Terminal, Va
             if (attributes.getBus() != null) {
                 attributes.setBus(null);
                 index.updateResource(attributes.getResource());
+                if (!Set.of(ConnectableType.LINE, ConnectableType.TWO_WINDINGS_TRANSFORMER, ConnectableType.THREE_WINDINGS_TRANSFORMER).contains(getConnectable().getType())) {
+                    index.notifyUpdate(getConnectable(), "bus", attributes.getConnectableBus(), null);
+                }
                 done = true;
             }
         }

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/ThreeWindingsTransformerImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/ThreeWindingsTransformerImpl.java
@@ -10,8 +10,8 @@ import com.powsybl.commons.extensions.Extension;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.extensions.ThreeWindingsTransformerPhaseAngleClock;
 import com.powsybl.network.store.iidm.impl.ConnectablePositionAdderImpl.ConnectablePositionCreator;
-import com.powsybl.network.store.iidm.impl.extensions.ThreeWindingsTransformerPhaseAngleClockImpl;
 import com.powsybl.network.store.iidm.impl.extensions.BranchStatusImpl;
+import com.powsybl.network.store.iidm.impl.extensions.ThreeWindingsTransformerPhaseAngleClockImpl;
 import com.powsybl.network.store.model.*;
 import com.powsybl.sld.iidm.extensions.BranchStatus;
 import com.powsybl.sld.iidm.extensions.ConnectablePosition;
@@ -278,6 +278,10 @@ public class ThreeWindingsTransformerImpl extends AbstractIdentifiableImpl<Three
             transformer.leg3.getOptionalPhaseTapChanger().ifPresent(tapChangers::add);
             return tapChangers;
         }
+
+        public void notifyUpdate(String attribute, Object oldValue, Object newValue) {
+            index.notifyUpdate(transformer, getLegAttribute() + "." + attribute, oldValue, newValue);
+        }
     }
 
     ThreeWindingsTransformerImpl(NetworkObjectIndex index, Resource<ThreeWindingsTransformerAttributes> resource) {
@@ -287,9 +291,9 @@ public class ThreeWindingsTransformerImpl extends AbstractIdentifiableImpl<Three
         leg2 = new LegImpl(index, resource.getAttributes().getLeg2(), this);
         leg3 = new LegImpl(index, resource.getAttributes().getLeg3(), this);
 
-        terminal1 = TerminalImpl.create(index, new ThreeWindingsTransformerToInjectionAttributesAdapter(resource.getAttributes(), Side.ONE), this);
-        terminal2 = TerminalImpl.create(index, new ThreeWindingsTransformerToInjectionAttributesAdapter(resource.getAttributes(), Side.TWO), this);
-        terminal3 = TerminalImpl.create(index, new ThreeWindingsTransformerToInjectionAttributesAdapter(resource.getAttributes(), Side.THREE), this);
+        terminal1 = TerminalImpl.create(index, new ThreeWindingsTransformerToInjectionAttributesAdapter((LegImpl) leg1, resource.getAttributes(), Side.ONE), this);
+        terminal2 = TerminalImpl.create(index, new ThreeWindingsTransformerToInjectionAttributesAdapter((LegImpl) leg2, resource.getAttributes(), Side.TWO), this);
+        terminal3 = TerminalImpl.create(index, new ThreeWindingsTransformerToInjectionAttributesAdapter((LegImpl) leg3, resource.getAttributes(), Side.THREE), this);
 
         ConnectablePositionAttributes cpa1 = resource.getAttributes().getPosition1();
         ConnectablePositionAttributes cpa2 = resource.getAttributes().getPosition2();

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/ThreeWindingsTransformerToInjectionAttributesAdapter.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/ThreeWindingsTransformerToInjectionAttributesAdapter.java
@@ -10,6 +10,7 @@ import com.powsybl.iidm.network.ThreeWindingsTransformer;
 import com.powsybl.network.store.model.*;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -17,11 +18,14 @@ import java.util.Set;
  */
 public class ThreeWindingsTransformerToInjectionAttributesAdapter implements InjectionAttributes {
 
+    private final ThreeWindingsTransformerImpl.LegImpl leg;
+
     private final ThreeWindingsTransformerAttributes attributes;
 
     private final ThreeWindingsTransformer.Side side;
 
-    public ThreeWindingsTransformerToInjectionAttributesAdapter(ThreeWindingsTransformerAttributes attributes, ThreeWindingsTransformer.Side side) {
+    public ThreeWindingsTransformerToInjectionAttributesAdapter(ThreeWindingsTransformerImpl.LegImpl leg, ThreeWindingsTransformerAttributes attributes, ThreeWindingsTransformer.Side side) {
+        this.leg = Objects.requireNonNull(leg);
         this.attributes = attributes;
         this.side = side;
     }
@@ -85,7 +89,9 @@ public class ThreeWindingsTransformerToInjectionAttributesAdapter implements Inj
 
     @Override
     public void setBus(String bus) {
+        String oldValue = getLegAttributes().getBus();
         getLegAttributes().setBus(bus);
+        leg.notifyUpdate("bus", oldValue, bus);
     }
 
     @Override

--- a/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreRepository.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreRepository.java
@@ -12,11 +12,13 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.powsybl.iidm.network.*;
 import com.powsybl.network.store.model.*;
+import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
 import javax.annotation.PostConstruct;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -913,7 +915,7 @@ public class NetworkStoreRepository {
                 .and(set("converterStationId2", bindMarker()))
                 .and(set(HVDC_ANGLE_DROOP_ACTIVE_POWER_CONTROL, bindMarker()))
                 .and(set(HVDC_OPERATOR_ACTIVE_POWER_RANGE, bindMarker()))
-            .where(eq("networkUuid", bindMarker()))
+                .where(eq("networkUuid", bindMarker()))
                 .and(eq("id", bindMarker())));
 
         psInsertDanglingLine = session.prepare(insertInto(DANGLING_LINE)
@@ -1003,6 +1005,14 @@ public class NetworkStoreRepository {
             }
         }
         return bs;
+    }
+
+    private static String emptyStringForNullValue(String value) {
+        return value == null ? "" : value;
+    }
+
+    private static String nullValueForEmptyString(String value) {
+        return StringUtils.isBlank(value) ? null : value;
     }
 
     // network
@@ -1533,7 +1543,7 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getPosition(),
                         reactiveLimits.getKind() == ReactiveLimitsKind.MIN_MAX ? reactiveLimits : null,
                         reactiveLimits.getKind() == ReactiveLimitsKind.CURVE ? reactiveLimits : null,
-                        resource.getAttributes().getBus(),
+                        emptyStringForNullValue(resource.getAttributes().getBus()),
                         resource.getAttributes().getConnectableBus(),
                         resource.getAttributes().getActivePowerControl(),
                         resource.getAttributes().getRegulatingTerminal(),
@@ -1594,7 +1604,7 @@ public class NetworkStoreRepository {
                             .q(one.getDouble(13))
                             .position(one.get(14, ConnectablePositionAttributes.class))
                             .reactiveLimits(minMaxReactiveLimitsAttributes != null ? minMaxReactiveLimitsAttributes : reactiveCapabilityCurveAttributes)
-                            .bus(one.getString(17))
+                            .bus(nullValueForEmptyString(one.getString(17)))
                             .connectableBus(one.getString(18))
                             .activePowerControl(one.get(19, ActivePowerControlAttributes.class))
                             .regulatingTerminal(one.get(20, TerminalRefAttributes.class))
@@ -1660,7 +1670,7 @@ public class NetworkStoreRepository {
                             .q(row.getDouble(14))
                             .position(row.get(15, ConnectablePositionAttributes.class))
                             .reactiveLimits(minMaxReactiveLimitsAttributes != null ? minMaxReactiveLimitsAttributes : reactiveCapabilityCurveAttributes)
-                            .bus(row.getString(18))
+                            .bus(nullValueForEmptyString(row.getString(18)))
                             .connectableBus(row.getString(19))
                             .activePowerControl(row.get(20, ActivePowerControlAttributes.class))
                             .regulatingTerminal(row.get(21, TerminalRefAttributes.class))
@@ -1724,7 +1734,7 @@ public class NetworkStoreRepository {
                             .q(row.getDouble(13))
                             .position(row.get(14, ConnectablePositionAttributes.class))
                             .reactiveLimits(minMaxReactiveLimitsAttributes != null ? minMaxReactiveLimitsAttributes : reactiveCapabilityCurveAttributes)
-                            .bus(row.getString(17))
+                            .bus(nullValueForEmptyString(row.getString(17)))
                             .connectableBus(row.getString(18))
                             .activePowerControl(row.get(19, ActivePowerControlAttributes.class))
                             .regulatingTerminal(row.get(20, TerminalRefAttributes.class))
@@ -1762,7 +1772,7 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getPosition(),
                         reactiveLimits.getKind() == ReactiveLimitsKind.MIN_MAX ? reactiveLimits : null,
                         reactiveLimits.getKind() == ReactiveLimitsKind.CURVE ? reactiveLimits : null,
-                        resource.getAttributes().getBus(),
+                        emptyStringForNullValue(resource.getAttributes().getBus()),
                         resource.getAttributes().getConnectableBus(),
                         resource.getAttributes().getActivePowerControl(),
                         resource.getAttributes().getRegulatingTerminal(),
@@ -1806,7 +1816,7 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getPosition(),
                         reactiveLimits.getKind() == ReactiveLimitsKind.MIN_MAX ? reactiveLimits : null,
                         reactiveLimits.getKind() == ReactiveLimitsKind.CURVE ? reactiveLimits : null,
-                        resource.getAttributes().getBus(),
+                        emptyStringForNullValue(resource.getAttributes().getBus()),
                         resource.getAttributes().getConnectableBus(),
                         resource.getAttributes().getActivePowerControl())));
             }
@@ -1855,7 +1865,7 @@ public class NetworkStoreRepository {
                             .q(one.getDouble(9))
                             .position(one.get(10, ConnectablePositionAttributes.class))
                             .reactiveLimits(minMaxReactiveLimitsAttributes != null ? minMaxReactiveLimitsAttributes : reactiveCapabilityCurveAttributes)
-                            .bus(one.getString(13))
+                            .bus(nullValueForEmptyString(one.getString(13)))
                             .connectableBus(one.getString(14))
                             .fictitious(one.getBool(15))
                             .aliasesWithoutType(one.getSet(16, String.class))
@@ -1909,7 +1919,7 @@ public class NetworkStoreRepository {
                             .q(row.getDouble(10))
                             .position(row.get(11, ConnectablePositionAttributes.class))
                             .reactiveLimits(minMaxReactiveLimitsAttributes != null ? minMaxReactiveLimitsAttributes : reactiveCapabilityCurveAttributes)
-                            .bus(row.getString(14))
+                            .bus(nullValueForEmptyString(row.getString(14)))
                             .connectableBus(row.getString(15))
                             .fictitious(row.getBool(16))
                             .aliasesWithoutType(row.getSet(17, String.class))
@@ -1962,7 +1972,7 @@ public class NetworkStoreRepository {
                             .q(row.getDouble(9))
                             .position(row.get(10, ConnectablePositionAttributes.class))
                             .reactiveLimits(minMaxReactiveLimitsAttributes != null ? minMaxReactiveLimitsAttributes : reactiveCapabilityCurveAttributes)
-                            .bus(row.getString(13))
+                            .bus(nullValueForEmptyString(row.getString(13)))
                             .connectableBus(row.getString(14))
                             .fictitious(row.getBool(15))
                             .aliasesWithoutType(row.getSet(16, String.class))
@@ -1995,7 +2005,7 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getPosition(),
                         reactiveLimits.getKind() == ReactiveLimitsKind.MIN_MAX ? reactiveLimits : null,
                         reactiveLimits.getKind() == ReactiveLimitsKind.CURVE ? reactiveLimits : null,
-                        resource.getAttributes().getBus(),
+                        emptyStringForNullValue(resource.getAttributes().getBus()),
                         resource.getAttributes().getConnectableBus(),
                         resource.getAttributes().getActivePowerControl(),
                         networkUuid,
@@ -2033,7 +2043,7 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getP(),
                         resource.getAttributes().getQ(),
                         resource.getAttributes().getPosition(),
-                        resource.getAttributes().getBus(),
+                        emptyStringForNullValue(resource.getAttributes().getBus()),
                         resource.getAttributes().getConnectableBus(),
                         resource.getAttributes().getLoadDetail()
                 )));
@@ -2076,7 +2086,7 @@ public class NetworkStoreRepository {
                             .p(one.getDouble(7))
                             .q(one.getDouble(8))
                             .position(one.get(9, ConnectablePositionAttributes.class))
-                            .bus(one.getString(10))
+                            .bus(nullValueForEmptyString(one.getString(10)))
                             .connectableBus(one.getString(11))
                             .loadDetail(one.get(12, LoadDetailAttributes.class))
                             .fictitious(one.getBool(13))
@@ -2123,7 +2133,7 @@ public class NetworkStoreRepository {
                             .p(row.getDouble(8))
                             .q(row.getDouble(9))
                             .position(row.get(10, ConnectablePositionAttributes.class))
-                            .bus(row.getString(11))
+                            .bus(nullValueForEmptyString(row.getString(11)))
                             .connectableBus(row.getString(12))
                             .loadDetail(row.get(13, LoadDetailAttributes.class))
                             .fictitious(row.getBool(14))
@@ -2169,7 +2179,7 @@ public class NetworkStoreRepository {
                             .p(row.getDouble(7))
                             .q(row.getDouble(8))
                             .position(row.get(9, ConnectablePositionAttributes.class))
-                            .bus(row.getString(10))
+                            .bus(nullValueForEmptyString(row.getString(10)))
                             .connectableBus(row.getString(11))
                             .loadDetail(row.get(12, LoadDetailAttributes.class))
                             .fictitious(row.getBool(13))
@@ -2198,7 +2208,7 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getP(),
                         resource.getAttributes().getQ(),
                         resource.getAttributes().getPosition(),
-                        resource.getAttributes().getBus(),
+                        emptyStringForNullValue(resource.getAttributes().getBus()),
                         resource.getAttributes().getConnectableBus(),
                         resource.getAttributes().getLoadDetail(),
                         networkUuid,
@@ -2237,7 +2247,7 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getP(),
                         resource.getAttributes().getQ(),
                         resource.getAttributes().getPosition(),
-                        resource.getAttributes().getBus(),
+                        emptyStringForNullValue(resource.getAttributes().getBus()),
                         resource.getAttributes().getConnectableBus(),
                         resource.getAttributes().getRegulatingTerminal(),
                         resource.getAttributes().isVoltageRegulatorOn(),
@@ -2287,7 +2297,7 @@ public class NetworkStoreRepository {
                             .p(row.getDouble(7))
                             .q(row.getDouble(8))
                             .position(row.get(9, ConnectablePositionAttributes.class))
-                            .bus(row.getString(10))
+                            .bus(nullValueForEmptyString(row.getString(10)))
                             .connectableBus(row.getString(11))
                             .regulatingTerminal(row.get(12, TerminalRefAttributes.class))
                             .voltageRegulatorOn(row.getBool(13))
@@ -2341,7 +2351,7 @@ public class NetworkStoreRepository {
                             .p(row.getDouble(8))
                             .q(row.getDouble(9))
                             .position(row.get(10, ConnectablePositionAttributes.class))
-                            .bus(row.getString(11))
+                            .bus(nullValueForEmptyString(row.getString(11)))
                             .connectableBus(row.getString(12))
                             .regulatingTerminal(row.get(13, TerminalRefAttributes.class))
                             .voltageRegulatorOn(row.getBool(14))
@@ -2394,7 +2404,7 @@ public class NetworkStoreRepository {
                             .p(row.getDouble(7))
                             .q(row.getDouble(8))
                             .position(row.get(9, ConnectablePositionAttributes.class))
-                            .bus(row.getString(10))
+                            .bus(nullValueForEmptyString(row.getString(10)))
                             .connectableBus(row.getString(11))
                             .regulatingTerminal(row.get(12, TerminalRefAttributes.class))
                             .voltageRegulatorOn(row.getBool(13))
@@ -2427,7 +2437,7 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getP(),
                         resource.getAttributes().getQ(),
                         resource.getAttributes().getPosition(),
-                        resource.getAttributes().getBus(),
+                        emptyStringForNullValue(resource.getAttributes().getBus()),
                         resource.getAttributes().getConnectableBus(),
                         resource.getAttributes().getRegulatingTerminal(),
                         resource.getAttributes().isVoltageRegulatorOn(),
@@ -2472,7 +2482,7 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getP(),
                         resource.getAttributes().getQ(),
                         resource.getAttributes().getPosition(),
-                        resource.getAttributes().getBus(),
+                        emptyStringForNullValue(resource.getAttributes().getBus()),
                         resource.getAttributes().getConnectableBus()
                 )));
             }
@@ -2520,7 +2530,7 @@ public class NetworkStoreRepository {
                             .p(row.getDouble(10))
                             .q(row.getDouble(11))
                             .position(row.get(12, ConnectablePositionAttributes.class))
-                            .bus(row.getString(13))
+                            .bus(nullValueForEmptyString(row.getString(13)))
                             .connectableBus(row.getString(14))
                             .fictitious(row.getBool(15))
                             .aliasesWithoutType(row.getSet(16, String.class))
@@ -2572,7 +2582,7 @@ public class NetworkStoreRepository {
                             .p(row.getDouble(11))
                             .q(row.getDouble(12))
                             .position(row.get(13, ConnectablePositionAttributes.class))
-                            .bus(row.getString(14))
+                            .bus(nullValueForEmptyString(row.getString(14)))
                             .connectableBus(row.getString(15))
                             .fictitious(row.getBool(16))
                             .aliasesWithoutType(row.getSet(17, String.class))
@@ -2623,7 +2633,7 @@ public class NetworkStoreRepository {
                             .p(row.getDouble(10))
                             .q(row.getDouble(11))
                             .position(row.get(12, ConnectablePositionAttributes.class))
-                            .bus(row.getString(13))
+                            .bus(nullValueForEmptyString(row.getString(13)))
                             .connectableBus(row.getString(14))
                             .fictitious(row.getBool(15))
                             .aliasesWithoutType(row.getSet(16, String.class))
@@ -2655,7 +2665,7 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getP(),
                         resource.getAttributes().getQ(),
                         resource.getAttributes().getPosition(),
-                        resource.getAttributes().getBus(),
+                        emptyStringForNullValue(resource.getAttributes().getBus()),
                         resource.getAttributes().getConnectableBus(),
                         networkUuid,
                         resource.getId(),
@@ -2691,7 +2701,7 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getP(),
                         resource.getAttributes().getQ(),
                         resource.getAttributes().getPosition(),
-                        resource.getAttributes().getBus(),
+                        emptyStringForNullValue(resource.getAttributes().getBus()),
                         resource.getAttributes().getConnectableBus()
                 )));
             }
@@ -2730,7 +2740,7 @@ public class NetworkStoreRepository {
                             .p(row.getDouble(6))
                             .q(row.getDouble(7))
                             .position(row.get(8, ConnectablePositionAttributes.class))
-                            .bus(row.getString(9))
+                            .bus(nullValueForEmptyString(row.getString(9)))
                             .connectableBus(row.getString(10))
                             .fictitious(row.getBool(11))
                             .aliasesWithoutType(row.getSet(12, String.class))
@@ -2773,7 +2783,7 @@ public class NetworkStoreRepository {
                             .p(row.getDouble(7))
                             .q(row.getDouble(8))
                             .position(row.get(9, ConnectablePositionAttributes.class))
-                            .bus(row.getString(10))
+                            .bus(nullValueForEmptyString(row.getString(10)))
                             .connectableBus(row.getString(11))
                             .fictitious(row.getBool(12))
                             .aliasesWithoutType(row.getSet(13, String.class))
@@ -2815,7 +2825,7 @@ public class NetworkStoreRepository {
                             .p(row.getDouble(6))
                             .q(row.getDouble(7))
                             .position(row.get(8, ConnectablePositionAttributes.class))
-                            .bus(row.getString(9))
+                            .bus(nullValueForEmptyString(row.getString(9)))
                             .connectableBus(row.getString(10))
                             .fictitious(row.getBool(11))
                             .aliasesWithoutType(row.getSet(12, String.class))
@@ -2842,7 +2852,7 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getP(),
                         resource.getAttributes().getQ(),
                         resource.getAttributes().getPosition(),
-                        resource.getAttributes().getBus(),
+                        emptyStringForNullValue(resource.getAttributes().getBus()),
                         resource.getAttributes().getConnectableBus(),
                         networkUuid,
                         resource.getId(),
@@ -2881,7 +2891,7 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getP(),
                         resource.getAttributes().getQ(),
                         resource.getAttributes().getPosition(),
-                        resource.getAttributes().getBus(),
+                        emptyStringForNullValue(resource.getAttributes().getBus()),
                         resource.getAttributes().getConnectableBus(),
                         resource.getAttributes().getRegulatingTerminal(),
                         resource.getAttributes().getVoltagePerReactiveControl())));
@@ -2929,7 +2939,7 @@ public class NetworkStoreRepository {
                             .p(row.getDouble(9))
                             .q(row.getDouble(10))
                             .position(row.get(11, ConnectablePositionAttributes.class))
-                            .bus(row.getString(12))
+                            .bus(nullValueForEmptyString(row.getString(12)))
                             .connectableBus(row.getString(13))
                             .regulatingTerminal(row.get(14, TerminalRefAttributes.class))
                             .voltagePerReactiveControl(row.get(15, VoltagePerReactivePowerControlAttributes.class))
@@ -2982,7 +2992,7 @@ public class NetworkStoreRepository {
                             .p(row.getDouble(10))
                             .q(row.getDouble(11))
                             .position(row.get(12, ConnectablePositionAttributes.class))
-                            .bus(row.getString(13))
+                            .bus(nullValueForEmptyString(row.getString(13)))
                             .connectableBus(row.getString(14))
                             .regulatingTerminal(row.get(15, TerminalRefAttributes.class))
                             .voltagePerReactiveControl(row.get(16, VoltagePerReactivePowerControlAttributes.class))
@@ -3034,7 +3044,7 @@ public class NetworkStoreRepository {
                             .p(row.getDouble(9))
                             .q(row.getDouble(10))
                             .position(row.get(11, ConnectablePositionAttributes.class))
-                            .bus(row.getString(12))
+                            .bus(nullValueForEmptyString(row.getString(12)))
                             .connectableBus(row.getString(13))
                             .regulatingTerminal(row.get(14, TerminalRefAttributes.class))
                             .voltagePerReactiveControl(row.get(15, VoltagePerReactivePowerControlAttributes.class))
@@ -3066,7 +3076,7 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getP(),
                         resource.getAttributes().getQ(),
                         resource.getAttributes().getPosition(),
-                        resource.getAttributes().getBus(),
+                        emptyStringForNullValue(resource.getAttributes().getBus()),
                         resource.getAttributes().getConnectableBus(),
                         resource.getAttributes().getRegulatingTerminal(),
                         resource.getAttributes().getVoltagePerReactiveControl(),
@@ -3243,8 +3253,8 @@ public class NetworkStoreRepository {
                         resource.getAttributes().isRetained(),
                         resource.getAttributes().isFictitious(),
                         kind,
-                        resource.getAttributes().getBus1(),
-                        resource.getAttributes().getBus2()
+                        emptyStringForNullValue(resource.getAttributes().getBus1()),
+                        emptyStringForNullValue(resource.getAttributes().getBus2())
                 )));
             }
             session.execute(batch);
@@ -3281,8 +3291,8 @@ public class NetworkStoreRepository {
                             .open(row.getBool(6))
                             .retained(row.getBool(7))
                             .fictitious(row.getBool(8))
-                            .bus1(row.getString(9))
-                            .bus2(row.getString(10))
+                            .bus1(nullValueForEmptyString(row.getString(9)))
+                            .bus2(nullValueForEmptyString(row.getString(10)))
                             .aliasesWithoutType(row.getSet(11, String.class))
                             .aliasByType(row.getMap(12, String.class, String.class))
                             .build())
@@ -3322,8 +3332,8 @@ public class NetworkStoreRepository {
                             .open(row.getBool(7))
                             .retained(row.getBool(8))
                             .fictitious(row.getBool(9))
-                            .bus1(row.getString(10))
-                            .bus2(row.getString(11))
+                            .bus1(nullValueForEmptyString(row.getString(10)))
+                            .bus2(nullValueForEmptyString(row.getString(11)))
                             .aliasesWithoutType(row.getSet(12, String.class))
                             .aliasByType(row.getMap(13, String.class, String.class))
                             .build())
@@ -3362,8 +3372,8 @@ public class NetworkStoreRepository {
                             .open(row.getBool(6))
                             .retained(row.getBool(7))
                             .fictitious(row.getBool(8))
-                            .bus1(row.getString(9))
-                            .bus2(row.getString(10))
+                            .bus1(nullValueForEmptyString(row.getString(9)))
+                            .bus2(nullValueForEmptyString(row.getString(10)))
                             .aliasesWithoutType(row.getSet(11, String.class))
                             .aliasByType(row.getMap(12, String.class, String.class))
                             .build())
@@ -3388,8 +3398,8 @@ public class NetworkStoreRepository {
                         resource.getAttributes().isRetained(),
                         resource.getAttributes().isFictitious(),
                         kind,
-                        resource.getAttributes().getBus1(),
-                        resource.getAttributes().getBus2(),
+                        emptyStringForNullValue(resource.getAttributes().getBus1()),
+                        emptyStringForNullValue(resource.getAttributes().getBus2()),
                         networkUuid,
                         resource.getId(),
                         resource.getAttributes().getVoltageLevelId())
@@ -3436,8 +3446,8 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getPosition2(),
                         resource.getAttributes().getPhaseTapChangerAttributes(),
                         resource.getAttributes().getRatioTapChangerAttributes(),
-                        resource.getAttributes().getBus1(),
-                        resource.getAttributes().getBus2(),
+                        emptyStringForNullValue(resource.getAttributes().getBus1()),
+                        emptyStringForNullValue(resource.getAttributes().getBus2()),
                         resource.getAttributes().getConnectableBus1(),
                         resource.getAttributes().getConnectableBus2(),
                         resource.getAttributes().getCurrentLimits1(),
@@ -3518,8 +3528,8 @@ public class NetworkStoreRepository {
                             .position2(one.get(17, ConnectablePositionAttributes.class))
                             .phaseTapChangerAttributes(one.get(18, PhaseTapChangerAttributes.class))
                             .ratioTapChangerAttributes(one.get(19, RatioTapChangerAttributes.class))
-                            .bus1(one.getString(20))
-                            .bus2(one.getString(21))
+                            .bus1(nullValueForEmptyString(one.getString(20)))
+                            .bus2(nullValueForEmptyString(one.getString(21)))
                             .connectableBus1(one.getString(22))
                             .connectableBus2(one.getString(23))
                             .currentLimits1(one.get(24, LimitsAttributes.class))
@@ -3605,8 +3615,8 @@ public class NetworkStoreRepository {
                             .position2(row.get(18, ConnectablePositionAttributes.class))
                             .phaseTapChangerAttributes(row.get(19, PhaseTapChangerAttributes.class))
                             .ratioTapChangerAttributes(row.get(20, RatioTapChangerAttributes.class))
-                            .bus1(row.getString(21))
-                            .bus2(row.getString(22))
+                            .bus1(nullValueForEmptyString(row.getString(21)))
+                            .bus2(nullValueForEmptyString(row.getString(22)))
                             .connectableBus1(row.getString(23))
                             .connectableBus2(row.getString(24))
                             .currentLimits1(row.get(25, LimitsAttributes.class))
@@ -3691,8 +3701,8 @@ public class NetworkStoreRepository {
                             .position2(row.get(17, ConnectablePositionAttributes.class))
                             .phaseTapChangerAttributes(row.get(18, PhaseTapChangerAttributes.class))
                             .ratioTapChangerAttributes(row.get(19, RatioTapChangerAttributes.class))
-                            .bus1(row.getString(20))
-                            .bus2(row.getString(21))
+                            .bus1(nullValueForEmptyString(row.getString(20)))
+                            .bus2(nullValueForEmptyString(row.getString(21)))
                             .connectableBus1(row.getString(22))
                             .connectableBus2(row.getString(23))
                             .currentLimits1(row.get(24, LimitsAttributes.class))
@@ -3751,8 +3761,8 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getPosition2(),
                         resource.getAttributes().getPhaseTapChangerAttributes(),
                         resource.getAttributes().getRatioTapChangerAttributes(),
-                        resource.getAttributes().getBus1(),
-                        resource.getAttributes().getBus2(),
+                        emptyStringForNullValue(resource.getAttributes().getBus1()),
+                        emptyStringForNullValue(resource.getAttributes().getBus2()),
                         resource.getAttributes().getConnectableBus1(),
                         resource.getAttributes().getConnectableBus2(),
                         resource.getAttributes().getCurrentLimits1(),
@@ -3832,11 +3842,11 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getLeg1().getCurrentLimitsAttributes(),
                         resource.getAttributes().getLeg2().getCurrentLimitsAttributes(),
                         resource.getAttributes().getLeg3().getCurrentLimitsAttributes(),
-                        resource.getAttributes().getLeg1().getBus(),
+                        emptyStringForNullValue(resource.getAttributes().getLeg1().getBus()),
                         resource.getAttributes().getLeg1().getConnectableBus(),
-                        resource.getAttributes().getLeg2().getBus(),
+                        emptyStringForNullValue(resource.getAttributes().getLeg2().getBus()),
                         resource.getAttributes().getLeg2().getConnectableBus(),
-                        resource.getAttributes().getLeg3().getBus(),
+                        emptyStringForNullValue(resource.getAttributes().getLeg3().getBus()),
                         resource.getAttributes().getLeg3().getConnectableBus(),
                         resource.getAttributes().getPhaseAngleClock(),
                         resource.getAttributes().getLeg1().getActivePowerLimitsAttributes(),
@@ -3938,7 +3948,7 @@ public class NetworkStoreRepository {
                                     .phaseTapChangerAttributes(one.get(12, PhaseTapChangerAttributes.class))
                                     .ratioTapChangerAttributes(one.get(13, RatioTapChangerAttributes.class))
                                     .currentLimitsAttributes(one.get(39, LimitsAttributes.class))
-                                    .bus(one.getString(42))
+                                    .bus(nullValueForEmptyString(one.getString(42)))
                                     .connectableBus(one.getString(43))
                                     .activePowerLimitsAttributes(one.get(55, LimitsAttributes.class))
                                     .apparentPowerLimitsAttributes(one.get(58, LimitsAttributes.class))
@@ -3958,7 +3968,7 @@ public class NetworkStoreRepository {
                                     .phaseTapChangerAttributes(one.get(23, PhaseTapChangerAttributes.class))
                                     .ratioTapChangerAttributes(one.get(24, RatioTapChangerAttributes.class))
                                     .currentLimitsAttributes(one.get(40, LimitsAttributes.class))
-                                    .bus(one.getString(44))
+                                    .bus(nullValueForEmptyString(one.getString(44)))
                                     .connectableBus(one.getString(45))
                                     .activePowerLimitsAttributes(one.get(56, LimitsAttributes.class))
                                     .apparentPowerLimitsAttributes(one.get(59, LimitsAttributes.class))
@@ -3978,7 +3988,7 @@ public class NetworkStoreRepository {
                                     .phaseTapChangerAttributes(one.get(34, PhaseTapChangerAttributes.class))
                                     .ratioTapChangerAttributes(one.get(35, RatioTapChangerAttributes.class))
                                     .currentLimitsAttributes(one.get(41, LimitsAttributes.class))
-                                    .bus(one.getString(46))
+                                    .bus(nullValueForEmptyString(one.getString(46)))
                                     .connectableBus(one.getString(47))
                                     .activePowerLimitsAttributes(one.get(57, LimitsAttributes.class))
                                     .apparentPowerLimitsAttributes(one.get(60, LimitsAttributes.class))
@@ -4086,7 +4096,7 @@ public class NetworkStoreRepository {
                                     .phaseTapChangerAttributes(row.get(13, PhaseTapChangerAttributes.class))
                                     .ratioTapChangerAttributes(row.get(14, RatioTapChangerAttributes.class))
                                     .currentLimitsAttributes(row.get(40, LimitsAttributes.class))
-                                    .bus(row.getString(43))
+                                    .bus(nullValueForEmptyString(row.getString(43)))
                                     .connectableBus(row.getString(44))
                                     .activePowerLimitsAttributes(row.get(56, LimitsAttributes.class))
                                     .apparentPowerLimitsAttributes(row.get(59, LimitsAttributes.class))
@@ -4106,7 +4116,7 @@ public class NetworkStoreRepository {
                                     .phaseTapChangerAttributes(row.get(24, PhaseTapChangerAttributes.class))
                                     .ratioTapChangerAttributes(row.get(25, RatioTapChangerAttributes.class))
                                     .currentLimitsAttributes(row.get(41, LimitsAttributes.class))
-                                    .bus(row.getString(45))
+                                    .bus(nullValueForEmptyString(row.getString(45)))
                                     .connectableBus(row.getString(46))
                                     .activePowerLimitsAttributes(row.get(57, LimitsAttributes.class))
                                     .apparentPowerLimitsAttributes(row.get(60, LimitsAttributes.class))
@@ -4126,7 +4136,7 @@ public class NetworkStoreRepository {
                                     .phaseTapChangerAttributes(row.get(35, PhaseTapChangerAttributes.class))
                                     .ratioTapChangerAttributes(row.get(36, RatioTapChangerAttributes.class))
                                     .currentLimitsAttributes(row.get(42, LimitsAttributes.class))
-                                    .bus(row.getString(47))
+                                    .bus(nullValueForEmptyString(row.getString(47)))
                                     .connectableBus(row.getString(48))
                                     .activePowerLimitsAttributes(row.get(58, LimitsAttributes.class))
                                     .apparentPowerLimitsAttributes(row.get(61, LimitsAttributes.class))
@@ -4233,7 +4243,7 @@ public class NetworkStoreRepository {
                                     .phaseTapChangerAttributes(row.get(14, PhaseTapChangerAttributes.class))
                                     .ratioTapChangerAttributes(row.get(15, RatioTapChangerAttributes.class))
                                     .currentLimitsAttributes(row.get(39, LimitsAttributes.class))
-                                    .bus(row.getString(42))
+                                    .bus(nullValueForEmptyString(row.getString(42)))
                                     .connectableBus(row.getString(43))
                                     .activePowerLimitsAttributes(row.get(55, LimitsAttributes.class))
                                     .apparentPowerLimitsAttributes(row.get(58, LimitsAttributes.class))
@@ -4253,7 +4263,7 @@ public class NetworkStoreRepository {
                                     .phaseTapChangerAttributes(row.get(24, PhaseTapChangerAttributes.class))
                                     .ratioTapChangerAttributes(row.get(25, RatioTapChangerAttributes.class))
                                     .currentLimitsAttributes(row.get(40, LimitsAttributes.class))
-                                    .bus(row.getString(44))
+                                    .bus(nullValueForEmptyString(row.getString(44)))
                                     .connectableBus(row.getString(45))
                                     .activePowerLimitsAttributes(row.get(56, LimitsAttributes.class))
                                     .apparentPowerLimitsAttributes(row.get(59, LimitsAttributes.class))
@@ -4273,7 +4283,7 @@ public class NetworkStoreRepository {
                                     .phaseTapChangerAttributes(row.get(34, PhaseTapChangerAttributes.class))
                                     .ratioTapChangerAttributes(row.get(35, RatioTapChangerAttributes.class))
                                     .currentLimitsAttributes(row.get(41, LimitsAttributes.class))
-                                    .bus(row.getString(46))
+                                    .bus(nullValueForEmptyString(row.getString(46)))
                                     .connectableBus(row.getString(47))
                                     .activePowerLimitsAttributes(row.get(57, LimitsAttributes.class))
                                     .apparentPowerLimitsAttributes(row.get(60, LimitsAttributes.class))
@@ -4413,8 +4423,8 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getQ2(),
                         resource.getAttributes().getPosition1(),
                         resource.getAttributes().getPosition2(),
-                        resource.getAttributes().getBus1(),
-                        resource.getAttributes().getBus2(),
+                        emptyStringForNullValue(resource.getAttributes().getBus1()),
+                        emptyStringForNullValue(resource.getAttributes().getBus2()),
                         resource.getAttributes().getConnectableBus1(),
                         resource.getAttributes().getConnectableBus2(),
                         resource.getAttributes().getMergedXnode(),
@@ -4490,8 +4500,8 @@ public class NetworkStoreRepository {
                             .q2(one.getDouble(15))
                             .position1(one.get(16, ConnectablePositionAttributes.class))
                             .position2(one.get(17, ConnectablePositionAttributes.class))
-                            .bus1(one.getString(18))
-                            .bus2(one.getString(19))
+                            .bus1(nullValueForEmptyString(one.getString(18)))
+                            .bus2(nullValueForEmptyString(one.getString(19)))
                             .connectableBus1(one.getString(20))
                             .connectableBus2(one.getString(21))
                             .mergedXnode(one.get(22, MergedXnodeAttributes.class))
@@ -4571,8 +4581,8 @@ public class NetworkStoreRepository {
                             .q2(row.getDouble(16))
                             .position1(row.get(17, ConnectablePositionAttributes.class))
                             .position2(row.get(18, ConnectablePositionAttributes.class))
-                            .bus1(row.getString(19))
-                            .bus2(row.getString(20))
+                            .bus1(nullValueForEmptyString(row.getString(19)))
+                            .bus2(nullValueForEmptyString(row.getString(20)))
                             .connectableBus1(row.getString(21))
                             .connectableBus2(row.getString(22))
                             .mergedXnode(row.get(23, MergedXnodeAttributes.class))
@@ -4651,8 +4661,8 @@ public class NetworkStoreRepository {
                             .q2(row.getDouble(15))
                             .position1(row.get(16, ConnectablePositionAttributes.class))
                             .position2(row.get(17, ConnectablePositionAttributes.class))
-                            .bus1(row.getString(18))
-                            .bus2(row.getString(19))
+                            .bus1(nullValueForEmptyString(row.getString(18)))
+                            .bus2(nullValueForEmptyString(row.getString(19)))
                             .connectableBus1(row.getString(20))
                             .connectableBus2(row.getString(21))
                             .mergedXnode(row.get(22, MergedXnodeAttributes.class))
@@ -4707,8 +4717,8 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getQ2(),
                         resource.getAttributes().getPosition1(),
                         resource.getAttributes().getPosition2(),
-                        resource.getAttributes().getBus1(),
-                        resource.getAttributes().getBus2(),
+                        emptyStringForNullValue(resource.getAttributes().getBus1()),
+                        emptyStringForNullValue(resource.getAttributes().getBus2()),
                         resource.getAttributes().getConnectableBus1(),
                         resource.getAttributes().getConnectableBus2(),
                         resource.getAttributes().getMergedXnode(),
@@ -4770,7 +4780,7 @@ public class NetworkStoreRepository {
                             .aliasByType(row.getMap(12, String.class, String.class))
                             .hvdcAngleDroopActivePowerControl(row.get(13, HvdcAngleDroopActivePowerControlAttributes.class))
                             .hvdcOperatorActivePowerRange(row.get(14, HvdcOperatorActivePowerRangeAttributes.class))
-                        .build())
+                            .build())
                     .build());
         }
         return resources;
@@ -4812,7 +4822,7 @@ public class NetworkStoreRepository {
                             .aliasByType(one.getMap(11, String.class, String.class))
                             .hvdcAngleDroopActivePowerControl(one.get(12, HvdcAngleDroopActivePowerControlAttributes.class))
                             .hvdcOperatorActivePowerRange(one.get(13, HvdcOperatorActivePowerRangeAttributes.class))
-                        .build())
+                            .build())
                     .build());
         }
         return Optional.empty();
@@ -4926,7 +4936,7 @@ public class NetworkStoreRepository {
                             .p(row.getDouble(14))
                             .q(row.getDouble(15))
                             .position(row.get(16, ConnectablePositionAttributes.class))
-                            .bus(row.getString(17))
+                            .bus(nullValueForEmptyString(row.getString(17)))
                             .connectableBus(row.getString(18))
                             .fictitious(row.getBool(19))
                             .aliasesWithoutType(row.getSet(20, String.class))
@@ -4986,7 +4996,7 @@ public class NetworkStoreRepository {
                             .p(one.getDouble(13))
                             .q(one.getDouble(14))
                             .position(one.get(15, ConnectablePositionAttributes.class))
-                            .bus(one.getString(16))
+                            .bus(nullValueForEmptyString(one.getString(16)))
                             .connectableBus(one.getString(17))
                             .fictitious(one.getBool(18))
                             .aliasesWithoutType(one.getSet(19, String.class))
@@ -5046,7 +5056,7 @@ public class NetworkStoreRepository {
                             .p(row.getDouble(13))
                             .q(row.getDouble(14))
                             .position(row.get(15, ConnectablePositionAttributes.class))
-                            .bus(row.getString(16))
+                            .bus(nullValueForEmptyString(row.getString(16)))
                             .connectableBus(row.getString(17))
                             .fictitious(row.getBool(18))
                             .aliasesWithoutType(row.getSet(19, String.class))
@@ -5085,7 +5095,7 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getP(),
                         resource.getAttributes().getQ(),
                         resource.getAttributes().getPosition(),
-                        resource.getAttributes().getBus(),
+                        emptyStringForNullValue(resource.getAttributes().getBus()),
                         resource.getAttributes().getConnectableBus(),
                         resource.getAttributes().getActivePowerLimits(),
                         resource.getAttributes().getApparentPowerLimits()
@@ -5122,7 +5132,7 @@ public class NetworkStoreRepository {
                         resource.getAttributes().getP(),
                         resource.getAttributes().getQ(),
                         resource.getAttributes().getPosition(),
-                        resource.getAttributes().getBus(),
+                        emptyStringForNullValue(resource.getAttributes().getBus()),
                         resource.getAttributes().getConnectableBus(),
                         resource.getAttributes().getActivePowerLimits(),
                         resource.getAttributes().getApparentPowerLimits(),


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
In node/breaker toplogy, when we connect or disconnect a terminal no notification is sent to listeners


**What is the new behavior (if this is a feature change)?**
In node/breaker toplogy, when we connect or disconnect a terminal notifications are sent to listeners

