### PR TITLE
Fix non linear shunt compensators Json serialization

### DIFF
--- a/network-store-model/src/main/java/com/powsybl/network/store/model/ShuntCompensatorNonLinearModelAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/ShuntCompensatorNonLinearModelAttributes.java
@@ -38,13 +38,11 @@ public class ShuntCompensatorNonLinearModelAttributes implements ShuntCompensato
         return sections.size();
     }
 
-    @JsonIgnore
     @Override
     public double getB(int sectionCount) {
         return sectionCount == 0 ? 0 : sections.get(sectionCount - 1).getB();
     }
 
-    @JsonIgnore
     @Override
     public double getG(int sectionCount) {
         return sectionCount == 0 ? 0 : sections.get(sectionCount - 1).getG();

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/ShuntCompensatorNonLinearModelAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/ShuntCompensatorNonLinearModelAttributes.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.network.store.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.powsybl.iidm.network.ShuntCompensatorModelType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
@@ -31,16 +32,19 @@ public class ShuntCompensatorNonLinearModelAttributes implements ShuntCompensato
     @Schema(description = "Sections")
     private List<ShuntCompensatorNonLinearSectionAttributes> sections;
 
+    @JsonIgnore
     @Override
     public int getMaximumSectionCount() {
         return sections.size();
     }
 
+    @JsonIgnore
     @Override
     public double getB(int sectionCount) {
         return sectionCount == 0 ? 0 : sections.get(sectionCount - 1).getB();
     }
 
+    @JsonIgnore
     @Override
     public double getG(int sectionCount) {
         return sectionCount == 0 ? 0 : sections.get(sectionCount - 1).getG();


### PR DESCRIPTION

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Currently, serializing and deserializing non linear shunt compensators attributes does not work since some getters are not ignored in json serialization


**What is the new behavior (if this is a feature change)?**
Non linear shunt compensators attributes are now correctly serialized/deserialized



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
