### PR TITLE
Fix network-store-server when voltagelevel is not in a substation

### DIFF
--- a/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreIT.java
+++ b/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreIT.java
@@ -4732,6 +4732,57 @@ public class NetworkStoreIT {
     }
 
     @Test
+    public void testVoltageLevelWithoutSubstation() {
+        UUID networkUuid;
+        try (NetworkStoreService service = createNetworkStoreService()) {
+            Network network = service.createNetwork("networknosubstation", "test");
+            networkUuid = service.getNetworkUuid(network);
+            network.newVoltageLevel()
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .setId("bbVL")
+                .setName("bbVL_name")
+                .setNominalV(200.0)
+                .setLowVoltageLimit(100.0)
+                .setHighVoltageLimit(200.0)
+                .add();
+            VoltageLevel voltageLevel = network.getVoltageLevel("bbVL");
+            assertNotNull(voltageLevel);
+            assertEquals(200.0, voltageLevel.getNominalV(), 0.0);
+            assertEquals(100.0, voltageLevel.getLowVoltageLimit(), 0.0);
+            assertEquals(200.0, voltageLevel.getHighVoltageLimit(), 0.0);
+            assertEquals(ContainerType.VOLTAGE_LEVEL, voltageLevel.getContainerType());
+            assertTrue(voltageLevel.getSubstation().isEmpty());
+
+            assertTrue(Iterables.isEmpty(voltageLevel.getConnectables()));
+            voltageLevel.getBusBreakerView().newBus().setId("bbVL_1").add();
+            Load load = voltageLevel.newLoad()
+                .setId("LOAD")
+                .setBus("bbVL_1")
+                .setP0(600.0)
+                .setQ0(200.0)
+                .add();
+            assertEquals(1, Iterables.size(voltageLevel.getConnectables()));
+            assertTrue(Iterables.contains(voltageLevel.getConnectables(), load));
+
+            service.flush(network);
+        }
+        try (NetworkStoreService service = createNetworkStoreService()) {
+            Network network = service.getNetwork(networkUuid);
+            VoltageLevel voltageLevel = network.getVoltageLevel("bbVL");
+            assertNotNull(voltageLevel);
+            assertEquals(200.0, voltageLevel.getNominalV(), 0.0);
+            assertEquals(100.0, voltageLevel.getLowVoltageLimit(), 0.0);
+            assertEquals(200.0, voltageLevel.getHighVoltageLimit(), 0.0);
+            assertEquals(ContainerType.VOLTAGE_LEVEL, voltageLevel.getContainerType());
+            assertTrue(voltageLevel.getSubstation().isEmpty());
+
+            Load load = network.getLoad("LOAD");
+            assertEquals(1, Iterables.size(voltageLevel.getConnectables()));
+            assertTrue(Iterables.contains(voltageLevel.getConnectables(), load));
+        }
+    }
+
+    @Test
     public void testNanValues() {
         try (NetworkStoreService service = createNetworkStoreService()) {
             service.flush(createGeneratorNetwork(service.getNetworkFactory(), ReactiveLimitsKind.MIN_MAX));

--- a/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreRepository.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreRepository.java
@@ -633,7 +633,7 @@ public class NetworkStoreRepository {
                 values.add(networkUuid);
                 values.add(resource.getVariantNum());
                 values.add(resource.getId());
-                values.add(resource.getAttributes().getContainerIds().stream().findFirst().orElseThrow());
+                values.add(resource.getAttributes().getContainerIds().iterator().next());
 
                 boundStatements.add(psUpdate.bind(values.toArray(new Object[0])));
             }

--- a/network-store-server/src/main/resources/schema.sql
+++ b/network-store-server/src/main/resources/schema.sql
@@ -60,7 +60,7 @@ CREATE TABLE IF NOT EXISTS voltageLevel (
     busToCalculatedBusForBusBreakerView text,
     calculatedBusesValid boolean,
     slackTerminal text,
-    PRIMARY KEY (networkUuid, variantNum, id, substationId)
+    PRIMARY KEY (networkUuid, variantNum, id)
 );
 create index on voltageLevel (networkUuid, variantNum, substationId);
 

--- a/network-store-server/src/test/java/com/powsybl/network/store/server/NetworkStoreControllerIT.java
+++ b/network-store-server/src/test/java/com/powsybl/network/store/server/NetworkStoreControllerIT.java
@@ -206,6 +206,22 @@ public class NetworkStoreControllerIT {
                 .content(objectMapper.writeValueAsString(Collections.singleton(baz2))))
                 .andExpect(status().isCreated());
 
+        //no substation for this voltage level
+        Resource<VoltageLevelAttributes> baz3 = Resource.voltageLevelBuilder()
+                .id("baz3")
+                .attributes(VoltageLevelAttributes.builder()
+                        .nominalV(382)
+                        .lowVoltageLimit(362)
+                        .highVoltageLimit(402)
+                        .topologyKind(TopologyKind.NODE_BREAKER)
+                        .internalConnections(Collections.emptyList())
+                        .build())
+                .build();
+        mvc.perform(post("/" + VERSION + "/networks/" + NETWORK_UUID + "/voltage-levels")
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Collections.singleton(baz3))))
+                .andExpect(status().isCreated());
+
         mvc.perform(get("/" + VERSION + "/networks/" + NETWORK_UUID + "/" + Resource.INITIAL_VARIANT_NUM + "/substations/bar/voltage-levels")
                 .contentType(APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -217,7 +233,7 @@ public class NetworkStoreControllerIT {
                 .contentType(APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
-                .andExpect(jsonPath("data", hasSize(2)));
+                .andExpect(jsonPath("data", hasSize(3)));
 
         mvc.perform(get("/" + VERSION + "/networks/" + NETWORK_UUID + "/" + Resource.INITIAL_VARIANT_NUM + "/voltage-levels/baz")
                 .contentType(APPLICATION_JSON))


### PR DESCRIPTION
Signed-off-by: HARPER Jon <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
BugFix


**What is the current behavior?** *(You can also link to an open issue here)*
A voltageLevel without a substation is not stored


**What is the new behavior (if this is a feature change)?**
stored


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
NO