### PR TITLE
add cloneNetwork

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,2 @@
+config.stopBubbling = true
+lombok.addLombokGeneratedAnnotation = true

--- a/network-store-client/src/main/java/com/powsybl/network/store/client/NetworkStoreService.java
+++ b/network-store-client/src/main/java/com/powsybl/network/store/client/NetworkStoreService.java
@@ -20,8 +20,10 @@ import com.powsybl.network.store.iidm.impl.CachedNetworkStoreClient;
 import com.powsybl.network.store.iidm.impl.NetworkFactoryImpl;
 import com.powsybl.network.store.iidm.impl.NetworkImpl;
 import com.powsybl.network.store.iidm.impl.NetworkStoreClient;
+import com.powsybl.network.store.iidm.impl.StoreClientUtils;
 import com.powsybl.network.store.model.NetworkInfos;
 import com.powsybl.network.store.model.Resource;
+import com.powsybl.network.store.model.VariantInfos;
 import com.powsybl.tools.Version;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,8 +34,10 @@ import org.springframework.stereotype.Service;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.function.BiFunction;
@@ -236,5 +240,30 @@ public class NetworkStoreService implements AutoCloseable {
     @Override
     @PreDestroy
     public void close() {
+    }
+
+    public void cloneVariant(Network network, String sourceVariantId, String targetVariantId) {
+        cloneVariant(network, sourceVariantId, targetVariantId, false);
+    }
+
+    public void cloneVariant(Network network, String sourceVariantId, String targetVariantId, boolean mayOverwrite) {
+        NetworkImpl networkImpl = getNetworkImpl(network);
+        UUID networkUuid = networkImpl.getUuid();
+        NetworkStoreClient client = networkImpl.getIndex().getStoreClient();
+        List<VariantInfos> variantsInfos = client.getVariantsInfos(networkUuid);
+        Optional<VariantInfos> targetVariant = StoreClientUtils.getVariant(targetVariantId, variantsInfos);
+        if (targetVariant.isPresent()) {
+            if (!mayOverwrite) {
+                throw new PowsyblException("Variant '" + targetVariantId + "' already exists");
+            } else {
+                if (Resource.INITIAL_VARIANT_NUM == targetVariant.get().getNum()) {
+                    throw new PowsyblException("Cloning over initial variant is forbidden");
+                }
+                client.deleteNetwork(networkUuid, targetVariant.get().getNum());
+            }
+        }
+        int sourceVariantNum = StoreClientUtils.getVariantNum(sourceVariantId, variantsInfos);
+        int targetVariantNum = StoreClientUtils.findFistAvailableVariantNum(variantsInfos);
+        client.cloneNetwork(networkImpl.getUuid(), sourceVariantNum, targetVariantNum, targetVariantId);
     }
 }

--- a/network-store-client/src/main/java/com/powsybl/network/store/client/RestNetworkStoreClient.java
+++ b/network-store-client/src/main/java/com/powsybl/network/store/client/RestNetworkStoreClient.java
@@ -7,13 +7,16 @@
 
 package com.powsybl.network.store.client;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.Lists;
+import com.powsybl.commons.PowsyblException;
 import com.powsybl.network.store.iidm.impl.NetworkStoreClient;
 import com.powsybl.network.store.model.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -32,8 +35,15 @@ public class RestNetworkStoreClient implements NetworkStoreClient {
 
     private final RestClient restClient;
 
+    private final ObjectMapper objectMapper;
+
     public RestNetworkStoreClient(RestClient restClient) {
+        this(restClient, new ObjectMapper());
+    }
+
+    public RestNetworkStoreClient(RestClient restClient, ObjectMapper objectMapper) {
         this.restClient = Objects.requireNonNull(restClient);
+        this.objectMapper = Objects.requireNonNull(objectMapper);
     }
 
     // network
@@ -150,6 +160,32 @@ public class RestNetworkStoreClient implements NetworkStoreClient {
         LOGGER.info("Cloning network {} variant {} to variant {} (variantId='{}')", networkUuid, sourceVariantNum, targetVariantNum, targetVariantId);
         restClient.put("/networks/{networkUuid}/{sourceVariantNum}/to/{targetVariantNum}?targetVariantId={targetVariantId}",
                 networkUuid, sourceVariantNum, targetVariantNum, targetVariantId);
+    }
+
+    @Override
+    public void cloneNetwork(UUID networkUuid, String sourceVariantId, String targetVariantId, boolean mayOverwrite) {
+        LOGGER.info("Cloning network {} variantId {} to variantId {}", networkUuid, sourceVariantId, targetVariantId);
+        try {
+            restClient.put("/networks/{networkUuid}/{sourceVariantId}/toId/{targetVariantId}?mayOverwrite={mayOverwrite}",
+                    networkUuid, sourceVariantId, targetVariantId, mayOverwrite);
+        } catch (HttpClientErrorException ex) {
+            String body = ex.getResponseBodyAsString();
+            Optional<TopLevelError> optError = RestTemplateResponseErrorHandler.parseJsonApiError(body, objectMapper);
+            if (optError.isPresent()) {
+                TopLevelError error = optError.get();
+                Optional<ErrorObject> errorCloneOverExisting = error.getErrors().stream()
+                        .filter(eo -> ErrorObject.CLONE_OVER_EXISTING_CODE.equals(eo.getCode())).findAny();
+                if (errorCloneOverExisting.isPresent()) {
+                    throw new PowsyblException(errorCloneOverExisting.get().getDetail(), ex);
+                }
+                Optional<ErrorObject> errorCloneOverInitial = error.getErrors().stream()
+                        .filter(eo -> ErrorObject.CLONE_OVER_INITIAL_FORBIDDEN_CODE.equals(eo.getCode())).findAny();
+                if (errorCloneOverInitial.isPresent()) {
+                    throw new PowsyblException(errorCloneOverInitial.get().getTitle(), ex);
+                }
+            }
+            throw ex;
+        }
     }
 
     // substation

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkStoreClient.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkStoreClient.java
@@ -37,6 +37,8 @@ public interface NetworkStoreClient {
 
     void cloneNetwork(UUID networkUuid, int sourceVariantNum, int targetVariantNum, String targetVariantId);
 
+    void cloneNetwork(UUID networkUuid, String sourceVariantId, String targetVariantId, boolean mayOverwrite);
+
     // substation
 
     void createSubstations(UUID networkUuid, List<Resource<SubstationAttributes>> substationResources);

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/OfflineNetworkStoreClient.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/OfflineNetworkStoreClient.java
@@ -19,8 +19,6 @@ import java.util.UUID;
  */
 public class OfflineNetworkStoreClient implements NetworkStoreClient {
 
-    private static final String ERROR_REQUIRED_DATA = "Cannot call methods from OfflineClient which must return data. The cache is supposed to prevent that.";
-
     @Override
     public List<NetworkInfos> getNetworksInfos() {
         return Collections.emptyList();
@@ -58,6 +56,11 @@ public class OfflineNetworkStoreClient implements NetworkStoreClient {
 
     @Override
     public void cloneNetwork(UUID networkUuid, int sourceVariantNum, int targetVariantNum, String targetVariantId) {
+        // nothing to do
+    }
+
+    @Override
+    public void cloneNetwork(UUID networkUuid, String sourceVariantId, String targetVariantId, boolean mayOverwrite) {
         // nothing to do
     }
 

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/OfflineNetworkStoreClient.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/OfflineNetworkStoreClient.java
@@ -19,6 +19,8 @@ import java.util.UUID;
  */
 public class OfflineNetworkStoreClient implements NetworkStoreClient {
 
+    private static final String ERROR_REQUIRED_DATA = "Cannot call methods from OfflineClient which must return data. The cache is supposed to prevent that.";
+
     @Override
     public List<NetworkInfos> getNetworksInfos() {
         return Collections.emptyList();

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/StoreClientUtils.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/StoreClientUtils.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package com.powsybl.network.store.iidm.impl;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.powsybl.commons.PowsyblException;
+import com.powsybl.network.store.model.VariantInfos;
+
+/**
+ * @author Jon Harper <jon.harper at rte-france.com>
+ */
+public final class StoreClientUtils {
+
+    private StoreClientUtils() { }
+
+    public static int findFistAvailableVariantNum(List<VariantInfos> variantsInfos) {
+        for (int i = 0; i < Integer.MAX_VALUE; i++) {
+            final int variantNum = i;
+            if (variantsInfos.stream().noneMatch(infos -> infos.getNum() == variantNum)) {
+                return variantNum;
+            }
+        }
+        throw new PowsyblException("Max number of variant reached: " + Integer.MAX_VALUE);
+    }
+
+    public static Optional<VariantInfos> getVariant(String variantId, List<VariantInfos> variantsInfos) {
+        return variantsInfos.stream()
+            .filter(infos -> infos.getId().equals(variantId))
+            .findFirst();
+    }
+
+    public static int getVariantNum(String variantId, List<VariantInfos> variantsInfos) {
+        return getVariant(variantId, variantsInfos)
+            .map(VariantInfos::getNum)
+            .orElseThrow(() -> new PowsyblException("Variant '" + variantId + "' not found"));
+    }
+}

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/VariantManagerImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/VariantManagerImpl.java
@@ -12,6 +12,8 @@ import com.powsybl.iidm.network.VariantManager;
 import com.powsybl.iidm.network.VariantManagerConstants;
 import com.powsybl.network.store.model.Resource;
 import com.powsybl.network.store.model.VariantInfos;
+import com.powsybl.network.store.model.utils.VariantUtils;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,7 +51,7 @@ public class VariantManagerImpl implements VariantManager {
 
     @Override
     public void setWorkingVariant(String variantId) {
-        int variantNum = StoreClientUtils.getVariantNum(variantId,
+        int variantNum = VariantUtils.getVariantNum(variantId,
             index.getStoreClient().getVariantsInfos(index.getNetwork().getUuid()));
         index.setWorkingVariantNum(variantNum);
     }
@@ -77,9 +79,9 @@ public class VariantManagerImpl implements VariantManager {
             throw new IllegalArgumentException("Empty target variant id list");
         }
         List<VariantInfos> variantsInfos = index.getStoreClient().getVariantsInfos(index.getNetwork().getUuid());
-        int sourceVariantNum = StoreClientUtils.getVariantNum(sourceVariantId, variantsInfos);
+        int sourceVariantNum = VariantUtils.getVariantNum(sourceVariantId, variantsInfos);
         for (String targetVariantId : targetVariantIds) {
-            Optional<VariantInfos> targetVariant = StoreClientUtils.getVariant(targetVariantId, variantsInfos);
+            Optional<VariantInfos> targetVariant = VariantUtils.getVariant(targetVariantId, variantsInfos);
             if (targetVariant.isPresent()) {
                 if (!mayOverwrite) {
                     throw new PowsyblException("Variant '" + targetVariantId + "' already exists");
@@ -87,7 +89,7 @@ public class VariantManagerImpl implements VariantManager {
                     removeVariant(targetVariantId);
                 }
             }
-            int targetVariantNum = StoreClientUtils.findFistAvailableVariantNum(variantsInfos);
+            int targetVariantNum = VariantUtils.findFistAvailableVariantNum(variantsInfos);
             // clone resources
             index.getStoreClient().cloneNetwork(index.getNetwork().getUuid(), sourceVariantNum, targetVariantNum, targetVariantId);
             notifyVariantCreated(sourceVariantId, targetVariantId);
@@ -119,7 +121,7 @@ public class VariantManagerImpl implements VariantManager {
         if (VariantManagerConstants.INITIAL_VARIANT_ID.equals(variantId)) {
             throw new PowsyblException("Removing initial variant is forbidden");
         }
-        int variantNum = StoreClientUtils.getVariantNum(variantId,
+        int variantNum = VariantUtils.getVariantNum(variantId,
             index.getStoreClient().getVariantsInfos(index.getNetwork().getUuid()));
         index.getStoreClient().deleteNetwork(index.getNetwork().getUuid(), variantNum);
         notifyVariantRemoved(variantId);

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/ErrorObject.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/ErrorObject.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package com.powsybl.network.store.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -10,6 +16,9 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
+/**
+ * @author Jon Harper <jon.harper at rte-france.com>
+ */
 @Schema(description = "Error Object compliant with Json API spec")
 @ToString
 @EqualsAndHashCode

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/ErrorObject.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/ErrorObject.java
@@ -1,0 +1,52 @@
+package com.powsybl.network.store.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Schema(description = "Error Object compliant with Json API spec")
+@ToString
+@EqualsAndHashCode
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ErrorObject {
+
+    @Schema(description = "the HTTP status code applicable to this problem", required = true)
+    public String status;
+
+    @Schema(description = "an application-specific error code", required = true)
+    public String code;
+
+    @Schema(description = "a short, human-readable summary of the problem", required = true)
+    public String title;
+
+    @Schema(description = "a human-readable explanation specific to this occurrence of the problem")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public String detail;
+
+    public static final String CLONE_OVER_INITIAL_FORBIDDEN_STATUS = "400";
+    public static final String CLONE_OVER_INITIAL_FORBIDDEN_CODE = "CLONE_OVER_INITIAL_FORBIDDEN";
+    public static final String CLONE_OVER_INITIAL_FORBIDDEN_TITLE = "Cloning over initial variant is forbidden";
+
+    public static ErrorObject cloneOverInitialForbidden() {
+        return new ErrorObject(CLONE_OVER_INITIAL_FORBIDDEN_STATUS, CLONE_OVER_INITIAL_FORBIDDEN_CODE,
+                CLONE_OVER_INITIAL_FORBIDDEN_TITLE, null);
+    }
+
+    public static final String CLONE_OVER_EXISTING_STATUS = "400";
+    public static final String CLONE_OVER_EXISTING_CODE = "CLONE_OVER_EXISTING";
+    public static final String CLONE_OVER_EXISTING_TITLE = "Cloning over existing variant without mayOverwrite=true";
+
+    public static ErrorObject cloneOverExisting(String targetVariantId) {
+        return new ErrorObject(CLONE_OVER_EXISTING_STATUS, CLONE_OVER_EXISTING_CODE, CLONE_OVER_EXISTING_TITLE,
+                "Variant " + targetVariantId + " already exists");
+    }
+}

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/TopLevelError.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/TopLevelError.java
@@ -1,0 +1,61 @@
+package com.powsybl.network.store.model;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Top level document compliant with Json API spec representing errors")
+public class TopLevelError {
+
+    public static final String META_STATUS = "status";
+    public static final String META_MESSAGE = "message";
+
+    @Schema(description = "Errors", required = true)
+    private final List<ErrorObject> errors;
+
+    @Schema(description = "Metadata")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final Map<String, String> meta;
+
+    @JsonCreator
+    public TopLevelError(@JsonProperty("errors") List<ErrorObject> errors, @JsonProperty("meta") Map<String, String> meta) {
+        this.errors = Objects.requireNonNull(errors);
+        this.meta = meta;
+    }
+
+    public static TopLevelError of(ErrorObject error) {
+        return new TopLevelError(ImmutableList.of(error), null);
+    }
+
+    public static TopLevelError of(List<ErrorObject> errors) {
+        return new TopLevelError(errors, null);
+    }
+
+    public static TopLevelError ofStatus(ErrorObject error, String status) {
+        return new TopLevelError(ImmutableList.of(error), ImmutableMap.of(META_STATUS, status));
+    }
+
+    public static TopLevelError ofMessage(ErrorObject error, String message) {
+        return new TopLevelError(ImmutableList.of(error), ImmutableMap.of(META_MESSAGE, message));
+    }
+
+    public static TopLevelError of(ErrorObject error, String status, String message) {
+        return new TopLevelError(ImmutableList.of(error), ImmutableMap.of(META_STATUS, status, META_MESSAGE, message));
+    }
+
+    public List<ErrorObject> getErrors() {
+        return errors;
+    }
+
+    public Map<String, String> getMeta() {
+        return meta;
+    }
+}

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/TopLevelError.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/TopLevelError.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package com.powsybl.network.store.model;
 
 import java.util.List;
@@ -10,6 +16,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+/**
+ * @author Jon Harper <jon.harper at rte-france.com>
+ */
 @Schema(description = "Top level document compliant with Json API spec representing errors")
 public class TopLevelError {
 

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/TopLevelError.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/TopLevelError.java
@@ -7,8 +7,6 @@ import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -32,7 +30,7 @@ public class TopLevelError {
     }
 
     public static TopLevelError of(ErrorObject error) {
-        return new TopLevelError(ImmutableList.of(error), null);
+        return new TopLevelError(List.of(error), null);
     }
 
     public static TopLevelError of(List<ErrorObject> errors) {
@@ -40,15 +38,15 @@ public class TopLevelError {
     }
 
     public static TopLevelError ofStatus(ErrorObject error, String status) {
-        return new TopLevelError(ImmutableList.of(error), ImmutableMap.of(META_STATUS, status));
+        return new TopLevelError(List.of(error), Map.of(META_STATUS, status));
     }
 
     public static TopLevelError ofMessage(ErrorObject error, String message) {
-        return new TopLevelError(ImmutableList.of(error), ImmutableMap.of(META_MESSAGE, message));
+        return new TopLevelError(List.of(error), Map.of(META_MESSAGE, message));
     }
 
     public static TopLevelError of(ErrorObject error, String status, String message) {
-        return new TopLevelError(ImmutableList.of(error), ImmutableMap.of(META_STATUS, status, META_MESSAGE, message));
+        return new TopLevelError(List.of(error), Map.of(META_STATUS, status, META_MESSAGE, message));
     }
 
     public List<ErrorObject> getErrors() {

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/utils/VariantUtils.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/utils/VariantUtils.java
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-package com.powsybl.network.store.iidm.impl;
+package com.powsybl.network.store.model.utils;
 
 import java.util.List;
 import java.util.Optional;
@@ -16,9 +16,9 @@ import com.powsybl.network.store.model.VariantInfos;
 /**
  * @author Jon Harper <jon.harper at rte-france.com>
  */
-public final class StoreClientUtils {
+public final class VariantUtils {
 
-    private StoreClientUtils() { }
+    private VariantUtils() { }
 
     public static int findFistAvailableVariantNum(List<VariantInfos> variantsInfos) {
         for (int i = 0; i < Integer.MAX_VALUE; i++) {

--- a/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreController.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/NetworkStoreController.java
@@ -152,6 +152,21 @@ public class NetworkStoreController {
         return ResponseEntity.ok().build();
     }
 
+    @PutMapping(value = "/{networkId}/{sourceVariantId}/toId/{targetVariantId}")
+    @Operation(summary = "Clone a network variant")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successfully clone the network variant"),
+            @ApiResponse(responseCode = ErrorObject.CLONE_OVER_EXISTING_STATUS, description = ErrorObject.CLONE_OVER_EXISTING_TITLE),
+            @ApiResponse(responseCode = ErrorObject.CLONE_OVER_INITIAL_FORBIDDEN_STATUS, description = ErrorObject.CLONE_OVER_INITIAL_FORBIDDEN_TITLE),
+        })
+    public ResponseEntity<Void> cloneNetwork(@Parameter(description = "Network ID", required = true) @PathVariable("networkId") UUID networkId,
+                                             @Parameter(description = "Source variant Id", required = true) @PathVariable("sourceVariantId") String sourceVariantId,
+                                             @Parameter(description = "Target variant Id", required = true) @PathVariable("targetVariantId") String targetVariantId,
+                                             @Parameter(description = "mayOverwrite", required = false) @RequestParam(required = false) boolean mayOverwrite) {
+        repository.cloneNetwork(networkId, sourceVariantId, targetVariantId, mayOverwrite);
+        return ResponseEntity.ok().build();
+    }
+
     // substation
 
     @GetMapping(value = "/{networkId}/{variantNum}/substations", produces = APPLICATION_JSON_VALUE)

--- a/network-store-server/src/main/java/com/powsybl/network/store/server/exceptions/JsonApiErrorResponseException.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/exceptions/JsonApiErrorResponseException.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import com.google.common.collect.ImmutableList;
 import com.powsybl.network.store.model.ErrorObject;
 import com.powsybl.network.store.model.TopLevelError;
 
@@ -13,7 +12,7 @@ public class JsonApiErrorResponseException extends RuntimeException {
     private final TopLevelError topLevelError;
 
     public JsonApiErrorResponseException(ErrorObject error) {
-        this(ImmutableList.of(error));
+        this(List.of(error));
     }
 
     public JsonApiErrorResponseException(List<ErrorObject> errors) {

--- a/network-store-server/src/main/java/com/powsybl/network/store/server/exceptions/JsonApiErrorResponseException.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/exceptions/JsonApiErrorResponseException.java
@@ -1,0 +1,50 @@
+package com.powsybl.network.store.server.exceptions;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.ImmutableList;
+import com.powsybl.network.store.model.ErrorObject;
+import com.powsybl.network.store.model.TopLevelError;
+
+public class JsonApiErrorResponseException extends RuntimeException {
+
+    private final TopLevelError topLevelError;
+
+    public JsonApiErrorResponseException(ErrorObject error) {
+        this(ImmutableList.of(error));
+    }
+
+    public JsonApiErrorResponseException(List<ErrorObject> errors) {
+        this(errors, null);
+    }
+
+    public JsonApiErrorResponseException(List<ErrorObject> errors, Map<String, String> meta) {
+        this(new TopLevelError(errors, meta));
+    }
+
+    public JsonApiErrorResponseException(TopLevelError topLevelError) {
+        this(topLevelError, null);
+    }
+
+    public JsonApiErrorResponseException(TopLevelError topLevelError, Throwable cause) {
+        super(computeMessage(topLevelError), cause);
+        this.topLevelError = topLevelError;
+    }
+
+    public TopLevelError getTopLevelError() {
+        return topLevelError;
+    }
+
+    private static final String computeMessage(TopLevelError topLevelError) {
+        Map<String, String> meta = topLevelError.getMeta();
+        if (meta != null && meta.get(TopLevelError.META_MESSAGE) != null) {
+            return meta.get(TopLevelError.META_MESSAGE);
+        } else {
+            return topLevelError.getErrors().stream()
+                    .map(errorObject -> errorObject.getCode() + ": " + errorObject.getTitle())
+                    .collect(Collectors.joining(", "));
+        }
+    }
+}

--- a/network-store-server/src/main/java/com/powsybl/network/store/server/exceptions/JsonApiErrorResponseException.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/exceptions/JsonApiErrorResponseException.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package com.powsybl.network.store.server.exceptions;
 
 import java.util.List;
@@ -7,6 +13,9 @@ import java.util.stream.Collectors;
 import com.powsybl.network.store.model.ErrorObject;
 import com.powsybl.network.store.model.TopLevelError;
 
+/**
+ * @author Jon Harper <jon.harper at rte-france.com>
+ */
 public class JsonApiErrorResponseException extends RuntimeException {
 
     private final TopLevelError topLevelError;

--- a/network-store-server/src/main/java/com/powsybl/network/store/server/exceptions/RestResponseEntityExceptionHandler.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/exceptions/RestResponseEntityExceptionHandler.java
@@ -1,0 +1,55 @@
+package com.powsybl.network.store.server.exceptions;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatus.Series;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import com.powsybl.network.store.model.ErrorObject;
+import com.powsybl.network.store.model.TopLevelError;
+
+@ControllerAdvice
+public class RestResponseEntityExceptionHandler extends ResponseEntityExceptionHandler {
+
+    private static HttpStatus computeHttpStatus(TopLevelError topLevelError) {
+        List<String> statusesString;
+        Map<String, String> meta = topLevelError.getMeta();
+        if (meta != null && meta.get(TopLevelError.META_STATUS) != null) {
+            statusesString = List.of(meta.get(TopLevelError.META_STATUS));
+        } else {
+            statusesString = topLevelError.getErrors().stream()
+                .map(ErrorObject::getStatus).collect(Collectors.toList());
+        }
+        List<HttpStatus> statuses = statusesString.stream()
+            .map(Integer::parseInt)
+            .distinct()
+            .map(HttpStatus::valueOf)
+            .collect(Collectors.toList());
+        if (statuses.size() == 1) {
+            return statuses.get(0);
+        }
+
+        List<Series> series = statuses.stream().map(HttpStatus::series).collect(Collectors.toList());
+        if (series.contains(HttpStatus.Series.CLIENT_ERROR)) {
+            return HttpStatus.BAD_REQUEST;
+        } else {
+            return HttpStatus.INTERNAL_SERVER_ERROR;
+        }
+    }
+
+    @ResponseBody
+    @ExceptionHandler(JsonApiErrorResponseException.class)
+    public ResponseEntity<TopLevelError> handleControllerException(HttpServletRequest request, JsonApiErrorResponseException ex) {
+        TopLevelError topLevelError = ex.getTopLevelError();
+        return new ResponseEntity<>(topLevelError, computeHttpStatus(topLevelError));
+    }
+}

--- a/network-store-server/src/main/java/com/powsybl/network/store/server/exceptions/RestResponseEntityExceptionHandler.java
+++ b/network-store-server/src/main/java/com/powsybl/network/store/server/exceptions/RestResponseEntityExceptionHandler.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package com.powsybl.network.store.server.exceptions;
 
 import java.util.List;
@@ -17,6 +23,9 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 import com.powsybl.network.store.model.ErrorObject;
 import com.powsybl.network.store.model.TopLevelError;
 
+/**
+ * @author Jon Harper <jon.harper at rte-france.com>
+ */
 @ControllerAdvice
 public class RestResponseEntityExceptionHandler extends ResponseEntityExceptionHandler {
 


### PR DESCRIPTION
Signed-off-by: HARPER Jon <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
cloneVariant on iidm network clones all objects so that the cloned variant is useable immediately and uses a lot of ram


**What is the new behavior (if this is a feature change)?**
Allow to clone a variant in networkstoreservice without paying for an iidm network clone when you are not going to use it


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
NO
