### PR TITLE
Fix sql errors are swalled

### DIFF
--- a/network-store-server/src/main/java/com/powsybl/network/store/server/Session.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/Session.java
@@ -99,6 +99,7 @@ public class Session {
             mainThrows = false;
         } catch (Exception e) {
             conn.rollback();
+            throw e;
         } finally {
             cleanExecute(mainThrows, batch.preparedStatements);
         }

--- a/network-store-server/src/test/java/com/powsybl/network/store/server/NetworkStoreControllerIT.java
+++ b/network-store-server/src/test/java/com/powsybl/network/store/server/NetworkStoreControllerIT.java
@@ -19,6 +19,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.util.NestedServletException;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -32,6 +33,7 @@ import java.util.UUID;
 
 import static com.powsybl.network.store.model.NetworkStoreApi.VERSION;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -78,6 +80,14 @@ public class NetworkStoreControllerIT {
                 .contentType(APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(Collections.singleton(foo))))
                 .andExpect(status().isCreated());
+
+        //Do it again, it should error
+        assertThrows(NestedServletException.class, () -> {
+            mvc.perform(post("/" + VERSION + "/networks")
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Collections.singleton(foo))))
+                .andReturn();
+        });
 
         mvc.perform(get("/" + VERSION + "/networks")
                         .contentType(APPLICATION_JSON))


### PR DESCRIPTION
Signed-off-by: HARPER Jon <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bugfix


**What is the current behavior?** *(You can also link to an open issue here)*
sql errors are swallowed. The whole batch is rollbacked if one element has a problem


**What is the new behavior (if this is a feature change)?**
sql errors not swallowed. The whole batch is still rollbacked


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
NO

**Other information**:
broken since the postgres migration