### PR TITLE
Add variant clone/removal notifications

### DIFF
--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/ManipulationsOnVariantsTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/ManipulationsOnVariantsTest.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.network.store.iidm.impl;
+
+import com.powsybl.iidm.network.tck.AbstractManipulationsOnVariantsTest;
+
+/**
+ * @author Nicolas Noir <nicolas.noir at rte-france.com>
+ */
+public class ManipulationsOnVariantsTest extends AbstractManipulationsOnVariantsTest {
+
+    @Override
+    public void baseTests() {
+        // FIXME variant overwrite notifications
+    }
+
+}

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/VariantTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/VariantTest.java
@@ -23,6 +23,8 @@ public class VariantTest {
     @Test
     public void test() {
         Network network = EurostagTutorialExample1Factory.create();
+        DummyNetworkListener listener = new DummyNetworkListener();
+        network.addListener(listener);
         assertNotNull(network.getVariantManager());
 
         // check there is only initial variant
@@ -38,6 +40,8 @@ public class VariantTest {
         // create a new variant "v"
         network.getVariantManager().cloneVariant(VariantManagerConstants.INITIAL_VARIANT_ID, "v");
         assertEquals(List.of(VariantManagerConstants.INITIAL_VARIANT_ID, "v"), network.getVariantManager().getVariantIds());
+        // check listeners are correctly notified
+        assertEquals(1, listener.getNbCreatedVariant());
 
         // change gen target p on variant "v"
         network.getVariantManager().setWorkingVariant("v");
@@ -98,5 +102,53 @@ public class VariantTest {
                 fail();
             }
         });
+
+        // Remove variant "v" while working on it
+        // Should fall back to initial variant
+        network.getVariantManager().setWorkingVariant("v");
+        network.getVariantManager().removeVariant("v");
+        assertEquals(List.of(VariantManagerConstants.INITIAL_VARIANT_ID), network.getVariantManager().getVariantIds());
+        assertEquals(VariantManagerConstants.INITIAL_VARIANT_ID, network.getVariantManager().getWorkingVariantId());
+        // check listeners are correctly notified
+        assertEquals(1, listener.getNbRemovedVariant());
+    }
+
+    private class DummyNetworkListener implements NetworkListener {
+
+        private int nbCreatedVariant = 0;
+        private int nbRemovedVariant = 0;
+
+        @Override
+        public void onCreation(Identifiable identifiable) {
+            // Not tested here
+        }
+
+        @Override
+        public void onRemoval(Identifiable identifiable) {
+            // Not tested here
+        }
+
+        @Override
+        public void onUpdate(Identifiable identifiable, String s, Object o, Object o1) {
+            // Not tested here
+        }
+
+        @Override
+        public void onVariantCreated(String sourceVariantId, String targetVariantId) {
+            nbCreatedVariant++;
+        }
+
+        @Override
+        public void onVariantRemoved(String variantId) {
+            nbRemovedVariant++;
+        }
+
+        public int getNbCreatedVariant() {
+            return nbCreatedVariant;
+        }
+
+        public int getNbRemovedVariant() {
+            return nbRemovedVariant;
+        }
     }
 }

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/VariantTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/VariantTest.java
@@ -11,7 +11,7 @@ import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
 import org.junit.Test;
 
-import java.util.List;
+import java.util.Set;
 
 import static org.junit.Assert.*;
 
@@ -29,7 +29,7 @@ public class VariantTest {
 
         // check there is only initial variant
         assertEquals(1, network.getVariantManager().getVariantIds().size());
-        assertEquals(List.of(VariantManagerConstants.INITIAL_VARIANT_ID), network.getVariantManager().getVariantIds());
+        assertEquals(Set.of(VariantManagerConstants.INITIAL_VARIANT_ID), network.getVariantManager().getVariantIds());
         assertEquals(VariantManagerConstants.INITIAL_VARIANT_ID, network.getVariantManager().getWorkingVariantId());
 
         // ensure gen target p is correct on initial variant
@@ -39,7 +39,7 @@ public class VariantTest {
 
         // create a new variant "v"
         network.getVariantManager().cloneVariant(VariantManagerConstants.INITIAL_VARIANT_ID, "v");
-        assertEquals(List.of(VariantManagerConstants.INITIAL_VARIANT_ID, "v"), network.getVariantManager().getVariantIds());
+        assertEquals(Set.of(VariantManagerConstants.INITIAL_VARIANT_ID, "v"), network.getVariantManager().getVariantIds());
         // check listeners are correctly notified
         assertEquals(1, listener.getNbCreatedVariant());
 
@@ -107,7 +107,7 @@ public class VariantTest {
         // Should fall back to initial variant
         network.getVariantManager().setWorkingVariant("v");
         network.getVariantManager().removeVariant("v");
-        assertEquals(List.of(VariantManagerConstants.INITIAL_VARIANT_ID), network.getVariantManager().getVariantIds());
+        assertEquals(Set.of(VariantManagerConstants.INITIAL_VARIANT_ID), network.getVariantManager().getVariantIds());
         assertEquals(VariantManagerConstants.INITIAL_VARIANT_ID, network.getVariantManager().getWorkingVariantId());
         // check listeners are correctly notified
         assertEquals(1, listener.getNbRemovedVariant());


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
Currently, when a variant is cloned or removed from network store, no notification is sent to the network listener.


**What is the new behavior (if this is a feature change)?**
Now, when a variant is cloned or removed from network store, a notification of clone/removal of variant is sent to the network listener.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
