### PR TITLE
The VL traverse to get a connectable bus must not exit (add a unit test)

### DIFF
--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/NodeBreakerTerminalTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/NodeBreakerTerminalTest.java
@@ -97,8 +97,10 @@ public class NodeBreakerTerminalTest extends AbstractNodeBreakerTest {
         VoltageLevel vl1 = network.getVoltageLevel("VL1");
 
         Terminal lt = network.getLoad("L").getTerminal();
+        Terminal ldt = network.getLoad("LD").getTerminal();
         Terminal gt = network.getGenerator("G").getTerminal();
-        Terminal ldt1 = network.getLine("L1").getTerminal1();
+        Terminal lt1 = network.getLine("L1").getTerminal1();
+        Terminal lt2 = network.getLine("L1").getTerminal2();
         Terminal bbs1t = network.getBusbarSection("BBS1").getTerminal();
 
         assertFalse(lt.disconnect());
@@ -117,11 +119,19 @@ public class NodeBreakerTerminalTest extends AbstractNodeBreakerTest {
         assertTrue(gt.connect());
         assertTrue(gt.isConnected());
 
-        assertTrue(ldt1.disconnect());
-        assertFalse(ldt1.isConnected());
-        assertNull(ldt1.getBusView().getBus());
-        assertNotNull(ldt1.getBusView().getConnectableBus());
-        assertEquals(vl1.getBusView().getBus("VL1_0"), ldt1.getBusView().getConnectableBus());
+        assertTrue(lt1.disconnect());
+        assertFalse(lt1.isConnected());
+        assertNull(lt1.getBusView().getBus());
+        assertNotNull(lt1.getBusView().getConnectableBus());
+        assertEquals(vl1.getBusView().getBus("VL1_0"), lt1.getBusView().getConnectableBus());
+        assertTrue(lt1.connect());
+        assertTrue(lt1.isConnected());
+
+        assertTrue(ldt.disconnect());
+        assertFalse(ldt.isConnected());
+        assertTrue(lt2.disconnect());
+        assertFalse(lt2.isConnected());
+        assertNull(ldt.getBusView().getConnectableBus());
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Slimane AMAR <slimane.amar@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
