### PR TITLE
Improve Network.getBranch performance

### DIFF
--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkImpl.java
@@ -668,10 +668,7 @@ public class NetworkImpl extends AbstractIdentifiableImpl<Network, NetworkAttrib
 
     @Override
     public Branch getBranch(String branchId) {
-        return index.getLine(branchId)
-                .map(Branch.class::cast)
-                .orElseGet(() -> index.getTwoWindingsTransformer(branchId)
-                        .orElse(null));
+        return index.getBranch(branchId);
     }
 
     @Override

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkObjectIndex.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkObjectIndex.java
@@ -924,6 +924,20 @@ public class NetworkObjectIndex {
         }
     }
 
+    public Branch<?> getBranch(String branchId) {
+        // first try in the line cache, then in 2 windings transformer cache, then load from server
+        if (lineCache.isLoaded(branchId)) {
+            return lineCache.getOne(branchId).orElse(null);
+        } else if (twoWindingsTransformerCache.isLoaded(branchId)) {
+            return twoWindingsTransformerCache.getOne(branchId).orElse(null);
+        } else {
+            return lineCache.getOne(branchId)
+                    .map(Branch.class::cast)
+                    .orElseGet(() -> twoWindingsTransformerCache.getOne(branchId)
+                            .orElse(null));
+        }
+    }
+
     @SuppressWarnings("unchecked")
     public Identifiable<?> getIdentifiable(String id) {
         Objects.requireNonNull(id);

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/NetworkGetBranchTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/NetworkGetBranchTest.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2020, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.network.store.iidm.impl;
+
+import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+public class NetworkGetBranchTest {
+
+    @Test
+    public void test() {
+        var network = EurostagTutorialExample1Factory.create();
+        assertNotNull(network.getBranch("NHV1_NHV2_1"));
+        assertNotNull(network.getBranch("NGEN_NHV1"));
+        assertNull(network.getBranch("foo"));
+        assertNull(network.getBranch("LOAD"));
+    }
+}


### PR DESCRIPTION
Signed-off-by: Geoffroy Jamgotchian <geoffroy.jamgotchian@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Performance improvement


**What is the current behavior?** *(You can also link to an open issue here)*
When writing a SLD diagram, we have extra query because when we search for a branch we begin by loading a line then a transfo. 


**What is the new behavior (if this is a feature change)?**
We first look at line and transfo cache before loading from server. We typically decrease the query number from 69 to 45


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
