### PR TITLE
Invalidate calculated buses in voltage level on element creation and removal

### DIFF
--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractBranchImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractBranchImpl.java
@@ -26,9 +26,9 @@ import java.util.Objects;
 public abstract class AbstractBranchImpl<T extends Branch<T>, U extends BranchAttributes> extends AbstractIdentifiableImpl<T, U>
         implements Branch<T>, LimitsOwner<Branch.Side>, ConnectablePositionCreator<T> {
 
-    private final Terminal terminal1;
+    private final TerminalImpl<BranchToInjectionAttributesAdapter> terminal1;
 
-    private final Terminal terminal2;
+    private final TerminalImpl<BranchToInjectionAttributesAdapter> terminal2;
 
     private ConnectablePositionImpl<T> connectablePositionExtension;
 
@@ -53,12 +53,12 @@ public abstract class AbstractBranchImpl<T extends Branch<T>, U extends BranchAt
     }
 
     @Override
-    public Terminal getTerminal1() {
+    public TerminalImpl<BranchToInjectionAttributesAdapter> getTerminal1() {
         return terminal1;
     }
 
     @Override
-    public Terminal getTerminal2() {
+    public TerminalImpl<BranchToInjectionAttributesAdapter> getTerminal2() {
         return terminal2;
     }
 
@@ -208,11 +208,6 @@ public abstract class AbstractBranchImpl<T extends Branch<T>, U extends BranchAt
             index.notifyUpdate(this, "apparentPowerLimits2", oldActivePowerLimits, activePowerLimitsAttributes);
         }
         updateResource();
-    }
-
-    @Override
-    public void remove() {
-        throw new UnsupportedOperationException("TODO");
     }
 
     @Override

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractInjectionImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractInjectionImpl.java
@@ -25,7 +25,7 @@ import java.util.Objects;
  */
 public abstract class AbstractInjectionImpl<I extends Injection<I>, D extends InjectionAttributes> extends AbstractIdentifiableImpl<I, D> implements ConnectablePositionCreator<I> {
 
-    protected final Terminal terminal;
+    protected final TerminalImpl<D> terminal;
 
     private ConnectablePositionImpl<I> connectablePositionExtension;
 
@@ -45,13 +45,8 @@ public abstract class AbstractInjectionImpl<I extends Injection<I>, D extends In
         return Collections.singletonList(terminal);
     }
 
-    public Terminal getTerminal() {
+    public TerminalImpl<D> getTerminal() {
         return terminal;
-    }
-
-    public void remove() {
-        //TODO
-        throw new UnsupportedOperationException("TODO");
     }
 
     @Override

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractSwitchAdder.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractSwitchAdder.java
@@ -41,4 +41,10 @@ abstract class AbstractSwitchAdder<T extends AbstractSwitchAdder<T>> extends Abs
     protected String getTypeDescription() {
         return "Switch";
     }
+
+    protected void invalidateCalculatedBuses() {
+        index.getVoltageLevel(voltageLevelResource.getId())
+                .orElseThrow(AssertionError::new)
+                .invalidateCalculatedBuses();
+    }
 }

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/BatteryAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/BatteryAdderImpl.java
@@ -88,7 +88,9 @@ public class BatteryAdderImpl extends AbstractInjectionAdder<BatteryAdderImpl> i
                         .reactiveLimits(minMaxAttributes)
                         .build())
                 .build();
-        return getIndex().createBattery(resource);
+        BatteryImpl battery = getIndex().createBattery(resource);
+        battery.getTerminal().getVoltageLevel().invalidateCalculatedBuses();
+        return battery;
     }
 
     @Override

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/BatteryImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/BatteryImpl.java
@@ -197,18 +197,19 @@ public class BatteryImpl extends AbstractInjectionImpl<Battery, BatteryAttribute
 
     @Override
     public ReactiveCapabilityCurveAdder newReactiveCapabilityCurve() {
-        return new ReactiveCapabilityCurveAdderImpl(this);
+        return new ReactiveCapabilityCurveAdderImpl<>(this);
     }
 
     @Override
     public MinMaxReactiveLimitsAdder newMinMaxReactiveLimits() {
-        return new MinMaxReactiveLimitsAdderImpl(this);
+        return new MinMaxReactiveLimitsAdderImpl<>(this);
     }
 
     @Override
     public void remove() {
         var resource = checkResource();
         index.removeBattery(resource.getId());
+        getTerminal().getVoltageLevel().invalidateCalculatedBuses();
         index.notifyRemoval(this);
     }
 

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/BusbarSectionAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/BusbarSectionAdderImpl.java
@@ -46,7 +46,9 @@ class BusbarSectionAdderImpl extends AbstractIdentifiableAdder<BusbarSectionAdde
                                                    .node(node)
                                                    .build())
                 .build();
-        return getIndex().createBusbarSection(resource);
+        BusbarSectionImpl busbarSection = getIndex().createBusbarSection(resource);
+        busbarSection.getTerminal().getVoltageLevel().invalidateCalculatedBuses();
+        return busbarSection;
     }
 
     @Override

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/BusbarSectionImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/BusbarSectionImpl.java
@@ -26,7 +26,7 @@ import java.util.List;
  */
 public class BusbarSectionImpl extends AbstractIdentifiableImpl<BusbarSection, BusbarSectionAttributes> implements BusbarSection {
 
-    protected final Terminal terminal;
+    protected final TerminalImpl<BusbarSectionToInjectionAdapter> terminal;
 
     private BusbarSectionPositionImpl busbarSectionPosition;
 
@@ -56,10 +56,11 @@ public class BusbarSectionImpl extends AbstractIdentifiableImpl<BusbarSection, B
     public void remove() {
         var resource = checkResource();
         index.removeBusBarSection(resource.getId());
+        getTerminal().getVoltageLevel().invalidateCalculatedBuses();
         index.notifyRemoval(this);
     }
 
-    public Terminal getTerminal() {
+    public TerminalImpl<BusbarSectionToInjectionAdapter> getTerminal() {
         return terminal;
     }
 

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/ConfiguredBusAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/ConfiguredBusAdderImpl.java
@@ -38,6 +38,8 @@ public class ConfiguredBusAdderImpl extends AbstractIdentifiableAdder<Configured
                         .fictitious(isFictitious())
                         .build())
                 .build();
+        // no need to invalidate calculated buses because a single configured bus (with no element connected)
+        // does not give a calculated bus
         return getIndex().createBus(resource);
     }
 

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/DanglingLineAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/DanglingLineAdderImpl.java
@@ -187,7 +187,9 @@ public class DanglingLineAdderImpl extends AbstractInjectionAdder<DanglingLineAd
                         .ucteXnodeCode(ucteXNodeCode)
                         .build())
                 .build();
-        return getIndex().createDanglingLine(resource);
+        DanglingLineImpl danglingLine = getIndex().createDanglingLine(resource);
+        danglingLine.getTerminal().getVoltageLevel().invalidateCalculatedBuses();
+        return danglingLine;
     }
 
     @Override

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/DanglingLineImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/DanglingLineImpl.java
@@ -259,6 +259,7 @@ public class DanglingLineImpl extends AbstractInjectionImpl<DanglingLine, Dangli
     @Override
     public void remove() {
         index.removeDanglingLine(checkResource().getId());
+        getTerminal().getVoltageLevel().invalidateCalculatedBuses();
         index.notifyRemoval(this);
     }
 

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/GeneratorAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/GeneratorAdderImpl.java
@@ -141,7 +141,9 @@ class GeneratorAdderImpl extends AbstractInjectionAdder<GeneratorAdderImpl> impl
                         .regulatingTerminal(terminalRefAttributes)
                         .build())
                 .build();
-        return getIndex().createGenerator(resource);
+        GeneratorImpl generator = getIndex().createGenerator(resource);
+        generator.getTerminal().getVoltageLevel().invalidateCalculatedBuses();
+        return generator;
     }
 
     @Override

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/GeneratorImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/GeneratorImpl.java
@@ -96,6 +96,7 @@ public class GeneratorImpl extends AbstractInjectionImpl<Generator, GeneratorAtt
     @Override
     public void remove() {
         index.removeGenerator(checkResource().getId());
+        getTerminal().getVoltageLevel().invalidateCalculatedBuses();
         index.notifyRemoval(this);
     }
 

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/LccConverterStationAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/LccConverterStationAdderImpl.java
@@ -50,7 +50,9 @@ public class LccConverterStationAdderImpl extends AbstractHvdcConverterStationAd
                         .powerFactor(powerFactor)
                         .build())
                 .build();
-        return getIndex().createLccConverterStation(resource);
+        LccConverterStationImpl station = getIndex().createLccConverterStation(resource);
+        station.getTerminal().getVoltageLevel().invalidateCalculatedBuses();
+        return station;
     }
 
     @Override

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/LccConverterStationImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/LccConverterStationImpl.java
@@ -82,6 +82,7 @@ public class LccConverterStationImpl extends AbstractHvdcConverterStationImpl<Lc
             throw new ValidationException(this, "Impossible to remove this converter station (still attached to '" + hvdcLine.getId() + "')");
         }
         index.removeLccConverterStation(resource.getId());
+        getTerminal().getVoltageLevel().invalidateCalculatedBuses();
         index.notifyRemoval(this);
     }
 }

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/LineAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/LineAdderImpl.java
@@ -106,7 +106,10 @@ class LineAdderImpl extends AbstractBranchAdder<LineAdderImpl> implements LineAd
                         .b2(b2)
                         .build())
                 .build();
-        return getIndex().createLine(resource);
+        LineImpl line = getIndex().createLine(resource);
+        line.getTerminal1().getVoltageLevel().invalidateCalculatedBuses();
+        line.getTerminal2().getVoltageLevel().invalidateCalculatedBuses();
+        return line;
     }
 
     @Override

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/LineImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/LineImpl.java
@@ -217,6 +217,8 @@ public class LineImpl extends AbstractBranchImpl<Line, LineAttributes> implement
     public void remove() {
         var resource = checkResource();
         index.removeLine(resource.getId());
+        getTerminal1().getVoltageLevel().invalidateCalculatedBuses();
+        getTerminal2().getVoltageLevel().invalidateCalculatedBuses();
         index.notifyRemoval(this);
     }
 }

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/LoadAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/LoadAdderImpl.java
@@ -72,8 +72,8 @@ class LoadAdderImpl extends AbstractInjectionAdder<LoadAdderImpl> implements Loa
                                           .q0(q0)
                                           .build())
                 .build();
-        Load load = getIndex().createLoad(resource);
-        ((VoltageLevelImpl) load.getTerminal().getVoltageLevel()).invalidateCalculatedBuses();
+        LoadImpl load = getIndex().createLoad(resource);
+        load.getTerminal().getVoltageLevel().invalidateCalculatedBuses();
         return load;
     }
 

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/LoadAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/LoadAdderImpl.java
@@ -72,7 +72,9 @@ class LoadAdderImpl extends AbstractInjectionAdder<LoadAdderImpl> implements Loa
                                           .q0(q0)
                                           .build())
                 .build();
-        return getIndex().createLoad(resource);
+        Load load = getIndex().createLoad(resource);
+        ((VoltageLevelImpl) load.getTerminal().getVoltageLevel()).invalidateCalculatedBuses();
+        return load;
     }
 
     @Override

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/LoadImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/LoadImpl.java
@@ -156,6 +156,7 @@ public class LoadImpl extends AbstractInjectionImpl<Load, LoadAttributes> implem
     @Override
     public void remove() {
         index.removeLoad(checkResource().getId());
+        getTerminal().getVoltageLevel().invalidateCalculatedBuses();
         index.notifyRemoval(this);
     }
 

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkObjectIndex.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkObjectIndex.java
@@ -528,7 +528,7 @@ public class NetworkObjectIndex {
         return generatorCache.getSome(voltageLevelId).collect(Collectors.toList());
     }
 
-    Generator createGenerator(Resource<GeneratorAttributes> resource) {
+    GeneratorImpl createGenerator(Resource<GeneratorAttributes> resource) {
         return generatorCache.create(resource);
     }
 
@@ -550,7 +550,7 @@ public class NetworkObjectIndex {
         return batteryCache.getSome(voltageLevelId).collect(Collectors.toList());
     }
 
-    Battery createBattery(Resource<BatteryAttributes> resource) {
+    BatteryImpl createBattery(Resource<BatteryAttributes> resource) {
         return batteryCache.create(resource);
     }
 
@@ -572,7 +572,7 @@ public class NetworkObjectIndex {
         return loadCache.getSome(voltageLevelId).collect(Collectors.toList());
     }
 
-    Load createLoad(Resource<LoadAttributes> resource) {
+    LoadImpl createLoad(Resource<LoadAttributes> resource) {
         return loadCache.create(resource);
     }
 
@@ -594,7 +594,7 @@ public class NetworkObjectIndex {
         return busbarSectionCache.getSome(voltageLevelId).collect(Collectors.toList());
     }
 
-    BusbarSection createBusbarSection(Resource<BusbarSectionAttributes> resource) {
+    BusbarSectionImpl createBusbarSection(Resource<BusbarSectionAttributes> resource) {
         return busbarSectionCache.create(resource);
     }
 
@@ -638,7 +638,7 @@ public class NetworkObjectIndex {
         return twoWindingsTransformerCache.getSome(voltageLevelId).collect(Collectors.toList());
     }
 
-    TwoWindingsTransformer createTwoWindingsTransformer(Resource<TwoWindingsTransformerAttributes> resource) {
+    TwoWindingsTransformerImpl createTwoWindingsTransformer(Resource<TwoWindingsTransformerAttributes> resource) {
         return twoWindingsTransformerCache.create(resource);
     }
 
@@ -660,7 +660,7 @@ public class NetworkObjectIndex {
         return threeWindingsTransformerCache.getSome(voltageLevelId).collect(Collectors.toList());
     }
 
-    ThreeWindingsTransformer createThreeWindingsTransformer(Resource<ThreeWindingsTransformerAttributes> resource) {
+    ThreeWindingsTransformerImpl createThreeWindingsTransformer(Resource<ThreeWindingsTransformerAttributes> resource) {
         return threeWindingsTransformerCache.create(resource);
     }
 
@@ -686,7 +686,7 @@ public class NetworkObjectIndex {
         return lineCache.getSome(voltageLevelId).collect(Collectors.toList());
     }
 
-    Line createLine(Resource<LineAttributes> resource) {
+    LineImpl createLine(Resource<LineAttributes> resource) {
         return lineCache.create(resource);
     }
 
@@ -709,7 +709,7 @@ public class NetworkObjectIndex {
         return shuntCompensatorCache.getSome(voltageLevelId).collect(Collectors.toList());
     }
 
-    ShuntCompensator createShuntCompensator(Resource<ShuntCompensatorAttributes> resource) {
+    ShuntCompensatorImpl createShuntCompensator(Resource<ShuntCompensatorAttributes> resource) {
         return shuntCompensatorCache.create(resource);
     }
 
@@ -731,7 +731,7 @@ public class NetworkObjectIndex {
         return vscConverterStationCache.getSome(voltageLevelId).collect(Collectors.toList());
     }
 
-    public VscConverterStation createVscConverterStation(Resource<VscConverterStationAttributes> resource) {
+    public VscConverterStationImpl createVscConverterStation(Resource<VscConverterStationAttributes> resource) {
         return vscConverterStationCache.create(resource);
     }
 
@@ -753,7 +753,7 @@ public class NetworkObjectIndex {
         return lccConverterStationCache.getSome(voltageLevelId).collect(Collectors.toList());
     }
 
-    public LccConverterStation createLccConverterStation(Resource<LccConverterStationAttributes> resource) {
+    public LccConverterStationImpl createLccConverterStation(Resource<LccConverterStationAttributes> resource) {
         return lccConverterStationCache.create(resource);
     }
 
@@ -783,7 +783,7 @@ public class NetworkObjectIndex {
         return staticVarCompensatorCache.getSome(voltageLevelId).collect(Collectors.toList());
     }
 
-    public StaticVarCompensator createStaticVarCompensator(Resource<StaticVarCompensatorAttributes> resource) {
+    public StaticVarCompensatorImpl createStaticVarCompensator(Resource<StaticVarCompensatorAttributes> resource) {
         return staticVarCompensatorCache.create(resource);
     }
 
@@ -823,7 +823,7 @@ public class NetworkObjectIndex {
         return danglingLineCache.getSome(voltageLevelId).collect(Collectors.toList());
     }
 
-    public DanglingLine createDanglingLine(Resource<DanglingLineAttributes> resource) {
+    public DanglingLineImpl createDanglingLine(Resource<DanglingLineAttributes> resource) {
         return danglingLineCache.create(resource);
     }
 

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/ShuntCompensatorAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/ShuntCompensatorAdderImpl.java
@@ -241,7 +241,9 @@ public class ShuntCompensatorAdderImpl extends AbstractInjectionAdder<ShuntCompe
                         .targetDeadband(targetDeadband)
                         .build())
                 .build();
-        return getIndex().createShuntCompensator(resource);
+        ShuntCompensatorImpl shuntCompensator = getIndex().createShuntCompensator(resource);
+        shuntCompensator.getTerminal().getVoltageLevel().invalidateCalculatedBuses();
+        return shuntCompensator;
     }
 
     @Override

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/ShuntCompensatorImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/ShuntCompensatorImpl.java
@@ -197,6 +197,7 @@ public class ShuntCompensatorImpl extends AbstractInjectionImpl<ShuntCompensator
     public void remove() {
         var resource = checkResource();
         index.removeShuntCompensator(resource.getId());
+        getTerminal().getVoltageLevel().invalidateCalculatedBuses();
         index.notifyRemoval(this);
     }
 }

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/StaticVarCompensatorAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/StaticVarCompensatorAdderImpl.java
@@ -98,7 +98,9 @@ public class StaticVarCompensatorAdderImpl extends AbstractInjectionAdder<Static
                         .regulatingTerminal(terminalRefAttributes)
                         .build())
                 .build();
-        return getIndex().createStaticVarCompensator(resource);
+        StaticVarCompensatorImpl svc = getIndex().createStaticVarCompensator(resource);
+        svc.getTerminal().getVoltageLevel().invalidateCalculatedBuses();
+        return svc;
     }
 
     @Override

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/StaticVarCompensatorImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/StaticVarCompensatorImpl.java
@@ -194,6 +194,7 @@ public class StaticVarCompensatorImpl extends AbstractInjectionImpl<StaticVarCom
     public void remove() {
         var resource = checkResource();
         index.removeStaticVarCompensator(resource.getId());
+        getTerminal().getVoltageLevel().invalidateCalculatedBuses();
         index.notifyRemoval(this);
     }
 }

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/SwitchAdderBusBreakerImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/SwitchAdderBusBreakerImpl.java
@@ -64,6 +64,8 @@ class SwitchAdderBusBreakerImpl extends AbstractSwitchAdder<SwitchAdderBusBreake
                         .fictitious(isFictitious())
                         .build())
                 .build();
-        return getIndex().createSwitch(resource);
+        Switch aSwitch = getIndex().createSwitch(resource);
+        invalidateCalculatedBuses();
+        return aSwitch;
     }
 }

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/SwitchAdderNodeBreakerImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/SwitchAdderNodeBreakerImpl.java
@@ -89,6 +89,8 @@ class SwitchAdderNodeBreakerImpl extends AbstractSwitchAdder<SwitchAdderNodeBrea
                         .fictitious(isFictitious())
                         .build())
                 .build();
-        return getIndex().createSwitch(resource);
+        Switch aSwitch = getIndex().createSwitch(resource);
+        invalidateCalculatedBuses();
+        return aSwitch;
     }
 }

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/TerminalImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/TerminalImpl.java
@@ -84,7 +84,7 @@ public class TerminalImpl<U extends InjectionAttributes> implements Terminal, Va
     }
 
     @Override
-    public VoltageLevel getVoltageLevel() {
+    public VoltageLevelImpl getVoltageLevel() {
         return index.getVoltageLevel(attributes.getVoltageLevelId()).orElseThrow(AssertionError::new);
     }
 

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/ThreeWindingsTransformerAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/ThreeWindingsTransformerAdderImpl.java
@@ -295,7 +295,11 @@ public class ThreeWindingsTransformerAdderImpl extends AbstractIdentifiableAdder
                         .leg3(leg3)
                         .build())
                 .build();
-        return getIndex().createThreeWindingsTransformer(resource);
+        ThreeWindingsTransformerImpl transformer = getIndex().createThreeWindingsTransformer(resource);
+        transformer.getLeg1().getTerminal().getVoltageLevel().invalidateCalculatedBuses();
+        transformer.getLeg2().getTerminal().getVoltageLevel().invalidateCalculatedBuses();
+        transformer.getLeg3().getTerminal().getVoltageLevel().invalidateCalculatedBuses();
+        return transformer;
     }
 
     @Override

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/ThreeWindingsTransformerImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/ThreeWindingsTransformerImpl.java
@@ -25,17 +25,17 @@ import java.util.*;
  */
 public class ThreeWindingsTransformerImpl extends AbstractIdentifiableImpl<ThreeWindingsTransformer, ThreeWindingsTransformerAttributes> implements ThreeWindingsTransformer, ConnectablePositionCreator<ThreeWindingsTransformer> {
 
-    private final Terminal terminal1;
+    private final TerminalImpl<ThreeWindingsTransformerToInjectionAttributesAdapter> terminal1;
 
-    private final Terminal terminal2;
+    private final TerminalImpl<ThreeWindingsTransformerToInjectionAttributesAdapter> terminal2;
 
-    private final Terminal terminal3;
+    private final TerminalImpl<ThreeWindingsTransformerToInjectionAttributesAdapter> terminal3;
 
-    private final Leg leg1;
+    private final LegImpl leg1;
 
-    private final Leg leg2;
+    private final LegImpl leg2;
 
-    private final Leg leg3;
+    private final LegImpl leg3;
 
     private ConnectablePositionImpl<ThreeWindingsTransformer> connectablePositionExtension;
 
@@ -60,7 +60,7 @@ public class ThreeWindingsTransformerImpl extends AbstractIdentifiableImpl<Three
         }
 
         @Override
-        public Terminal getTerminal() {
+        public TerminalImpl<ThreeWindingsTransformerToInjectionAttributesAdapter> getTerminal() {
             if (attributes.getLegNumber() == 1) {
                 return transformer.terminal1;
             } else if (attributes.getLegNumber() == 2) {
@@ -348,17 +348,17 @@ public class ThreeWindingsTransformerImpl extends AbstractIdentifiableImpl<Three
     }
 
     @Override
-    public Leg getLeg1() {
+    public LegImpl getLeg1() {
         return leg1;
     }
 
     @Override
-    public Leg getLeg2() {
+    public LegImpl getLeg2() {
         return leg2;
     }
 
     @Override
-    public Leg getLeg3() {
+    public LegImpl getLeg3() {
         return leg3;
     }
 
@@ -381,6 +381,9 @@ public class ThreeWindingsTransformerImpl extends AbstractIdentifiableImpl<Three
     public void remove() {
         var resource = checkResource();
         index.removeThreeWindingsTransformer(resource.getId());
+        leg1.getTerminal().getVoltageLevel().invalidateCalculatedBuses();
+        leg2.getTerminal().getVoltageLevel().invalidateCalculatedBuses();
+        leg3.getTerminal().getVoltageLevel().invalidateCalculatedBuses();
         index.notifyRemoval(this);
     }
 

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/TieLineAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/TieLineAdderImpl.java
@@ -240,7 +240,10 @@ public class TieLineAdderImpl extends AbstractBranchAdder<TieLineAdderImpl> impl
                                         .build())
                         .build()).build();
         getIndex().createLine(resource);
-        return new TieLineImpl(getIndex(), resource);
+        TieLineImpl tieLine = new TieLineImpl(getIndex(), resource);
+        tieLine.getTerminal1().getVoltageLevel().invalidateCalculatedBuses();
+        tieLine.getTerminal2().getVoltageLevel().invalidateCalculatedBuses();
+        return tieLine;
     }
 
     private void validate() {

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/TwoWindingsTransformerAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/TwoWindingsTransformerAdderImpl.java
@@ -129,7 +129,10 @@ class TwoWindingsTransformerAdderImpl extends AbstractBranchAdder<TwoWindingsTra
                         .fictitious(isFictitious())
                         .build())
                 .build();
-        return getIndex().createTwoWindingsTransformer(resource);
+        TwoWindingsTransformerImpl transformer = getIndex().createTwoWindingsTransformer(resource);
+        transformer.getTerminal1().getVoltageLevel().invalidateCalculatedBuses();
+        transformer.getTerminal2().getVoltageLevel().invalidateCalculatedBuses();
+        return transformer;
     }
 
     @Override

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/TwoWindingsTransformerImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/TwoWindingsTransformerImpl.java
@@ -201,6 +201,8 @@ public class TwoWindingsTransformerImpl extends AbstractBranchImpl<TwoWindingsTr
     public void remove() {
         var resource = checkResource();
         index.removeTwoWindingsTransformer(resource.getId());
+        getTerminal1().getVoltageLevel().invalidateCalculatedBuses();
+        getTerminal2().getVoltageLevel().invalidateCalculatedBuses();
         index.notifyRemoval(this);
     }
 

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/VscConverterStationAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/VscConverterStationAdderImpl.java
@@ -68,7 +68,9 @@ public class VscConverterStationAdderImpl extends AbstractHvdcConverterStationAd
                         .reactivePowerSetPoint(reactivePowerSetPoint)
                         .build())
                 .build();
-        return getIndex().createVscConverterStation(resource);
+        VscConverterStationImpl station = getIndex().createVscConverterStation(resource);
+        station.getTerminal().getVoltageLevel().invalidateCalculatedBuses();
+        return station;
     }
 
     @Override

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/VscConverterStationImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/VscConverterStationImpl.java
@@ -157,6 +157,7 @@ public class VscConverterStationImpl extends AbstractHvdcConverterStationImpl<Vs
             throw new ValidationException(this, "Impossible to remove this converter station (still attached to '" + hvdcLine.getId() + "')");
         }
         index.removeVscConverterStation(resource.getId());
+        getTerminal().getVoltageLevel().invalidateCalculatedBuses();
         index.notifyRemoval(this);
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
The calculated buses for the voltage level are not invalidated when adding a new load in the network


**What is the new behavior (if this is a feature change)?**
Calculated buses are now invalidated


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
