### PR TITLE
return temporary limits by descending durations

### DIFF
--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractLoadingLimits.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractLoadingLimits.java
@@ -11,15 +11,15 @@ import com.powsybl.iidm.network.ValidationUtil;
 import com.powsybl.network.store.model.LimitsAttributes;
 import com.powsybl.network.store.model.TemporaryLimitAttributes;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Objects;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public abstract class AbstractLoadingLimits<T extends LoadingLimits> implements LoadingLimits {
+
+    public static final Comparator<Integer> ACCEPTABLE_DURATION_COMPARATOR = (acceptableDuration1, acceptableDuration2) -> acceptableDuration2 - acceptableDuration1;
 
     private static final class TemporaryLimitImpl implements LoadingLimits.TemporaryLimit {
 
@@ -73,8 +73,13 @@ public abstract class AbstractLoadingLimits<T extends LoadingLimits> implements 
 
     @Override
     public Collection<LoadingLimits.TemporaryLimit> getTemporaryLimits() {
-        return attributes.getTemporaryLimits() == null ? Collections.emptyList()
-                                                       : attributes.getTemporaryLimits().values().stream().map(TemporaryLimitImpl::new).collect(Collectors.toUnmodifiableList());
+        if (attributes.getTemporaryLimits() == null) {
+            return Collections.emptyList();
+        }
+        // make sure limits are provided by descending durations
+        TreeMap<Integer, TemporaryLimitAttributes> sortedLimitAttributes = new TreeMap<>(ACCEPTABLE_DURATION_COMPARATOR);
+        sortedLimitAttributes.putAll(attributes.getTemporaryLimits());
+        return sortedLimitAttributes.values().stream().map(TemporaryLimitImpl::new).collect(Collectors.toUnmodifiableList());
     }
 
     @Override

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractLoadingLimits.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractLoadingLimits.java
@@ -11,15 +11,15 @@ import com.powsybl.iidm.network.ValidationUtil;
 import com.powsybl.network.store.model.LimitsAttributes;
 import com.powsybl.network.store.model.TemporaryLimitAttributes;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public abstract class AbstractLoadingLimits<T extends LoadingLimits> implements LoadingLimits {
-
-    public static final Comparator<Integer> ACCEPTABLE_DURATION_COMPARATOR = (acceptableDuration1, acceptableDuration2) -> acceptableDuration2 - acceptableDuration1;
 
     private static final class TemporaryLimitImpl implements LoadingLimits.TemporaryLimit {
 
@@ -72,14 +72,9 @@ public abstract class AbstractLoadingLimits<T extends LoadingLimits> implements 
     }
 
     @Override
-    public Collection<LoadingLimits.TemporaryLimit> getTemporaryLimits() {
-        if (attributes.getTemporaryLimits() == null) {
-            return Collections.emptyList();
-        }
-        // make sure limits are provided by descending durations
-        TreeMap<Integer, TemporaryLimitAttributes> sortedLimitAttributes = new TreeMap<>(ACCEPTABLE_DURATION_COMPARATOR);
-        sortedLimitAttributes.putAll(attributes.getTemporaryLimits());
-        return sortedLimitAttributes.values().stream().map(TemporaryLimitImpl::new).collect(Collectors.toUnmodifiableList());
+    public Collection<TemporaryLimit> getTemporaryLimits() {
+        return attributes.getTemporaryLimits() == null ? Collections.emptyList()
+            : attributes.getTemporaryLimits().values().stream().sorted().map(TemporaryLimitImpl::new).collect(Collectors.toUnmodifiableList());
     }
 
     @Override

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractLoadingLimitsAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractLoadingLimitsAdderImpl.java
@@ -16,7 +16,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
@@ -26,8 +25,6 @@ import java.util.stream.Collectors;
  */
 public abstract class AbstractLoadingLimitsAdderImpl<S, O extends LimitsOwner<S>, L extends LoadingLimits, A extends LoadingLimitsAdder<L, A>>
         implements LoadingLimitsAdderExt<S, O, L, A> {
-
-    private static final Comparator<Integer> ACCEPTABLE_DURATION_COMPARATOR = (acceptableDuration1, acceptableDuration2) -> acceptableDuration2 - acceptableDuration1;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractLoadingLimitsAdderImpl.class);
 
@@ -73,7 +70,7 @@ public abstract class AbstractLoadingLimitsAdderImpl<S, O extends LimitsOwner<S>
 
     public void addTemporaryLimit(TemporaryLimitAttributes temporaryLimitAttribute) {
         if (temporaryLimits == null) {
-            temporaryLimits = new TreeMap<>(ACCEPTABLE_DURATION_COMPARATOR);
+            temporaryLimits = new TreeMap<>(AbstractLoadingLimits.ACCEPTABLE_DURATION_COMPARATOR);
         }
         temporaryLimits.put(temporaryLimitAttribute.getAcceptableDuration(), temporaryLimitAttribute);
     }

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractLoadingLimitsAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractLoadingLimitsAdderImpl.java
@@ -16,6 +16,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
@@ -25,6 +26,8 @@ import java.util.stream.Collectors;
  */
 public abstract class AbstractLoadingLimitsAdderImpl<S, O extends LimitsOwner<S>, L extends LoadingLimits, A extends LoadingLimitsAdder<L, A>>
         implements LoadingLimitsAdderExt<S, O, L, A> {
+
+    private static final Comparator<Integer> ACCEPTABLE_DURATION_COMPARATOR = (acceptableDuration1, acceptableDuration2) -> acceptableDuration2 - acceptableDuration1;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractLoadingLimitsAdderImpl.class);
 
@@ -70,7 +73,7 @@ public abstract class AbstractLoadingLimitsAdderImpl<S, O extends LimitsOwner<S>
 
     public void addTemporaryLimit(TemporaryLimitAttributes temporaryLimitAttribute) {
         if (temporaryLimits == null) {
-            temporaryLimits = new TreeMap<>(AbstractLoadingLimits.ACCEPTABLE_DURATION_COMPARATOR);
+            temporaryLimits = new TreeMap<>(ACCEPTABLE_DURATION_COMPARATOR);
         }
         temporaryLimits.put(temporaryLimitAttribute.getAcceptableDuration(), temporaryLimitAttribute);
     }

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/LineTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/LineTest.java
@@ -17,7 +17,6 @@ import com.powsybl.network.store.model.ConnectableDirection;
 import com.powsybl.network.store.model.ConnectablePositionAttributes;
 import com.powsybl.network.store.model.LimitsAttributes;
 import com.powsybl.network.store.model.TemporaryLimitAttributes;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Optional;
@@ -82,7 +81,7 @@ public class LineTest extends AbstractLineTest {
 
         temporaryLimits.put(10, TemporaryLimitAttributes.builder().name("TempLimit10").value(8).acceptableDuration(10).fictitious(false).build());
         // check duration sorting order: first entry has the highest duration
-        Assert.assertEquals(10., l1.getNullableCurrentLimits1().getTemporaryLimits().iterator().next().getAcceptableDuration(), 0);
+        assertEquals(10., l1.getNullableCurrentLimits1().getTemporaryLimits().iterator().next().getAcceptableDuration(), 0);
     }
 
     @Override

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/TemporaryLimitAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/TemporaryLimitAttributes.java
@@ -24,7 +24,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @Schema(description = "Temporary limit attributes")
-public class TemporaryLimitAttributes {
+public class TemporaryLimitAttributes implements Comparable<TemporaryLimitAttributes> {
 
     @JsonIgnore
     @Schema(description = "Temporary limit side", required = true)
@@ -45,4 +45,10 @@ public class TemporaryLimitAttributes {
 
     @Schema(description = "Temporary limit is fictitious")
     private boolean fictitious;
+
+    @Override
+    // descending order on acceptableDuration
+    public int compareTo(TemporaryLimitAttributes other) {
+        return other.getAcceptableDuration() - this.getAcceptableDuration();
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
This PR changes how temporary limits are sorted by acceptable durations when we retrieve them from database.


**What is the current behavior?** *(You can also link to an open issue here)*
When we access the temporary limits stored in database, we've got a tree-map that naturally sorts acceptable durations
by ascending order, which is not conform to the interface specification


**What is the new behavior (if this is a feature change)?**
We make sure acceptable durations are sorted by descending order when we retrieve them, which is conform to com.powsybl.iidm.network.LoadingLimits interface


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
