### PR TITLE
Fix null exception when creating connectable position extension

### DIFF
--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractBranchImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractBranchImpl.java
@@ -444,9 +444,13 @@ public abstract class AbstractBranchImpl<T extends Branch<T>, U extends BranchAt
         var resource = checkResource();
         if (type == ConnectablePosition.class) {
             connectablePositionExtension = (ConnectablePositionImpl<T>) extension;
-            resource.getAttributes().setPosition1(connectablePositionExtension.getFeeder1().getConnectablePositionAttributes());
-            resource.getAttributes().setPosition2(connectablePositionExtension.getFeeder2().getConnectablePositionAttributes());
-            updateResource();
+            if (connectablePositionExtension.getFeeder1() != null) {
+                resource.getAttributes().setPosition1(connectablePositionExtension.getFeeder1().getConnectablePositionAttributes());
+            }
+            if (connectablePositionExtension.getFeeder2() != null) {
+                resource.getAttributes().setPosition2(connectablePositionExtension.getFeeder2().getConnectablePositionAttributes());
+                updateResource();
+            }
         } else if (type == BranchStatus.class) {
             BranchStatus branchStatus = (BranchStatus) extension;
             setBranchStatus(branchStatus.getStatus());
@@ -458,11 +462,6 @@ public abstract class AbstractBranchImpl<T extends Branch<T>, U extends BranchAt
     @Override
     public ConnectablePositionImpl<T> createConnectablePositionExtension(Feeder feeder, Feeder feeder1, Feeder feeder2, Feeder feeder3) {
         ConnectablePosition.check(feeder, feeder1, feeder2, feeder3);
-
-        if (feeder1 == null || feeder2 == null) {
-            throw new IllegalArgumentException("feeder 1 and feeder 2 are inclusive");
-        }
-
         var cpa1 = ConnectablePositionAttributes.builder()
                 .label(feeder1.getName())
                 .order(feeder1.getOrder().orElse(null))
@@ -478,7 +477,6 @@ public abstract class AbstractBranchImpl<T extends Branch<T>, U extends BranchAt
                 new ConnectablePositionImpl.FeederImpl(cpa1),
                 new ConnectablePositionImpl.FeederImpl(cpa2),
                 null);
-
     }
 
     private <E extends Extension<T>> E createBranchStatusExtension() {

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractBranchImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractBranchImpl.java
@@ -444,10 +444,10 @@ public abstract class AbstractBranchImpl<T extends Branch<T>, U extends BranchAt
         var resource = checkResource();
         if (type == ConnectablePosition.class) {
             connectablePositionExtension = (ConnectablePositionImpl<T>) extension;
-            if (connectablePositionExtension.getFeeder1() != null) {
+            if (connectablePositionExtension != null && connectablePositionExtension.getFeeder1() != null) {
                 resource.getAttributes().setPosition1(connectablePositionExtension.getFeeder1().getConnectablePositionAttributes());
             }
-            if (connectablePositionExtension.getFeeder2() != null) {
+            if (connectablePositionExtension != null && connectablePositionExtension.getFeeder2() != null) {
                 resource.getAttributes().setPosition2(connectablePositionExtension.getFeeder2().getConnectablePositionAttributes());
                 updateResource();
             }
@@ -462,16 +462,24 @@ public abstract class AbstractBranchImpl<T extends Branch<T>, U extends BranchAt
     @Override
     public ConnectablePositionImpl<T> createConnectablePositionExtension(Feeder feeder, Feeder feeder1, Feeder feeder2, Feeder feeder3) {
         ConnectablePosition.check(feeder, feeder1, feeder2, feeder3);
-        var cpa1 = ConnectablePositionAttributes.builder()
-                .label(feeder1.getName())
-                .order(feeder1.getOrder().orElse(null))
-                .direction(ConnectableDirection.valueOf(feeder1.getDirection().name()))
-                .build();
-        var cpa2 = ConnectablePositionAttributes.builder()
-                .label(feeder2.getName())
-                .order(feeder2.getOrder().orElse(null))
-                .direction(ConnectableDirection.valueOf(feeder2.getDirection().name()))
-                .build();
+        ConnectablePositionAttributes cpa1 = null;
+        ConnectablePositionAttributes cpa2 = null;
+        if (feeder1 != null) {
+            cpa1 = ConnectablePositionAttributes.builder()
+                    .label(feeder1.getName())
+                    .order(feeder1.getOrder().orElse(null))
+                    .direction(ConnectableDirection.valueOf(feeder1.getDirection().name()))
+                    .build();
+        }
+
+        if (feeder2 != null) {
+            cpa2 = ConnectablePositionAttributes.builder()
+                    .label(feeder2.getName())
+                    .order(feeder2.getOrder().orElse(null))
+                    .direction(ConnectableDirection.valueOf(feeder2.getDirection().name()))
+                    .build();
+        }
+
         return new ConnectablePositionImpl<>(getBranch(),
                 null,
                 new ConnectablePositionImpl.FeederImpl(cpa1),

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractBranchImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractBranchImpl.java
@@ -37,10 +37,10 @@ public abstract class AbstractBranchImpl<T extends Branch<T>, U extends BranchAt
         terminal2 = TerminalImpl.create(index, new BranchToInjectionAttributesAdapter(this, resource.getAttributes(), false), getBranch());
         ConnectablePositionAttributes cpa1 = resource.getAttributes().getPosition1();
         ConnectablePositionAttributes cpa2 = resource.getAttributes().getPosition2();
-        if (cpa1 != null && cpa2 != null) {
+        if (cpa1 != null || cpa2 != null) {
             connectablePositionExtension = new ConnectablePositionImpl<>(getBranch(), null,
-                    new ConnectablePositionImpl.FeederImpl(cpa1),
-                    new ConnectablePositionImpl.FeederImpl(cpa2), null);
+                    cpa1 != null ? new ConnectablePositionImpl.FeederImpl(cpa1) : null,
+                    cpa2 != null ? new ConnectablePositionImpl.FeederImpl(cpa2) : null, null);
         }
     }
 

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractBranchImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractBranchImpl.java
@@ -456,27 +456,28 @@ public abstract class AbstractBranchImpl<T extends Branch<T>, U extends BranchAt
     }
 
     @Override
-    public ConnectablePositionImpl<T> createConnectablePositionExtension(Feeder feeder, Feeder feeder1, Feeder feeder2,
-                                                                         Feeder feeder3) {
-        Objects.requireNonNull(feeder2);
-        if (feeder3 != null) {
-            throw new IllegalArgumentException("feeder3 must be null for branches");
-        }
+    public ConnectablePositionImpl<T> createConnectablePositionExtension(Feeder feeder, Feeder feeder1, Feeder feeder2, Feeder feeder3) {
         ConnectablePosition.check(feeder, feeder1, feeder2, feeder3);
-        ConnectablePositionAttributes cpa1 = ConnectablePositionAttributes.builder()
-                .label(feeder1.getName())
-                .order(feeder1.getOrder().orElse(null))
-                .direction(ConnectableDirection.valueOf(feeder1.getDirection().name()))
-                .build();
-        ConnectablePositionAttributes cpa2 = ConnectablePositionAttributes.builder()
-                .label(feeder2.getName())
-                .order(feeder2.getOrder().orElse(null))
-                .direction(ConnectableDirection.valueOf(feeder2.getDirection().name()))
-                .build();
+        ConnectablePositionAttributes cpa1 = null;
+        ConnectablePositionAttributes cpa2 = null;
+        if (feeder1 != null) {
+            cpa1 = ConnectablePositionAttributes.builder()
+                    .label(feeder1.getName())
+                    .order(feeder1.getOrder().orElse(null))
+                    .direction(ConnectableDirection.valueOf(feeder1.getDirection().name()))
+                    .build();
+        }
+        if (feeder2 != null) {
+            cpa2 = ConnectablePositionAttributes.builder()
+                    .label(feeder2.getName())
+                    .order(feeder2.getOrder().orElse(null))
+                    .direction(ConnectableDirection.valueOf(feeder2.getDirection().name()))
+                    .build();
+        }
         return new ConnectablePositionImpl<>(getBranch(),
                 null,
-                new ConnectablePositionImpl.FeederImpl(cpa1),
-                new ConnectablePositionImpl.FeederImpl(cpa2),
+                cpa1 != null ? new ConnectablePositionImpl.FeederImpl(cpa1) : null,
+                cpa2 != null ? new ConnectablePositionImpl.FeederImpl(cpa2) : null,
                 null);
     }
 

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractBranchImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractBranchImpl.java
@@ -458,27 +458,27 @@ public abstract class AbstractBranchImpl<T extends Branch<T>, U extends BranchAt
     @Override
     public ConnectablePositionImpl<T> createConnectablePositionExtension(Feeder feeder, Feeder feeder1, Feeder feeder2, Feeder feeder3) {
         ConnectablePosition.check(feeder, feeder1, feeder2, feeder3);
-        ConnectablePositionAttributes cpa1 = null;
-        ConnectablePositionAttributes cpa2 = null;
-        if (feeder1 != null) {
-            cpa1 = ConnectablePositionAttributes.builder()
-                    .label(feeder1.getName())
-                    .order(feeder1.getOrder().orElse(null))
-                    .direction(ConnectableDirection.valueOf(feeder1.getDirection().name()))
-                    .build();
+
+        if (feeder1 == null || feeder2 == null) {
+            throw new IllegalArgumentException("feeder 1 and feeder 2 are inclusive");
         }
-        if (feeder2 != null) {
-            cpa2 = ConnectablePositionAttributes.builder()
-                    .label(feeder2.getName())
-                    .order(feeder2.getOrder().orElse(null))
-                    .direction(ConnectableDirection.valueOf(feeder2.getDirection().name()))
-                    .build();
-        }
+
+        var cpa1 = ConnectablePositionAttributes.builder()
+                .label(feeder1.getName())
+                .order(feeder1.getOrder().orElse(null))
+                .direction(ConnectableDirection.valueOf(feeder1.getDirection().name()))
+                .build();
+        var cpa2 = ConnectablePositionAttributes.builder()
+                .label(feeder2.getName())
+                .order(feeder2.getOrder().orElse(null))
+                .direction(ConnectableDirection.valueOf(feeder2.getDirection().name()))
+                .build();
         return new ConnectablePositionImpl<>(getBranch(),
                 null,
-                cpa1 != null ? new ConnectablePositionImpl.FeederImpl(cpa1) : null,
-                cpa2 != null ? new ConnectablePositionImpl.FeederImpl(cpa2) : null,
+                new ConnectablePositionImpl.FeederImpl(cpa1),
+                new ConnectablePositionImpl.FeederImpl(cpa2),
                 null);
+
     }
 
     private <E extends Extension<T>> E createBranchStatusExtension() {

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractBranchImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractBranchImpl.java
@@ -449,8 +449,8 @@ public abstract class AbstractBranchImpl<T extends Branch<T>, U extends BranchAt
             }
             if (connectablePositionExtension != null && connectablePositionExtension.getFeeder2() != null) {
                 resource.getAttributes().setPosition2(connectablePositionExtension.getFeeder2().getConnectablePositionAttributes());
-                updateResource();
             }
+            updateResource();
         } else if (type == BranchStatus.class) {
             BranchStatus branchStatus = (BranchStatus) extension;
             setBranchStatus(branchStatus.getStatus());
@@ -482,8 +482,8 @@ public abstract class AbstractBranchImpl<T extends Branch<T>, U extends BranchAt
 
         return new ConnectablePositionImpl<>(getBranch(),
                 null,
-                new ConnectablePositionImpl.FeederImpl(cpa1),
-                new ConnectablePositionImpl.FeederImpl(cpa2),
+                cpa1 != null ? new ConnectablePositionImpl.FeederImpl(cpa1) : null,
+                cpa2 != null ? new ConnectablePositionImpl.FeederImpl(cpa2) : null,
                 null);
     }
 

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/CreateNetworksUtil.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/CreateNetworksUtil.java
@@ -7,6 +7,8 @@
 package com.powsybl.network.store.iidm.impl;
 
 import com.powsybl.iidm.network.*;
+import com.powsybl.iidm.network.extensions.ConnectablePosition;
+import com.powsybl.iidm.network.extensions.ConnectablePositionAdder;
 
 import java.util.List;
 import java.util.SortedSet;
@@ -815,7 +817,7 @@ final class CreateNetworksUtil {
                 .setNode2(3)
                 .setOpen(false)
                 .add();
-        network.newLine()
+        var l1 = network.newLine()
                 .setId("L1")
                 .setVoltageLevel1("VL1")
                 .setNode1(3)
@@ -828,6 +830,17 @@ final class CreateNetworksUtil {
                 .setG2(0.0)
                 .setB2(0.0)
                 .add();
+        l1.newExtension(ConnectablePositionAdder.class)
+                .newFeeder1()
+                .withName("cn1")
+                .withOrder(0)
+                .withDirection(ConnectablePosition.Direction.TOP).add()
+                .newFeeder2()
+                .withName("cn1")
+                .withOrder(0)
+                .withDirection(ConnectablePosition.Direction.TOP).add()
+                .add();
+
         return network;
     }
 

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/CreateNetworksUtil.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/CreateNetworksUtil.java
@@ -7,8 +7,6 @@
 package com.powsybl.network.store.iidm.impl;
 
 import com.powsybl.iidm.network.*;
-import com.powsybl.iidm.network.extensions.ConnectablePosition;
-import com.powsybl.iidm.network.extensions.ConnectablePositionAdder;
 
 import java.util.List;
 import java.util.SortedSet;
@@ -817,7 +815,7 @@ final class CreateNetworksUtil {
                 .setNode2(3)
                 .setOpen(false)
                 .add();
-        var l1 = network.newLine()
+        network.newLine()
                 .setId("L1")
                 .setVoltageLevel1("VL1")
                 .setNode1(3)
@@ -829,16 +827,6 @@ final class CreateNetworksUtil {
                 .setB1(0.0)
                 .setG2(0.0)
                 .setB2(0.0)
-                .add();
-        l1.newExtension(ConnectablePositionAdder.class)
-                .newFeeder1()
-                .withName("cn1")
-                .withOrder(0)
-                .withDirection(ConnectablePosition.Direction.TOP).add()
-                .newFeeder2()
-                .withName("cn1")
-                .withOrder(0)
-                .withDirection(ConnectablePosition.Direction.TOP).add()
                 .add();
 
         return network;

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/CreateNetworksUtil.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/CreateNetworksUtil.java
@@ -828,7 +828,6 @@ final class CreateNetworksUtil {
                 .setG2(0.0)
                 .setB2(0.0)
                 .add();
-
         return network;
     }
 

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/LineTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/LineTest.java
@@ -85,7 +85,7 @@ public class LineTest extends AbstractLineTest {
     }
 
     @Test
-    public void testAddConnectablePositionExtensionToLineWithOneFeeder() {
+    public void testAddConnectablePositionExtensionToLine() {
         Network network = CreateNetworksUtil.createNodeBreakerNetworkWithLine();
         Line l1 = network.getLine("L1");
         ConnectablePositionAttributes cpa1 = new ConnectablePositionAttributes("cpa1", 0, ConnectableDirection.TOP);

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/LineTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/LineTest.java
@@ -108,8 +108,7 @@ public class LineTest extends AbstractLineTest {
 
         assertNotNull(connectablePositionExtension1);
         assertNotNull(connectablePositionExtension2);
-        assertThrows(IllegalArgumentException.class,
-                () -> new ConnectablePositionImpl<>(l1.getBranch(), null,
+        assertThrows(IllegalArgumentException.class, () -> new ConnectablePositionImpl<>(l1.getBranch(), null,
                         null,
                         null,
                         null));

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/LineTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/LineTest.java
@@ -9,8 +9,6 @@ package com.powsybl.network.store.iidm.impl;
 import com.powsybl.iidm.network.Branch;
 import com.powsybl.iidm.network.LimitType;
 import com.powsybl.iidm.network.Network;
-import com.powsybl.iidm.network.extensions.ConnectablePosition;
-import com.powsybl.iidm.network.extensions.ConnectablePositionAdder;
 import com.powsybl.iidm.network.tck.AbstractLineTest;
 import com.powsybl.network.store.model.LimitsAttributes;
 import com.powsybl.network.store.model.TemporaryLimitAttributes;
@@ -78,39 +76,5 @@ public class LineTest extends AbstractLineTest {
     @Override
     public void testRemoveAcLine() {
         // exception message is not the same and should not be checked in TCK
-    }
-
-    @Test
-    public void testAddConnectablePositionExtensionToLineWithOneFeeder() {
-        Network network = CreateNetworksUtil.createNodeBreakerNetworkWithLine();
-        LineImpl l1 = (LineImpl) network.getLine("L1");
-        l1.newExtension(ConnectablePositionAdder.class)
-                .newFeeder1()
-                .withName("cn1")
-                .withOrder(0)
-                .withDirection(ConnectablePosition.Direction.TOP).add()
-                .newFeeder2()
-                .withName("cn1")
-                .withOrder(0)
-                .withDirection(ConnectablePosition.Direction.TOP).add()
-                .add();
-        var cpa1 = l1.getResource().getAttributes().getPosition1();
-        var cpa2 = l1.getResource().getAttributes().getPosition2();
-
-        var connectablePositionExtension1 = new ConnectablePositionImpl<>(l1.getBranch(), null,
-                cpa1 != null ? new ConnectablePositionImpl.FeederImpl(cpa1) : null,
-                null,
-                null);
-        var connectablePositionExtension2 = new ConnectablePositionImpl<>(l1.getBranch(), null,
-                null,
-                cpa2 != null ? new ConnectablePositionImpl.FeederImpl(cpa2) : null,
-                null);
-
-        assertNotNull(connectablePositionExtension1);
-        assertNotNull(connectablePositionExtension2);
-        assertThrows(IllegalArgumentException.class, () -> new ConnectablePositionImpl<>(l1.getBranch(), null,
-                        null,
-                        null,
-                        null));
     }
 }

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/LineTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/LineTest.java
@@ -9,6 +9,8 @@ package com.powsybl.network.store.iidm.impl;
 import com.powsybl.iidm.network.Branch;
 import com.powsybl.iidm.network.LimitType;
 import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.extensions.ConnectablePosition;
+import com.powsybl.iidm.network.extensions.ConnectablePositionAdder;
 import com.powsybl.iidm.network.tck.AbstractLineTest;
 import com.powsybl.network.store.model.LimitsAttributes;
 import com.powsybl.network.store.model.TemporaryLimitAttributes;
@@ -76,5 +78,40 @@ public class LineTest extends AbstractLineTest {
     @Override
     public void testRemoveAcLine() {
         // exception message is not the same and should not be checked in TCK
+    }
+
+    @Test
+    public void testAddConnectablePositionExtensionToLineWithOneFeeder() {
+        Network network = CreateNetworksUtil.createNodeBreakerNetworkWithLine();
+        LineImpl l1 = (LineImpl) network.getLine("L1");
+        l1.newExtension(ConnectablePositionAdder.class)
+                .newFeeder1()
+                .withName("cn1")
+                .withOrder(0)
+                .withDirection(ConnectablePosition.Direction.TOP).add()
+                .newFeeder2()
+                .withName("cn1")
+                .withOrder(0)
+                .withDirection(ConnectablePosition.Direction.TOP).add()
+                .add();
+        var cpa1 = l1.getResource().getAttributes().getPosition1();
+        var cpa2 = l1.getResource().getAttributes().getPosition2();
+
+        var connectablePositionExtension1 = new ConnectablePositionImpl<>(l1.getBranch(), null,
+                cpa1 != null ? new ConnectablePositionImpl.FeederImpl(cpa1) : null,
+                null,
+                null);
+        var connectablePositionExtension2 = new ConnectablePositionImpl<>(l1.getBranch(), null,
+                null,
+                cpa2 != null ? new ConnectablePositionImpl.FeederImpl(cpa2) : null,
+                null);
+
+        assertNotNull(connectablePositionExtension1);
+        assertNotNull(connectablePositionExtension2);
+        assertThrows(IllegalArgumentException.class,
+                () -> new ConnectablePositionImpl<>(l1.getBranch(), null,
+                        null,
+                        null,
+                        null));
     }
 }

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/LineTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/LineTest.java
@@ -127,12 +127,23 @@ public class LineTest extends AbstractLineTest {
                 .setG2(0.0)
                 .setB2(0.0)
                 .add();
-        l3.newExtension(ConnectablePositionAdder.class).newFeeder2().withDirection(ConnectablePosition.Direction.TOP).withOrder(0).withName("cpx").add().add();
+        l3.newExtension(ConnectablePositionAdder.class).newFeeder2().withDirection(ConnectablePosition.Direction.TOP).withOrder(0).withName("cpa3").add().add();
 
         assertEquals("cpa1", l1.getExtension(ConnectablePosition.class).getFeeder1().getName());
         assertEquals(ConnectablePosition.Direction.TOP, l1.getExtension(ConnectablePosition.class).getFeeder1().getDirection());
         assertEquals(Optional.of(0), l1.getExtension(ConnectablePosition.class).getFeeder1().getOrder());
+        assertEquals("cpa2", l1.getExtension(ConnectablePosition.class).getFeeder2().getName());
+        assertEquals(ConnectablePosition.Direction.TOP, l1.getExtension(ConnectablePosition.class).getFeeder2().getDirection());
+        assertEquals(Optional.of(0), l1.getExtension(ConnectablePosition.class).getFeeder2().getOrder());
+
+        assertEquals("cpa1", l2.getExtension(ConnectablePosition.class).getFeeder1().getName());
+        assertEquals(ConnectablePosition.Direction.TOP, l2.getExtension(ConnectablePosition.class).getFeeder1().getDirection());
+        assertEquals(Optional.of(0), l2.getExtension(ConnectablePosition.class).getFeeder1().getOrder());
         assertNull(l2.getExtension(ConnectablePosition.class).getFeeder2());
+
+        assertEquals("cpa3", l3.getExtension(ConnectablePosition.class).getFeeder2().getName());
+        assertEquals(ConnectablePosition.Direction.TOP, l3.getExtension(ConnectablePosition.class).getFeeder2().getDirection());
+        assertEquals(Optional.of(0), l3.getExtension(ConnectablePosition.class).getFeeder2().getOrder());
         assertNull(l3.getExtension(ConnectablePosition.class).getFeeder1());
     }
 }

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/LineTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/LineTest.java
@@ -8,12 +8,18 @@ package com.powsybl.network.store.iidm.impl;
 
 import com.powsybl.iidm.network.Branch;
 import com.powsybl.iidm.network.LimitType;
+import com.powsybl.iidm.network.Line;
 import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.extensions.ConnectablePosition;
+import com.powsybl.iidm.network.extensions.ConnectablePositionAdder;
 import com.powsybl.iidm.network.tck.AbstractLineTest;
+import com.powsybl.network.store.model.ConnectableDirection;
+import com.powsybl.network.store.model.ConnectablePositionAttributes;
 import com.powsybl.network.store.model.LimitsAttributes;
 import com.powsybl.network.store.model.TemporaryLimitAttributes;
 import org.junit.Test;
 
+import java.util.Optional;
 import java.util.TreeMap;
 
 import static org.junit.Assert.*;
@@ -76,5 +82,57 @@ public class LineTest extends AbstractLineTest {
     @Override
     public void testRemoveAcLine() {
         // exception message is not the same and should not be checked in TCK
+    }
+
+    @Test
+    public void testAddConnectablePositionExtensionToLineWithOneFeeder() {
+        Network network = CreateNetworksUtil.createNodeBreakerNetworkWithLine();
+        Line l1 = network.getLine("L1");
+        ConnectablePositionAttributes cpa1 = new ConnectablePositionAttributes("cpa1", 0, ConnectableDirection.TOP);
+        ConnectablePositionAttributes cpa2 = new ConnectablePositionAttributes("cpa2", 0, ConnectableDirection.TOP);
+
+        var f1 = new ConnectablePositionImpl.FeederImpl(cpa1);
+        var f2 = new ConnectablePositionImpl.FeederImpl(cpa2);
+
+        ConnectablePosition cp = new ConnectablePositionImpl(l1, null, f1, f2, null);
+        ConnectablePosition cp1 = new ConnectablePositionImpl(l1, null, f1, null, null);
+
+        l1.addExtension(ConnectablePosition.class, cp);
+
+        Line l2 = network.newLine()
+                .setId("L2")
+                .setVoltageLevel1("VL1")
+                .setNode1(3)
+                .setVoltageLevel2("VL2")
+                .setNode2(3)
+                .setR(1.0)
+                .setX(1.0)
+                .setG1(0.0)
+                .setB1(0.0)
+                .setG2(0.0)
+                .setB2(0.0)
+                .add();
+        l2.addExtension(ConnectablePosition.class, cp1);
+
+        Line l3 = network.newLine()
+                .setId("L3")
+                .setVoltageLevel1("VL1")
+                .setNode1(3)
+                .setVoltageLevel2("VL2")
+                .setNode2(3)
+                .setR(1.0)
+                .setX(1.0)
+                .setG1(0.0)
+                .setB1(0.0)
+                .setG2(0.0)
+                .setB2(0.0)
+                .add();
+        l3.newExtension(ConnectablePositionAdder.class).newFeeder2().withDirection(ConnectablePosition.Direction.TOP).withOrder(0).withName("cpx").add().add();
+
+        assertEquals("cpa1", l1.getExtension(ConnectablePosition.class).getFeeder1().getName());
+        assertEquals(ConnectablePosition.Direction.TOP, l1.getExtension(ConnectablePosition.class).getFeeder1().getDirection());
+        assertEquals(Optional.of(0), l1.getExtension(ConnectablePosition.class).getFeeder1().getOrder());
+        assertNull(l2.getExtension(ConnectablePosition.class).getFeeder2());
+        assertNull(l3.getExtension(ConnectablePosition.class).getFeeder1());
     }
 }

--- a/network-store-server/src/test/java/com/powsybl/network/store/server/NetworkStoreControllerIT.java
+++ b/network-store-server/src/test/java/com/powsybl/network/store/server/NetworkStoreControllerIT.java
@@ -344,9 +344,48 @@ public class NetworkStoreControllerIT {
             .build();
 
         mvc.perform(post("/" + VERSION + "/networks/" + NETWORK_UUID + "/lines")
-            .contentType(APPLICATION_JSON)
-            .content(objectMapper.writeValueAsString(Collections.singleton(resLine))))
-            .andExpect(status().isCreated());
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Collections.singleton(resLine))))
+                .andExpect(status().isCreated());
+
+        // line creation Without Positions
+        Resource<LineAttributes> lineWithoutFirstPositions = Resource.lineBuilder()
+                .id("idLineWithoutFirstPosition")
+                .attributes(LineAttributes.builder()
+                        .voltageLevelId1("vl1")
+                        .voltageLevelId2("vl2")
+                        .name("idLineWithoutFirstPosition")
+                        .node1(1)
+                        .node2(1)
+                        .bus1("bus1")
+                        .bus2("bus2")
+                        .connectableBus1("bus1")
+                        .connectableBus2("bus2")
+                        .r(1)
+                        .x(1)
+                        .g1(1)
+                        .b1(1)
+                        .g2(1)
+                        .b2(1)
+                        .p1(0)
+                        .q1(0)
+                        .p2(0)
+                        .q2(0)
+                        .fictitious(true)
+                        .properties(new HashMap<>(Map.of("property1", "value1", "property2", "value2")))
+                        .aliasesWithoutType(new HashSet<>(Set.of("alias1")))
+                        .aliasByType(new HashMap<>(Map.of("aliasInt", "valueAliasInt", "aliasDouble", "valueAliasDouble")))
+                        .position1(null)
+                        .position2(null)
+                        .mergedXnode(MergedXnodeAttributes.builder().rdp(50.).build())
+                        .currentLimits1(LimitsAttributes.builder().permanentLimit(20.).build())
+                        .build())
+                .build();
+
+        mvc.perform(post("/" + VERSION + "/networks/" + NETWORK_UUID + "/lines")
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Collections.singleton(lineWithoutFirstPositions))))
+                .andExpect(status().isCreated());
 
         mvc.perform(get("/" + VERSION + "/networks/" + NETWORK_UUID + "/" + Resource.INITIAL_VARIANT_NUM + "/lines/idLine")
                 .contentType(APPLICATION_JSON))

--- a/network-store-server/src/test/java/com/powsybl/network/store/server/NetworkStoreControllerIT.java
+++ b/network-store-server/src/test/java/com/powsybl/network/store/server/NetworkStoreControllerIT.java
@@ -347,6 +347,39 @@ public class NetworkStoreControllerIT {
                         .contentType(APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(Collections.singleton(resLine))))
                 .andExpect(status().isCreated());
+        mvc.perform(get("/" + VERSION + "/networks/" + NETWORK_UUID + "/" + Resource.INITIAL_VARIANT_NUM + "/lines/idLine")
+                        .contentType(APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+                .andExpect(jsonPath("data[0].id").value("idLine"))
+                .andExpect(jsonPath("data[0].attributes.p1").value(0.))
+                .andExpect(jsonPath("data[0].attributes.bus2").value("bus2"))
+                .andExpect(jsonPath("data[0].attributes.node1").value(1))
+                .andExpect(jsonPath("data[0].attributes.fictitious").value(true))
+                .andExpect(jsonPath("data[0].attributes.properties[\"property1\"]").value("value1"))
+                .andExpect(jsonPath("data[0].attributes.aliasByType[\"aliasDouble\"]").value("valueAliasDouble"))
+                .andExpect(jsonPath("data[0].attributes.aliasesWithoutType").value("alias1"))
+                .andExpect(jsonPath("data[0].attributes.position1.label").value("labPosition1"))
+                .andExpect(jsonPath("data[0].attributes.position1.direction").value("BOTTOM"))
+                .andExpect(jsonPath("data[0].attributes.position2.label").value("labPosition2"))
+                .andExpect(jsonPath("data[0].attributes.position2.direction").value("TOP"))
+                .andExpect(jsonPath("data[0].attributes.mergedXnode.rdp").value(50.0))
+                .andExpect(jsonPath("data[0].attributes.currentLimits1.permanentLimit").value(20.));
+
+        resLine.getAttributes().setP1(100.);  // changing p1 value
+        resLine.getAttributes().getProperties().put("property1", "newValue1");  // changing property value
+        mvc.perform(put("/" + VERSION + "/networks/" + NETWORK_UUID + "/lines")
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Collections.singleton(resLine))))
+                .andExpect(status().isOk());
+
+        mvc.perform(get("/" + VERSION + "/networks/" + NETWORK_UUID + "/" + Resource.INITIAL_VARIANT_NUM + "/lines/idLine")
+                        .contentType(APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
+                .andExpect(jsonPath("data[0].id").value("idLine"))
+                .andExpect(jsonPath("data[0].attributes.p1").value(100.))
+                .andExpect(jsonPath("data[0].attributes.properties[\"property1\"]").value("newValue1"));
 
         // line creation Without Positions
         Resource<LineAttributes> lineWithoutFirstPositions = Resource.lineBuilder()
@@ -387,11 +420,12 @@ public class NetworkStoreControllerIT {
                         .content(objectMapper.writeValueAsString(Collections.singleton(lineWithoutFirstPositions))))
                 .andExpect(status().isCreated());
 
-        mvc.perform(get("/" + VERSION + "/networks/" + NETWORK_UUID + "/" + Resource.INITIAL_VARIANT_NUM + "/lines/idLine")
-                .contentType(APPLICATION_JSON))
+
+        mvc.perform(get("/" + VERSION + "/networks/" + NETWORK_UUID + "/" + Resource.INITIAL_VARIANT_NUM + "/lines/idLineWithoutFirstPosition")
+                        .contentType(APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
-                .andExpect(jsonPath("data[0].id").value("idLine"))
+                .andExpect(jsonPath("data[0].id").value("idLineWithoutFirstPosition"))
                 .andExpect(jsonPath("data[0].attributes.p1").value(0.))
                 .andExpect(jsonPath("data[0].attributes.bus2").value("bus2"))
                 .andExpect(jsonPath("data[0].attributes.node1").value(1))
@@ -399,27 +433,8 @@ public class NetworkStoreControllerIT {
                 .andExpect(jsonPath("data[0].attributes.properties[\"property1\"]").value("value1"))
                 .andExpect(jsonPath("data[0].attributes.aliasByType[\"aliasDouble\"]").value("valueAliasDouble"))
                 .andExpect(jsonPath("data[0].attributes.aliasesWithoutType").value("alias1"))
-                .andExpect(jsonPath("data[0].attributes.position1.label").value("labPosition1"))
-                .andExpect(jsonPath("data[0].attributes.position1.direction").value("BOTTOM"))
-                .andExpect(jsonPath("data[0].attributes.position2.label").value("labPosition2"))
-                .andExpect(jsonPath("data[0].attributes.position2.direction").value("TOP"))
                 .andExpect(jsonPath("data[0].attributes.mergedXnode.rdp").value(50.0))
                 .andExpect(jsonPath("data[0].attributes.currentLimits1.permanentLimit").value(20.));
-
-        resLine.getAttributes().setP1(100.);  // changing p1 value
-        resLine.getAttributes().getProperties().put("property1", "newValue1");  // changing property value
-        mvc.perform(put("/" + VERSION + "/networks/" + NETWORK_UUID + "/lines")
-                .contentType(APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(Collections.singleton(resLine))))
-                .andExpect(status().isOk());
-
-        mvc.perform(get("/" + VERSION + "/networks/" + NETWORK_UUID + "/" + Resource.INITIAL_VARIANT_NUM + "/lines/idLine")
-                .contentType(APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON))
-                .andExpect(jsonPath("data[0].id").value("idLine"))
-                .andExpect(jsonPath("data[0].attributes.p1").value(100.))
-                .andExpect(jsonPath("data[0].attributes.properties[\"property1\"]").value("newValue1"));
 
         Resource<LineAttributes> resLine2 = Resource.lineBuilder()
             .id("idLine2")

--- a/network-store-server/src/test/java/com/powsybl/network/store/server/NetworkStoreControllerIT.java
+++ b/network-store-server/src/test/java/com/powsybl/network/store/server/NetworkStoreControllerIT.java
@@ -420,7 +420,6 @@ public class NetworkStoreControllerIT {
                         .content(objectMapper.writeValueAsString(Collections.singleton(lineWithoutFirstPositions))))
                 .andExpect(status().isCreated());
 
-
         mvc.perform(get("/" + VERSION + "/networks/" + NETWORK_UUID + "/" + Resource.INITIAL_VARIANT_NUM + "/lines/idLineWithoutFirstPosition")
                         .contentType(APPLICATION_JSON))
                 .andExpect(status().isOk())


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Bug fix

**What is the current behavior?** *(You can also link to an open issue here)*

we have NullPointerException error when adding connectablePositionExtension with a null value for feeder1 or null value for feeder2

**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
