### PR TITLE
New method to import study with parameters

### DIFF
--- a/network-store-client/src/main/java/com/powsybl/network/store/client/NetworkStoreService.java
+++ b/network-store-client/src/main/java/com/powsybl/network/store/client/NetworkStoreService.java
@@ -145,6 +145,10 @@ public class NetworkStoreService implements AutoCloseable {
         return importNetwork(dataSource, null, LocalComputationManager.getDefault(), null, reporter, flush);
     }
 
+    public Network importNetwork(ReadOnlyDataSource dataSource, Reporter reporter, Properties parameters, boolean flush) {
+        return importNetwork(dataSource, null, LocalComputationManager.getDefault(), parameters, reporter, flush);
+    }
+
     public Network importNetwork(ReadOnlyDataSource dataSource, PreloadingStrategy preloadingStrategy) {
         return importNetwork(dataSource, preloadingStrategy, LocalComputationManager.getDefault(), null);
     }

--- a/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreIT.java
+++ b/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreIT.java
@@ -2303,7 +2303,7 @@ public class NetworkStoreIT {
             Xnode xnode = (Xnode) dl.getExtensionByName("xnode");
             assertEquals("XG__F_21", xnode.getCode());
             assertEquals(1, dl.getExtensions().size());
-            Xnode sameXnode = dl.getExtension(Xnode.class);
+            Xnode sameXnode = (Xnode) dl.getExtension(Xnode.class);
             assertEquals("XG__F_21", sameXnode.getCode());
             ConnectablePosition connectablePosition = dl.getExtension(ConnectablePosition.class);
             assertNull(connectablePosition);

--- a/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreIT.java
+++ b/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreIT.java
@@ -2303,7 +2303,7 @@ public class NetworkStoreIT {
             Xnode xnode = (Xnode) dl.getExtensionByName("xnode");
             assertEquals("XG__F_21", xnode.getCode());
             assertEquals(1, dl.getExtensions().size());
-            Xnode sameXnode = (Xnode) dl.getExtension(Xnode.class);
+            Xnode sameXnode = dl.getExtension(Xnode.class);
             assertEquals("XG__F_21", sameXnode.getCode());
             ConnectablePosition connectablePosition = dl.getExtension(ConnectablePosition.class);
             assertNull(connectablePosition);
@@ -4557,7 +4557,7 @@ public class NetworkStoreIT {
     }
 
     @Test
-    public void testImportWithPropertiesWithoutFlush() {
+    public void testImportWithProperties() {
         try (NetworkStoreService service = createNetworkStoreService()) {
 
             ReporterModel report = new ReporterModel("test", "test");

--- a/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreIT.java
+++ b/network-store-integration-test/src/test/java/com/powsybl/network/store/integration/NetworkStoreIT.java
@@ -2303,7 +2303,7 @@ public class NetworkStoreIT {
             Xnode xnode = (Xnode) dl.getExtensionByName("xnode");
             assertEquals("XG__F_21", xnode.getCode());
             assertEquals(1, dl.getExtensions().size());
-            Xnode sameXnode = (Xnode) dl.getExtension(Xnode.class);
+            Xnode sameXnode = dl.getExtension(Xnode.class);
             assertEquals("XG__F_21", sameXnode.getCode());
             ConnectablePosition connectablePosition = dl.getExtension(ConnectablePosition.class);
             assertNull(connectablePosition);
@@ -4551,6 +4551,25 @@ public class NetworkStoreIT {
             assertTrue(assertThrows(PowsyblException.class, () -> service.getNetwork(networkUuid1)).getMessage().contains(String.format("Network '%s' not found", networkUuid1)));
 
             network = service.importNetwork(getResource("test.xiidm", "/"), report, true);
+            UUID networkUuid2 = service.getNetworkUuid(network);
+            service.getNetwork(networkUuid2);
+        }
+    }
+
+    @Test
+    public void testImportWithPropertiesWithoutFlush() {
+        try (NetworkStoreService service = createNetworkStoreService()) {
+
+            ReporterModel report = new ReporterModel("test", "test");
+            Properties importParameters = new Properties();
+            importParameters.put("randomImportParameters", "randomImportValue");
+
+            Network network = service.importNetwork(getResource("test.xiidm", "/"), report, importParameters, false);
+            final UUID networkUuid1 = service.getNetworkUuid(network);
+
+            assertTrue(assertThrows(PowsyblException.class, () -> service.getNetwork(networkUuid1)).getMessage().contains(String.format("Network '%s' not found", networkUuid1)));
+
+            network = service.importNetwork(getResource("test.xiidm", "/"), report, importParameters, true);
             UUID networkUuid2 = service.getNetworkUuid(network);
             service.getNetwork(networkUuid2);
         }


### PR DESCRIPTION
Signed-off-by: LE SAULNIER Kevin <kevin.lesaulnier@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
feature


**What is the current behavior?** *(You can also link to an open issue here)*
A method importing a study was always passing null as parameters value


**What is the new behavior (if this is a feature change)?**
A new method allow the user to pass properties as parameters value
