### PR TITLE
Make the database flush optional when importing a network

### DIFF
--- a/network-store-client/src/main/java/com/powsybl/network/store/client/NetworkStoreService.java
+++ b/network-store-client/src/main/java/com/powsybl/network/store/client/NetworkStoreService.java
@@ -32,7 +32,10 @@ import org.springframework.stereotype.Service;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.UUID;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
@@ -137,7 +140,11 @@ public class NetworkStoreService implements AutoCloseable {
     }
 
     public Network importNetwork(ReadOnlyDataSource dataSource, Reporter reporter) {
-        return importNetwork(dataSource, null, LocalComputationManager.getDefault(), null, reporter);
+        return importNetwork(dataSource, reporter, true);
+    }
+
+    public Network importNetwork(ReadOnlyDataSource dataSource, Reporter reporter, boolean flush) {
+        return importNetwork(dataSource, null, LocalComputationManager.getDefault(), null, reporter, flush);
     }
 
     public Network importNetwork(ReadOnlyDataSource dataSource, PreloadingStrategy preloadingStrategy) {
@@ -146,17 +153,29 @@ public class NetworkStoreService implements AutoCloseable {
 
     public Network importNetwork(ReadOnlyDataSource dataSource, PreloadingStrategy preloadingStrategy,
                                  ComputationManager computationManager, Properties parameters) {
+        return importNetwork(dataSource, preloadingStrategy, computationManager, parameters, true);
+    }
+
+    public Network importNetwork(ReadOnlyDataSource dataSource, PreloadingStrategy preloadingStrategy,
+                                 ComputationManager computationManager, Properties parameters, boolean flush) {
         Importer importer = Importers.findImporter(dataSource, computationManager);
         if (importer == null) {
             throw new PowsyblException("No importer found");
         }
         Network network = importer.importData(dataSource, getNetworkFactory(preloadingStrategy), parameters);
-        flush(network);
+        if (flush) {
+            flush(network);
+        }
         return network;
     }
 
     public Network importNetwork(ReadOnlyDataSource dataSource, PreloadingStrategy preloadingStrategy,
                                  ComputationManager computationManager, Properties parameters, Reporter reporter) {
+        return importNetwork(dataSource, preloadingStrategy, computationManager, parameters, reporter, true);
+    }
+
+    public Network importNetwork(ReadOnlyDataSource dataSource, PreloadingStrategy preloadingStrategy,
+                                 ComputationManager computationManager, Properties parameters, Reporter reporter, boolean flush) {
         Importer importer = Importers.findImporter(dataSource, computationManager);
         if (importer == null) {
             throw new PowsyblException("No importer found");
@@ -168,7 +187,9 @@ public class NetworkStoreService implements AutoCloseable {
         } else {
             network = importer.importData(dataSource, getNetworkFactory(preloadingStrategy), parameters);
         }
-        flush(network);
+        if (flush) {
+            flush(network);
+        }
         return network;
     }
 

--- a/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreIT.java
+++ b/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreIT.java
@@ -4518,6 +4518,23 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
     }
 
     @Test
+    public void testImportWithoutFlush() {
+        try (NetworkStoreService service = createNetworkStoreService()) {
+
+            ReporterModel report = new ReporterModel("test", "test");
+
+            Network network = service.importNetwork(getResource("test.xiidm", "/"), report, false);
+            final UUID networkUuid1 = service.getNetworkUuid(network);
+
+            assertTrue(assertThrows(PowsyblException.class, () -> service.getNetwork(networkUuid1)).getMessage().contains(String.format("Network '%s' not found", networkUuid1)));
+
+            network = service.importNetwork(getResource("test.xiidm", "/"), report, true);
+            UUID networkUuid2 = service.getNetworkUuid(network);
+            service.getNetwork(networkUuid2);
+        }
+    }
+
+    @Test
     public void testImportWithReport() {
         try (NetworkStoreService service = createNetworkStoreService()) {
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
When we import a network, it is automatically flushed in the database


**What is the new behavior (if this is a feature change)?**
The flush in database is now optional

