### PR TITLE
Fix getIdentifiable and getIdentifiables because of missing configure…

### DIFF
--- a/network-store-client/src/main/java/com/powsybl/network/store/client/CollectionBuffer.java
+++ b/network-store-client/src/main/java/com/powsybl/network/store/client/CollectionBuffer.java
@@ -24,9 +24,9 @@ public class CollectionBuffer<T extends IdentifiableAttributes> {
 
     private final TriConsumer<UUID, Integer, List<String>> removeFct;
 
-    private final Map<String, Resource<T>> createResources = new HashMap<>();
+    private final Map<String, Resource<T>> createResources = new LinkedHashMap<>();
 
-    private final Map<String, Resource<T>> updateResources = new HashMap<>();
+    private final Map<String, Resource<T>> updateResources = new LinkedHashMap<>();
 
     private final Set<String> removeResources = new HashSet<>();
 

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractBranchAdder.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractBranchAdder.java
@@ -81,7 +81,7 @@ abstract class AbstractBranchAdder<T extends AbstractBranchAdder<T>> extends Abs
             throw new ValidationException(this, "connectable bus 1 is not set");
         }
 
-        if (connectionBus != null && index.getBus(connectionBus).isEmpty()) {
+        if (connectionBus != null && index.getConfiguredBus(connectionBus).isEmpty()) {
             throw new ValidationException(this, "connectable bus 1 '" + connectionBus + " not found");
         }
     }
@@ -154,7 +154,7 @@ abstract class AbstractBranchAdder<T extends AbstractBranchAdder<T>> extends Abs
             throw new ValidationException(this, "connectable bus 2 is not set");
         }
 
-        if (connectionBus != null && index.getBus(connectionBus).isEmpty()) {
+        if (connectionBus != null && index.getConfiguredBus(connectionBus).isEmpty()) {
             throw new ValidationException(this, "connectable bus 2 '" + connectionBus + " not found");
         }
     }

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractInjectionAdder.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractInjectionAdder.java
@@ -82,7 +82,7 @@ abstract class AbstractInjectionAdder<T extends AbstractInjectionAdder<T>> exten
         if (getVoltageLevelResource().getAttributes().getTopologyKind() == TopologyKind.NODE_BREAKER) {
             throw new ValidationException(this, "bus only used in a bus breaker topology");
         }
-        if (index.getBus(connectionBus).isEmpty()) {
+        if (index.getConfiguredBus(connectionBus).isEmpty()) {
             throw new ValidationException(this, "connectable bus '" + connectionBus + "' not found");
         }
     }

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/BusBreakerViewImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/BusBreakerViewImpl.java
@@ -62,7 +62,7 @@ public class BusBreakerViewImpl implements VoltageLevel.BusBreakerView {
             return new ArrayList<>(calculateBuses().values());
         } else {
             // configured buses
-            return index.getBuses(voltageLevelResource.getId());
+            return index.getConfiguredBuses(voltageLevelResource.getId());
         }
     }
 
@@ -78,7 +78,7 @@ public class BusBreakerViewImpl implements VoltageLevel.BusBreakerView {
             return calculateBuses().get(busId);
         } else {
             // configured bus
-            return index.getBus(busId).filter(bus1 -> bus1.getVoltageLevel().getId().equals(voltageLevelResource.getId()))
+            return index.getConfiguredBus(busId).filter(bus1 -> bus1.getVoltageLevel().getId().equals(voltageLevelResource.getId()))
                     .orElse(null);
         }
     }
@@ -99,7 +99,7 @@ public class BusBreakerViewImpl implements VoltageLevel.BusBreakerView {
         if (!getSwitches(removedBus.getId()).isEmpty()) {
             throw new PowsyblException("Cannot remove bus '" + removedBus.getId() + "' because switch(es) is connected to it");
         }
-        index.removeBus(busId);
+        index.removeConfiguredBus(busId);
         index.notifyRemoval(removedBus);
     }
 
@@ -147,7 +147,7 @@ public class BusBreakerViewImpl implements VoltageLevel.BusBreakerView {
             // calculated bus
             return getTopologyInstance().calculateBus(index, voltageLevelResource, aSwitch.getNode1());
         } else {
-            return index.getBus(aSwitch.getBus1()).orElse(null);
+            return index.getConfiguredBus(aSwitch.getBus1()).orElse(null);
         }
     }
 
@@ -158,7 +158,7 @@ public class BusBreakerViewImpl implements VoltageLevel.BusBreakerView {
             // calculated bus
             return getTopologyInstance().calculateBus(index, voltageLevelResource, aSwitch.getNode2());
         } else {
-            return index.getBus(aSwitch.getBus2()).orElse(null);
+            return index.getConfiguredBus(aSwitch.getBus2()).orElse(null);
         }
     }
 

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/ConfiguredBusAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/ConfiguredBusAdderImpl.java
@@ -40,7 +40,7 @@ public class ConfiguredBusAdderImpl extends AbstractIdentifiableAdder<Configured
                 .build();
         // no need to invalidate calculated buses because a single configured bus (with no element connected)
         // does not give a calculated bus
-        return getIndex().createBus(resource);
+        return getIndex().createConfiguredBus(resource);
     }
 
     @Override

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkObjectIndex.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkObjectIndex.java
@@ -253,7 +253,7 @@ public class NetworkObjectIndex {
 
     private final ObjectCache<DanglingLine, DanglingLineImpl, DanglingLineAttributes> danglingLineCache;
 
-    private final ObjectCache<Bus, ConfiguredBusImpl, ConfiguredBusAttributes> busCache;
+    private final ObjectCache<Bus, ConfiguredBusImpl, ConfiguredBusAttributes> configuredBusCache;
 
     public NetworkObjectIndex(NetworkStoreClient storeClient) {
         this.storeClient = Objects.requireNonNull(storeClient);
@@ -353,7 +353,7 @@ public class NetworkObjectIndex {
             () -> storeClient.getDanglingLines(network.getUuid(), workingVariantNum),
             id -> storeClient.removeDanglingLines(network.getUuid(), workingVariantNum, Collections.singletonList(id)),
             resource -> DanglingLineImpl.create(NetworkObjectIndex.this, resource));
-        busCache = new ObjectCache<>(resource -> storeClient.createConfiguredBuses(network.getUuid(), Collections.singletonList(resource)),
+        configuredBusCache = new ObjectCache<>(resource -> storeClient.createConfiguredBuses(network.getUuid(), Collections.singletonList(resource)),
             id -> storeClient.getConfiguredBus(network.getUuid(), workingVariantNum, id),
             voltageLevelId -> storeClient.getVoltageLevelConfiguredBuses(network.getUuid(), workingVariantNum, voltageLevelId),
             () -> storeClient.getConfiguredBuses(network.getUuid(), workingVariantNum),
@@ -395,7 +395,7 @@ public class NetworkObjectIndex {
         lineCache.setResourcesToObjects();
         hvdcLineCache.setResourcesToObjects();
         danglingLineCache.setResourcesToObjects();
-        busCache.setResourcesToObjects();
+        configuredBusCache.setResourcesToObjects();
     }
 
     void notifyCreation(Identifiable<?> identifiable) {
@@ -845,6 +845,7 @@ public class NetworkObjectIndex {
                 .addAll(getLines())
                 .addAll(getHvdcLines())
                 .addAll(getDanglingLines())
+                .addAll(getConfiguredBuses())
                 .build();
     }
 
@@ -906,6 +907,7 @@ public class NetworkObjectIndex {
                 .or(() -> getLine(id))
                 .or(() -> getHvdcLine(id))
                 .or(() -> getDanglingLine(id))
+                .or(() -> getConfiguredBus(id))
                 .orElse(null);
     }
 
@@ -913,26 +915,26 @@ public class NetworkObjectIndex {
         danglingLineCache.remove(danglingLineId);
     }
 
-    //buses
+    // configured buses
 
-    Optional<ConfiguredBusImpl> getBus(String id) {
-        return busCache.getOne(id);
+    Optional<ConfiguredBusImpl> getConfiguredBus(String id) {
+        return configuredBusCache.getOne(id);
     }
 
-    List<Bus> getBuses() {
-        return busCache.getAll().collect(Collectors.toList());
+    List<Bus> getConfiguredBuses() {
+        return configuredBusCache.getAll().collect(Collectors.toList());
     }
 
-    List<Bus> getBuses(String voltageLevelId) {
-        return busCache.getSome(voltageLevelId).collect(Collectors.toList());
+    List<Bus> getConfiguredBuses(String voltageLevelId) {
+        return configuredBusCache.getSome(voltageLevelId).collect(Collectors.toList());
     }
 
-    ConfiguredBusImpl createBus(Resource<ConfiguredBusAttributes> resource) {
-        return busCache.create(resource);
+    ConfiguredBusImpl createConfiguredBus(Resource<ConfiguredBusAttributes> resource) {
+        return configuredBusCache.create(resource);
     }
 
-    public void removeBus(String busId) {
-        busCache.remove(busId);
+    public void removeConfiguredBus(String busId) {
+        configuredBusCache.remove(busId);
     }
 
     static void checkId(String id) {

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/TerminalBusBreakerViewImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/TerminalBusBreakerViewImpl.java
@@ -65,7 +65,7 @@ public class TerminalBusBreakerViewImpl<U extends InjectionAttributes> implement
             return calculateBus();
         } else {  // configured bus
             String busId = attributes.getBus();
-            return busId != null ? index.getBus(busId).orElseThrow(() -> new AssertionError(busId + " " + NOT_FOUND)) : null;
+            return busId != null ? index.getConfiguredBus(busId).orElseThrow(() -> new AssertionError(busId + " " + NOT_FOUND)) : null;
         }
     }
 
@@ -73,7 +73,7 @@ public class TerminalBusBreakerViewImpl<U extends InjectionAttributes> implement
     public Bus getConnectableBus() {
         if (isBusBeakerTopologyKind()) { // Configured bus
             String busId = attributes.getConnectableBus();
-            return index.getBus(busId).orElseThrow(() -> new AssertionError(busId + " " + NOT_FOUND));
+            return index.getConfiguredBus(busId).orElseThrow(() -> new AssertionError(busId + " " + NOT_FOUND));
         } else {  // Calculated bus
             Bus bus = getBus();
             if (bus != null) {
@@ -89,7 +89,7 @@ public class TerminalBusBreakerViewImpl<U extends InjectionAttributes> implement
     public void setConnectableBus(String busId) {
         checkNodeBreakerTopology();
 
-        if (index.getBus(busId).isEmpty()) {
+        if (index.getConfiguredBus(busId).isEmpty()) {
             throw new PowsyblException(busId + " " + NOT_FOUND);
         }
 

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/ThreeWindingsTransformerAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/ThreeWindingsTransformerAdderImpl.java
@@ -151,7 +151,7 @@ public class ThreeWindingsTransformerAdderImpl extends AbstractIdentifiableAdder
                 throw new ValidationException(this, "connectable bus is not set");
             }
 
-            if (connectionBus != null && index.getBus(connectionBus).isEmpty()) {
+            if (connectionBus != null && index.getConfiguredBus(connectionBus).isEmpty()) {
                 throw new ValidationException(this, "connectable bus leg " + legNumber + " '" + connectionBus + " not found");
             }
         }

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/ConfiguredBusBugTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/ConfiguredBusBugTest.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.network.store.iidm.impl;
+
+import com.powsybl.iidm.network.Identifiable;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+public class ConfiguredBusBugTest {
+
+    @Test
+    public void test() {
+        Network network = EurostagTutorialExample1Factory.create(new NetworkFactoryImpl());
+        List<String> ids = network.getIdentifiables().stream().map(Identifiable::getId).collect(Collectors.toList());
+        assertEquals(List.of("P1", "P2", "VLGEN", "VLHV1", "VLHV2", "VLLOAD", "GEN", "LOAD", "NGEN_NHV1", "NHV2_NLOAD",
+                "NHV1_NHV2_1", "NHV1_NHV2_2", "NGEN", "NHV1", "NHV2", "NLOAD"), ids);
+        assertNotNull(network.getIdentifiable("NGEN"));
+    }
+}

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/ConfiguredBusBugTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/ConfiguredBusBugTest.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.network.store.iidm.impl;
 
+import com.powsybl.iidm.network.Bus;
 import com.powsybl.iidm.network.Identifiable;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
@@ -29,5 +30,9 @@ public class ConfiguredBusBugTest {
         assertEquals(List.of("P1", "P2", "VLGEN", "VLHV1", "VLHV2", "VLLOAD", "GEN", "LOAD", "NGEN_NHV1", "NHV2_NLOAD",
                 "NHV1_NHV2_1", "NHV1_NHV2_2", "NGEN", "NHV1", "NHV2", "NLOAD"), ids);
         assertNotNull(network.getIdentifiable("NGEN"));
+
+        ids = network.getIdentifiables().stream().filter(i -> i instanceof Bus).map(Identifiable::getId).collect(Collectors.toList());
+        assertEquals(List.of("NGEN", "NHV1", "NHV2", "NLOAD"), ids);
+        assertNotNull(network.getBusBreakerView().getBus("NLOAD"));
     }
 }

--- a/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreIT.java
+++ b/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreIT.java
@@ -3385,9 +3385,13 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
             assertNotNull(gen);
             assertTrue(gen instanceof Generator);
 
+            Identifiable bus = network.getIdentifiable("NLOAD");
+            assertNotNull(bus);
+            assertTrue(bus instanceof Bus);
+
             assertEquals(16, network.getIdentifiables().size());
             assertEquals(Arrays.asList("P1", "P2", "VLHV2", "VLHV1", "VLGEN", "VLLOAD", "GEN", "LOAD", "NGEN_NHV1",
-                            "NHV2_NLOAD", "NHV1_NHV2_2", "NHV1_NHV2_1", "NHV1", "NHV2", "NGEN", "NLOAD"),
+                    "NHV2_NLOAD", "NHV1_NHV2_2", "NHV1_NHV2_1", "NLOAD", "NHV1", "NHV2", "NGEN"),
                 network.getIdentifiables().stream().map(Identifiable::getId).collect(Collectors.toList()));
         }
     }

--- a/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreIT.java
+++ b/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreIT.java
@@ -3385,8 +3385,9 @@ public class NetworkStoreIT extends AbstractEmbeddedCassandraSetup {
             assertNotNull(gen);
             assertTrue(gen instanceof Generator);
 
-            assertEquals(12, network.getIdentifiables().size());
-            assertEquals(Arrays.asList("P1", "P2", "VLHV2", "VLHV1", "VLGEN", "VLLOAD", "GEN", "LOAD", "NGEN_NHV1", "NHV2_NLOAD", "NHV1_NHV2_2", "NHV1_NHV2_1"),
+            assertEquals(16, network.getIdentifiables().size());
+            assertEquals(Arrays.asList("P1", "P2", "VLHV2", "VLHV1", "VLGEN", "VLLOAD", "GEN", "LOAD", "NGEN_NHV1",
+                            "NHV2_NLOAD", "NHV1_NHV2_2", "NHV1_NHV2_1", "NHV1", "NHV2", "NGEN", "NLOAD"),
                 network.getIdentifiables().stream().map(Identifiable::getId).collect(Collectors.toList()));
         }
     }


### PR DESCRIPTION
…d bus

Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
`Network.getIdentifiable` and `Network.getIdentifiables` does not include configured buses.


**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
