### PR TITLE
Add getV/getAngle impl for busbarsection, same as getTerminal().getI()

### DIFF
--- a/powsybl-network-store-client-parent/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/BusbarSectionImpl.java
+++ b/powsybl-network-store-client-parent/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/BusbarSectionImpl.java
@@ -109,11 +109,11 @@ public class BusbarSectionImpl extends AbstractIdentifiableImpl<BusbarSection, B
 
     @Override
     public double getV() {
-        throw new UnsupportedOperationException("TODO");
+        return getTerminal().isConnected() ? getTerminal().getBusView().getBus().getV() : Double.NaN;
     }
 
     @Override
     public double getAngle() {
-        throw new UnsupportedOperationException("TODO");
+        return getTerminal().isConnected() ? getTerminal().getBusView().getBus().getAngle() : Double.NaN;
     }
 }

--- a/powsybl-network-store-client-parent/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/TerminalImpl.java
+++ b/powsybl-network-store-client-parent/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/TerminalImpl.java
@@ -129,7 +129,7 @@ public class TerminalImpl<U extends InjectionAttributes> implements Terminal, Va
         if (connectable.getType() == IdentifiableType.BUSBAR_SECTION) {
             return 0;
         }
-        return isConnected() ? Math.hypot(getP(), getQ()) / (Math.sqrt(3.) * getBusView().getBus().getV() / 1000) : 0;
+        return isConnected() ? Math.hypot(getP(), getQ()) / (Math.sqrt(3.) * getBusView().getBus().getV() / 1000) : Double.NaN;
     }
 
     private Resource<VoltageLevelAttributes> getVoltageLevelResource() {


### PR DESCRIPTION
Signed-off-by: HARPER Jon <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
iidm export v1 uses busbarsection.getV, throws


**What is the new behavior (if this is a feature change)?**
iidm export v1 works


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
NO

**Other information**:
Tests to be added in the tck