### PR TITLE
Use connection pooling for NetworkStoreRepository.

### DIFF
--- a/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreRepository.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreRepository.java
@@ -21,7 +21,6 @@ import org.springframework.stereotype.Repository;
 
 import javax.annotation.PostConstruct;
 import javax.sql.DataSource;
-import java.sql.SQLException;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
@@ -40,20 +39,16 @@ public class NetworkStoreRepository {
 
     @Autowired
     public NetworkStoreRepository(DataSource ds) {
-        try {
-            this.session = new Session(ds.getConnection());
-        } catch (SQLException e) {
-            throw new PowsyblException(e);
-        }
+        this.session = new Session(ds);
     }
 
     private final Session session;
 
     private static final int BATCH_SIZE = 1000;
 
-    private Supplier<java.sql.PreparedStatement> psCloneNetworkSupplier;
+    private PreparedStatement psCloneNetwork;
 
-    private final Map<String, Supplier<java.sql.PreparedStatement>> clonePreparedStatementsSupplier = new LinkedHashMap<>();
+    private final Map<String, PreparedStatement> clonePreparedStatements = new LinkedHashMap<>();
     private final Map<String, PreparedStatement> insertPreparedStatements = new LinkedHashMap<>();
     private final Map<String, PreparedStatement> updatePreparedStatements = new LinkedHashMap<>();
 
@@ -102,29 +97,23 @@ public class NetworkStoreRepository {
         return session.prepare(insert.build());
     }
 
-    private Supplier<java.sql.PreparedStatement> buildCloneStatement(Map<String, Mapping> mapping, String tableName) {
+    private PreparedStatement buildCloneStatement(Map<String, Mapping> mapping, String tableName) {
         Set<String> keys = mapping.keySet();
-        return () -> {
-            try {
-                return session.conn.prepareStatement(
-                    "insert into " + tableName + "(" +
-                        VARIANT_NUM + ", " +
-                        NETWORK_UUID + ", " +
-                        ID_STR + ", " +
-                        String.join(",", keys) +
-                        ") " +
-                        "select " +
-                        "?" + "," +
-                        NETWORK_UUID + "," +
-                        ID_STR + "," +
-                        String.join(",", keys) +
-                        " from " + tableName + " " +
-                        "where networkUuid = ? and variantNum = ?"
-                );
-            } catch (SQLException e) {
-                throw new PowsyblException("Unable to create the clone prepared statement", e);
-            }
-        };
+        return session.prepare(
+            "insert into " + tableName + "(" +
+                VARIANT_NUM + ", " +
+                NETWORK_UUID + ", " +
+                ID_STR + ", " +
+                String.join(",", keys) +
+                ") " +
+                "select " +
+                "?" + "," +
+                NETWORK_UUID + "," +
+                ID_STR + "," +
+                String.join(",", keys) +
+                " from " + tableName + " " +
+                "where networkUuid = ? and variantNum = ?"
+        );
     }
 
     private PreparedStatement buildUpdateStatement(Map<String, Mapping> mapping,
@@ -158,29 +147,23 @@ public class NetworkStoreRepository {
         keysNetworks.forEach(insertNetwork::value);
         insertPreparedStatements.put(NETWORK, session.prepare(insertNetwork.build()));
 
-        psCloneNetworkSupplier = () -> {
-            try {
-                return session.conn.prepareStatement(
-                    "insert into network(" +
-                        VARIANT_NUM + ", " +
-                        VARIANT_ID + ", " +
-                        UUID_STR + ", " +
-                        ID_STR + ", " +
-                        String.join(",", keysNetworks.stream().filter(k -> !k.equals(UUID_STR) && !k.equals(VARIANT_ID) && !k.equals(NAME)).collect(Collectors.toList())) +
-                        ") " +
-                        "select" + " " +
-                        "?" + ", " +
-                        "?" + ", " +
-                        UUID_STR + ", " +
-                        ID_STR + ", " +
-                        String.join(",", keysNetworks.stream().filter(k -> !k.equals(UUID_STR) && !k.equals(VARIANT_ID) && !k.equals(NAME)).collect(Collectors.toList())) +
-                        " from network" + " " +
-                        "where uuid = ? and variantNum = ?"
-                );
-            } catch (SQLException e) {
-                throw new PowsyblException("Unable to create the network clone prepared statement ", e);
-            }
-        };
+        psCloneNetwork = session.prepare(
+                "insert into network(" +
+                VARIANT_NUM + ", " +
+                VARIANT_ID + ", " +
+                UUID_STR + ", " +
+                ID_STR + ", " +
+                String.join(",", keysNetworks.stream().filter(k -> !k.equals(UUID_STR) && !k.equals(VARIANT_ID) && !k.equals(NAME)).collect(Collectors.toList())) +
+                ") " +
+                "select" + " " +
+                "?" + ", " +
+                "?" + ", " +
+                UUID_STR + ", " +
+                ID_STR + ", " +
+                String.join(",", keysNetworks.stream().filter(k -> !k.equals(UUID_STR) && !k.equals(VARIANT_ID) && !k.equals(NAME)).collect(Collectors.toList())) +
+                " from network" + " " +
+                "where uuid = ? and variantNum = ?"
+        );
 
         Update updateNetwork = update(NETWORK).set(Assignment.setColumn(ID_STR));
         keysNetworks.forEach(k -> {
@@ -196,103 +179,103 @@ public class NetworkStoreRepository {
         // substation
 
         insertPreparedStatements.put(SUBSTATION, buildInsertStatement(mappings.getSubstationMappings(), SUBSTATION));
-        clonePreparedStatementsSupplier.put(SUBSTATION, buildCloneStatement(mappings.getSubstationMappings(), SUBSTATION));
+        clonePreparedStatements.put(SUBSTATION, buildCloneStatement(mappings.getSubstationMappings(), SUBSTATION));
         updatePreparedStatements.put(SUBSTATION, buildUpdateStatement(mappings.getSubstationMappings(), SUBSTATION, null));
 
         // voltage level
 
         insertPreparedStatements.put(VOLTAGE_LEVEL, buildInsertStatement(mappings.getVoltageLevelMappings(), VOLTAGE_LEVEL));
-        clonePreparedStatementsSupplier.put(VOLTAGE_LEVEL, buildCloneStatement(mappings.getVoltageLevelMappings(), VOLTAGE_LEVEL));
+        clonePreparedStatements.put(VOLTAGE_LEVEL, buildCloneStatement(mappings.getVoltageLevelMappings(), VOLTAGE_LEVEL));
         updatePreparedStatements.put(VOLTAGE_LEVEL, buildUpdateStatement(mappings.getVoltageLevelMappings(), VOLTAGE_LEVEL, SUBSTATION_ID));
 
         // generator
 
         insertPreparedStatements.put(GENERATOR, buildInsertStatement(mappings.getGeneratorMappings(), GENERATOR));
-        clonePreparedStatementsSupplier.put(GENERATOR, buildCloneStatement(mappings.getGeneratorMappings(), GENERATOR));
+        clonePreparedStatements.put(GENERATOR, buildCloneStatement(mappings.getGeneratorMappings(), GENERATOR));
         updatePreparedStatements.put(GENERATOR, buildUpdateStatement(mappings.getGeneratorMappings(), GENERATOR, VOLTAGE_LEVEL_ID));
 
         // battery
 
         insertPreparedStatements.put(BATTERY, buildInsertStatement(mappings.getBatteryMappings(), BATTERY));
-        clonePreparedStatementsSupplier.put(BATTERY, buildCloneStatement(mappings.getBatteryMappings(), BATTERY));
+        clonePreparedStatements.put(BATTERY, buildCloneStatement(mappings.getBatteryMappings(), BATTERY));
         updatePreparedStatements.put(BATTERY, buildUpdateStatement(mappings.getBatteryMappings(), BATTERY, VOLTAGE_LEVEL_ID));
 
         // load
 
         insertPreparedStatements.put(LOAD, buildInsertStatement(mappings.getLoadMappings(), LOAD));
-        clonePreparedStatementsSupplier.put(LOAD, buildCloneStatement(mappings.getLoadMappings(), LOAD));
+        clonePreparedStatements.put(LOAD, buildCloneStatement(mappings.getLoadMappings(), LOAD));
         updatePreparedStatements.put(LOAD, buildUpdateStatement(mappings.getLoadMappings(), LOAD, VOLTAGE_LEVEL_ID));
 
         // shunt compensator
 
         insertPreparedStatements.put(SHUNT_COMPENSATOR, buildInsertStatement(mappings.getShuntCompensatorMappings(), SHUNT_COMPENSATOR));
-        clonePreparedStatementsSupplier.put(SHUNT_COMPENSATOR, buildCloneStatement(mappings.getShuntCompensatorMappings(), SHUNT_COMPENSATOR));
+        clonePreparedStatements.put(SHUNT_COMPENSATOR, buildCloneStatement(mappings.getShuntCompensatorMappings(), SHUNT_COMPENSATOR));
         updatePreparedStatements.put(SHUNT_COMPENSATOR, buildUpdateStatement(mappings.getShuntCompensatorMappings(), SHUNT_COMPENSATOR, VOLTAGE_LEVEL_ID));
 
         // vsc converter station
 
         insertPreparedStatements.put(VSC_CONVERTER_STATION, buildInsertStatement(mappings.getVscConverterStationMappings(), VSC_CONVERTER_STATION));
-        clonePreparedStatementsSupplier.put(VSC_CONVERTER_STATION, buildCloneStatement(mappings.getVscConverterStationMappings(), VSC_CONVERTER_STATION));
+        clonePreparedStatements.put(VSC_CONVERTER_STATION, buildCloneStatement(mappings.getVscConverterStationMappings(), VSC_CONVERTER_STATION));
         updatePreparedStatements.put(VSC_CONVERTER_STATION, buildUpdateStatement(mappings.getVscConverterStationMappings(), VSC_CONVERTER_STATION, VOLTAGE_LEVEL_ID));
 
         // lcc converter station
 
         insertPreparedStatements.put(LCC_CONVERTER_STATION, buildInsertStatement(mappings.getLccConverterStationMappings(), LCC_CONVERTER_STATION));
-        clonePreparedStatementsSupplier.put(LCC_CONVERTER_STATION, buildCloneStatement(mappings.getLccConverterStationMappings(), LCC_CONVERTER_STATION));
+        clonePreparedStatements.put(LCC_CONVERTER_STATION, buildCloneStatement(mappings.getLccConverterStationMappings(), LCC_CONVERTER_STATION));
         updatePreparedStatements.put(LCC_CONVERTER_STATION, buildUpdateStatement(mappings.getLccConverterStationMappings(), LCC_CONVERTER_STATION, VOLTAGE_LEVEL_ID));
 
         // static var compensator
 
         insertPreparedStatements.put(STATIC_VAR_COMPENSATOR, buildInsertStatement(mappings.getStaticVarCompensatorMappings(), STATIC_VAR_COMPENSATOR));
-        clonePreparedStatementsSupplier.put(STATIC_VAR_COMPENSATOR, buildCloneStatement(mappings.getStaticVarCompensatorMappings(), STATIC_VAR_COMPENSATOR));
+        clonePreparedStatements.put(STATIC_VAR_COMPENSATOR, buildCloneStatement(mappings.getStaticVarCompensatorMappings(), STATIC_VAR_COMPENSATOR));
         updatePreparedStatements.put(STATIC_VAR_COMPENSATOR, buildUpdateStatement(mappings.getStaticVarCompensatorMappings(), STATIC_VAR_COMPENSATOR, VOLTAGE_LEVEL_ID));
 
         // busbar section
 
         insertPreparedStatements.put(BUSBAR_SECTION, buildInsertStatement(mappings.getBusbarSectionMappings(), BUSBAR_SECTION));
-        clonePreparedStatementsSupplier.put(BUSBAR_SECTION, buildCloneStatement(mappings.getBusbarSectionMappings(), BUSBAR_SECTION));
+        clonePreparedStatements.put(BUSBAR_SECTION, buildCloneStatement(mappings.getBusbarSectionMappings(), BUSBAR_SECTION));
         updatePreparedStatements.put(BUSBAR_SECTION, buildUpdateStatement(mappings.getBusbarSectionMappings(), BUSBAR_SECTION, VOLTAGE_LEVEL_ID));
 
         // switch
 
         insertPreparedStatements.put(SWITCH, buildInsertStatement(mappings.getSwitchMappings(), SWITCH));
-        clonePreparedStatementsSupplier.put(SWITCH, buildCloneStatement(mappings.getSwitchMappings(), SWITCH));
+        clonePreparedStatements.put(SWITCH, buildCloneStatement(mappings.getSwitchMappings(), SWITCH));
         updatePreparedStatements.put(SWITCH, buildUpdateStatement(mappings.getSwitchMappings(), SWITCH, VOLTAGE_LEVEL_ID));
 
         // two windings transformer
 
         insertPreparedStatements.put(TWO_WINDINGS_TRANSFORMER, buildInsertStatement(mappings.getTwoWindingsTransformerMappings(), TWO_WINDINGS_TRANSFORMER));
-        clonePreparedStatementsSupplier.put(TWO_WINDINGS_TRANSFORMER, buildCloneStatement(mappings.getTwoWindingsTransformerMappings(), TWO_WINDINGS_TRANSFORMER));
+        clonePreparedStatements.put(TWO_WINDINGS_TRANSFORMER, buildCloneStatement(mappings.getTwoWindingsTransformerMappings(), TWO_WINDINGS_TRANSFORMER));
         updatePreparedStatements.put(TWO_WINDINGS_TRANSFORMER, buildUpdateStatement(mappings.getTwoWindingsTransformerMappings(), TWO_WINDINGS_TRANSFORMER, null));
 
         // three windings transformer
 
         insertPreparedStatements.put(THREE_WINDINGS_TRANSFORMER, buildInsertStatement(mappings.getThreeWindingsTransformerMappings(), THREE_WINDINGS_TRANSFORMER));
-        clonePreparedStatementsSupplier.put(THREE_WINDINGS_TRANSFORMER, buildCloneStatement(mappings.getThreeWindingsTransformerMappings(), THREE_WINDINGS_TRANSFORMER));
+        clonePreparedStatements.put(THREE_WINDINGS_TRANSFORMER, buildCloneStatement(mappings.getThreeWindingsTransformerMappings(), THREE_WINDINGS_TRANSFORMER));
         updatePreparedStatements.put(THREE_WINDINGS_TRANSFORMER, buildUpdateStatement(mappings.getThreeWindingsTransformerMappings(), THREE_WINDINGS_TRANSFORMER, null));
 
         // line
 
         insertPreparedStatements.put(LINE, buildInsertStatement(mappings.getLineMappings(), LINE));
-        clonePreparedStatementsSupplier.put(LINE, buildCloneStatement(mappings.getLineMappings(), LINE));
+        clonePreparedStatements.put(LINE, buildCloneStatement(mappings.getLineMappings(), LINE));
         updatePreparedStatements.put(LINE, buildUpdateStatement(mappings.getLineMappings(), LINE, null));
 
         // hvdc line
 
         insertPreparedStatements.put(HVDC_LINE, buildInsertStatement(mappings.getHvdcLineMappings(), HVDC_LINE));
-        clonePreparedStatementsSupplier.put(HVDC_LINE, buildCloneStatement(mappings.getHvdcLineMappings(), HVDC_LINE));
+        clonePreparedStatements.put(HVDC_LINE, buildCloneStatement(mappings.getHvdcLineMappings(), HVDC_LINE));
         updatePreparedStatements.put(HVDC_LINE, buildUpdateStatement(mappings.getHvdcLineMappings(), HVDC_LINE, null));
 
         // dangling line
 
         insertPreparedStatements.put(DANGLING_LINE, buildInsertStatement(mappings.getDanglingLineMappings(), DANGLING_LINE));
-        clonePreparedStatementsSupplier.put(DANGLING_LINE, buildCloneStatement(mappings.getDanglingLineMappings(), DANGLING_LINE));
+        clonePreparedStatements.put(DANGLING_LINE, buildCloneStatement(mappings.getDanglingLineMappings(), DANGLING_LINE));
         updatePreparedStatements.put(DANGLING_LINE, buildUpdateStatement(mappings.getDanglingLineMappings(), DANGLING_LINE, VOLTAGE_LEVEL_ID));
 
         // configured bus
 
         insertPreparedStatements.put(CONFIGURED_BUS, buildInsertStatement(mappings.getConfiguredBusMappings(), CONFIGURED_BUS));
-        clonePreparedStatementsSupplier.put(CONFIGURED_BUS, buildCloneStatement(mappings.getConfiguredBusMappings(), CONFIGURED_BUS));
+        clonePreparedStatements.put(CONFIGURED_BUS, buildCloneStatement(mappings.getConfiguredBusMappings(), CONFIGURED_BUS));
         updatePreparedStatements.put(CONFIGURED_BUS, buildUpdateStatement(mappings.getConfiguredBusMappings(), CONFIGURED_BUS, VOLTAGE_LEVEL_ID));
     }
 
@@ -431,24 +414,24 @@ public class NetworkStoreRepository {
 
         var stopwatch = Stopwatch.createStarted();
 
-        try {
-            java.sql.PreparedStatement psCloneNetwork = psCloneNetworkSupplier.get();
-            psCloneNetwork.setInt(1, targetVariantNum);
-            psCloneNetwork.setString(2, nonNullTargetVariantId);
-            psCloneNetwork.setObject(3, uuid);
-            psCloneNetwork.setInt(4, sourceVariantNum);
-            psCloneNetwork.executeUpdate();
+        BatchStatement batch = BatchStatement.newInstance(BatchType.UNLOGGED);
+        List<BoundStatement> boundStatements = new ArrayList<>();
 
-            for (Supplier<java.sql.PreparedStatement> psSupplier : clonePreparedStatementsSupplier.values()) {
-                java.sql.PreparedStatement ps = psSupplier.get();
-                ps.setInt(1, targetVariantNum);
-                ps.setObject(2, uuid);
-                ps.setInt(3, sourceVariantNum);
-                ps.executeUpdate();
-            }
-        } catch (SQLException e) {
-            throw new PowsyblException(e);
+        boundStatements.add(psCloneNetwork.bind(
+            targetVariantNum,
+            nonNullTargetVariantId,
+            uuid,
+            sourceVariantNum));
+
+        for (PreparedStatement ps : clonePreparedStatements.values()) {
+            boundStatements.add(ps.bind(
+                targetVariantNum,
+                uuid,
+                sourceVariantNum
+            ));
         }
+        batch = batch.addAll(boundStatements);
+        session.execute(batch);
 
         stopwatch.stop();
         LOGGER.info("Network clone done in {} ms", stopwatch.elapsed(TimeUnit.MILLISECONDS));

--- a/network-store-server/src/main/java/com/powsybl/network/store/server/PreparedStatement.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/PreparedStatement.java
@@ -7,70 +7,30 @@
 
 package com.powsybl.network.store.server;
 
-import java.io.UncheckedIOException;
-import java.sql.SQLException;
-import java.sql.Connection;
-import java.time.Instant;
-import java.util.List;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.powsybl.network.store.server.QueryBuilder.BoundStatement;
-import com.powsybl.network.store.server.exceptions.UncheckedSqlException;
 
 public class PreparedStatement implements BoundStatement {
-    Connection conn;
     String query;
-    ThreadLocal<java.sql.PreparedStatement> tlPs = new ThreadLocal<>();
+    Object[] values;
 
-    public PreparedStatement(String query, Connection conn) {
+    public PreparedStatement(String query) {
         this.query = query;
-        this.conn = conn;
     }
 
     public PreparedStatement bind(Object... values) {
-        int idx = 0;
-        try {
-            java.sql.PreparedStatement statement = tlPs.get();
-            if (statement == null) {
-                statement = conn.prepareStatement(query);
-                tlPs.set(statement);
-            }
-            for (Object o : values) {
-                if (o instanceof Instant) {
-                    Instant d = (Instant) o;
-                    statement.setObject(++idx, new java.sql.Date(d.toEpochMilli()));
-                } else if (o == null || !Row.isCustomTypeJsonified(o.getClass())) {
-                    statement.setObject(++idx, o);
-                } else {
-                    try {
-                        statement.setObject(++idx, Row.mapper.writeValueAsString(o));
-                    } catch (JsonProcessingException e) {
-                        throw new UncheckedIOException(e);
-                    }
-
-                }
-            }
-            // TODO this is a hack, we only use bind() for batches for now.
-            // the new cassandra immutable API creates one BoundStatement per
-            // query, and to avoid o(n^2) behavior in batchStatement.add(), we
-            // put them all in a list and use batchStatement.addAll(). This
-            // makes it hard to make an equivalent with a jdbc PreparedStatement,
-            // where one statement holds all the data for the different queries
-            statement.addBatch();
-        } catch (SQLException e) {
-            throw new UncheckedSqlException(e);
-        }
-        return this;
+        PreparedStatement ps = new PreparedStatement(this.query);
+        ps.values = values;
+        return ps;
     }
 
     @Override
     public String getQuery() {
-        throw new RuntimeException("Not implemented");
+        return query;
     }
 
     @Override
-    public List<Object> values() {
-        throw new RuntimeException("Not implemented");
+    public Object[] values() {
+        return values;
     }
 
 }

--- a/network-store-server/src/main/java/com/powsybl/network/store/server/QueryBuilder.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/QueryBuilder.java
@@ -47,7 +47,7 @@ public final class QueryBuilder {
     public interface SimpleStatement {
         String getQuery();
 
-        List<Object> values();
+        Object[] values();
     }
 
     public interface BoundStatement extends SimpleStatement {
@@ -93,8 +93,8 @@ public final class QueryBuilder {
         }
 
         @Override
-        public List<Object> values() {
-            return clauses.stream().map(o -> o.o).collect(Collectors.toList());
+        public Object[] values() {
+            return clauses.stream().map(o -> o.o).toArray();
         }
 
         @Override
@@ -143,7 +143,7 @@ public final class QueryBuilder {
         }
 
         @Override
-        public List<Object> values() {
+        public Object[] values() {
             throw new PowsyblException("For now we use insert only with prepared statements");
         }
 
@@ -194,8 +194,8 @@ public final class QueryBuilder {
         }
 
         @Override
-        public List<Object> values() {
-            return clauses.stream().map(o -> o.o).collect(Collectors.toList());
+        public Object[] values() {
+            return clauses.stream().map(o -> o.o).toArray();
         }
 
     }
@@ -237,8 +237,8 @@ public final class QueryBuilder {
         }
 
         @Override
-        public List<Object> values() {
-            return clauses.stream().map(o -> o.o).collect(Collectors.toList());
+        public Object[] values() {
+            return clauses.stream().map(o -> o.o).toArray();
         }
     }
 

--- a/network-store-server/src/main/java/com/powsybl/network/store/server/Session.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/Session.java
@@ -7,9 +7,16 @@
 
 package com.powsybl.network.store.server;
 
-import java.sql.Connection;
+import javax.sql.DataSource;
 import java.sql.SQLException;
 import java.util.Collection;
+import java.util.stream.Collectors;
+import java.util.Map.Entry;
+import java.util.List;
+import java.util.ArrayList;
+import java.time.Instant;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.io.UncheckedIOException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,49 +25,70 @@ import com.powsybl.commons.PowsyblException;
 import com.powsybl.network.store.server.QueryBuilder.BoundStatement;
 import com.powsybl.network.store.server.QueryBuilder.Select;
 import com.powsybl.network.store.server.QueryBuilder.SimpleStatement;
+import com.powsybl.network.store.server.exceptions.UncheckedSqlException;
 
 public class Session {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Session.class);
-    Connection conn;
+    DataSource dataSource;
 
-    public Session(Connection conn) {
-        this.conn = conn;
+    public Session(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public PreparedStatement prepare(String s) {
+        return new PreparedStatement(s);
     }
 
     public PreparedStatement prepare(SimpleStatement o) {
         String s = o.getQuery();
-        return new PreparedStatement(s, conn);
+        return prepare(s);
     }
 
     public ResultSet execute(SimpleStatement o) {
-        try {
-            String s = o.getQuery();
-            java.sql.PreparedStatement ps = conn.prepareStatement(s);
-            int idx = 0;
-            for (Object obj : o.values()) {
-                ps.setObject(++idx, obj);
+        String s = o.getQuery();
+        if (o instanceof Select) {
+            java.sql.Connection conn = null;
+            java.sql.PreparedStatement ps = null;
+            //Don't use try-with-ressources because we return the
+            //result set, so the caller is responsible for closing everything
+            //unless we get an exception before returning, in which case we are responsible.
+            try {
+                conn = dataSource.getConnection();
+                ps = conn.prepareStatement(s);
+                bindValues(ps, o.values());
+                return new ResultSet(conn, ps, ps.executeQuery());
+            } catch (SQLException e) {
+                if (ps != null) {
+                    closeQuietly(ps, e);
+                }
+                if (conn != null) {
+                    closeQuietly(conn, e);
+                }
+                throw new UncheckedSqlException(e);
             }
-            if (o instanceof Select) {
-                return new ResultSet(ps, ps.executeQuery());
-            } else {
+        } else {
+            try (
+                java.sql.Connection conn = dataSource.getConnection();
+                java.sql.PreparedStatement ps = conn.prepareStatement(s);
+            ) {
+                bindValues(ps, o.values());
                 ps.executeUpdate();
-                ps.close();
                 return null;
+            } catch (SQLException e) {
+                throw new UncheckedSqlException(e);
             }
-        } catch (SQLException e) {
-            throw new PowsyblException(e);
         }
     }
 
-    private void cleanExecute(boolean mainThrows, Collection<BoundStatement> statements) throws SQLException {
+    private void cleanExecute(boolean mainThrows, java.sql.Connection conn, Collection<java.sql.PreparedStatement> statements) throws SQLException {
         // close all the statements and reset setAutoCommit even if one the first statements throws an exception.
         // Don't bother throwing if main already threw, instead log directly, because this is called in the finally block.
         // This avoids the difficulty of not shadowing any throwable coming from the main block.
         SQLException firstException = null;
-        for (BoundStatement statement : statements) {
+        for (java.sql.PreparedStatement statement : statements) {
             try {
-                ((PreparedStatement) statement).tlPs.get().close();
+                statement.close();
             } catch (SQLException e) {
                 if (firstException != null) {
                     firstException.addSuppressed(e);
@@ -68,7 +96,6 @@ public class Session {
                     firstException = e;
                 }
             }
-            ((PreparedStatement) statement).tlPs.remove();
         }
         try {
             conn.setAutoCommit(true);
@@ -89,20 +116,37 @@ public class Session {
     }
 
     private void doExecute(BatchStatement batch) throws SQLException {
-        boolean mainThrows = true;
-        try {
-            conn.setAutoCommit(false);
-            for (BoundStatement statement : batch.preparedStatements) {
-                ((PreparedStatement) statement).tlPs.get().executeBatch();
+        try (
+            java.sql.Connection conn = dataSource.getConnection();
+        ) {
+            boolean mainThrows = true;
+            List<java.sql.PreparedStatement> actualStatements = new ArrayList<>();
+            try {
+                conn.setAutoCommit(false);
+                var grouped = batch.preparedStatements.stream().collect(Collectors.groupingBy(BoundStatement::getQuery));
+                try {
+                    for (Entry<String, List<BoundStatement>> entry : grouped.entrySet()) {
+                        String query = entry.getKey();
+                        //Don't use try-with-ressource as we have a dynamic number of statements
+                        java.sql.PreparedStatement ps = conn.prepareStatement(query);
+                        actualStatements.add(ps);
+                        for (BoundStatement statement : entry.getValue()) {
+                            bindValues(ps, statement.values());
+                            ps.addBatch();
+                        }
+                        ps.executeBatch();
+                    }
+                    conn.commit();
+                } catch (SQLException e) {
+                    conn.rollback();
+                    throw e;
+                }
+                mainThrows = false;
+            } finally {
+                cleanExecute(mainThrows, conn, actualStatements);
             }
-            conn.commit();
-            mainThrows = false;
-        } catch (Exception e) {
-            conn.rollback();
-            throw e;
-        } finally {
-            cleanExecute(mainThrows, batch.preparedStatements);
         }
+
         for (SimpleStatement statement : batch.statements2) {
             execute(statement);
         }
@@ -116,4 +160,35 @@ public class Session {
         }
     }
 
+    // suppress additional exceptions and add to initial exception, or just log
+    private static void closeQuietly(AutoCloseable autoCloseable, Exception firstException) {
+        try {
+            autoCloseable.close();
+        } catch (Exception additionalException) {
+            if (firstException != null) {
+                firstException.addSuppressed(additionalException);
+            } else {
+                LOGGER.error("Additional error closing " + autoCloseable, additionalException);
+            }
+        }
+    }
+
+    private static void bindValues(java.sql.PreparedStatement statement, Object[] values) throws SQLException {
+        int idx = 0;
+        for (Object o : values) {
+            if (o instanceof Instant) {
+                Instant d = (Instant) o;
+                statement.setObject(++idx, new java.sql.Date(d.toEpochMilli()));
+            } else if (o == null || !Row.isCustomTypeJsonified(o.getClass())) {
+                statement.setObject(++idx, o);
+            } else {
+                try {
+                    statement.setObject(++idx, Row.mapper.writeValueAsString(o));
+                } catch (JsonProcessingException e) {
+                    throw new UncheckedIOException(e);
+                }
+
+            }
+        }
+    }
 }


### PR DESCRIPTION
This allows for recovery when the connection drops (e.g. at database restart).
This also removes the need to use threadlocals because prepared statements are
not reused anymore, we recreate them each time (because the connection is returned
to the pool).

Signed-off-by: HARPER Jon <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
Only one connection for networkstorerepository:
- no parallelism between different requests
- no error recovery
- complex reuse of prepared statements (ThreadLocal)


**What is the new behavior (if this is a feature change)?**
connection pooling:
- parallelism between different requests
- error recovery
- simple prepared statements recreated at each request


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
NO