### PR TITLE
update resource and add notification when we remove a property

### DIFF
--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractIdentifiableImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractIdentifiableImpl.java
@@ -264,7 +264,12 @@ public abstract class AbstractIdentifiableImpl<I extends Identifiable<I>, D exte
         Resource<D> r = getResource();
         Map<String, String> properties = r.getAttributes().getProperties();
         if (properties != null) {
-            return properties.remove(key) != null;
+            String oldValue = properties.get(key);
+            if (properties.remove(key) != null) {
+                index.updateResource(resource);
+                index.notifyElementRemoved(this, () -> "properties[" + key + "]", oldValue);
+                return true;
+            }
         }
         return false;
     }

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractIdentifiableImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractIdentifiableImpl.java
@@ -261,15 +261,12 @@ public abstract class AbstractIdentifiableImpl<I extends Identifiable<I>, D exte
 
     @Override
     public boolean removeProperty(String key) {
-        Resource<D> r = getResource();
-        Map<String, String> properties = r.getAttributes().getProperties();
-        if (properties != null) {
+        Map<String, String> properties = getResource().getAttributes().getProperties();
+        if (properties != null && properties.containsKey(key)) {
             String oldValue = properties.get(key);
-            if (properties.remove(key) != null) {
-                index.updateResource(resource);
-                index.notifyElementRemoved(this, () -> "properties[" + key + "]", oldValue);
-                return true;
-            }
+            updateResource(r -> r.getAttributes().getProperties().remove(key));
+            index.notifyElementRemoved(this, () -> "properties[" + key + "]", oldValue);
+            return true;
         }
         return false;
     }

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkObjectIndex.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkObjectIndex.java
@@ -520,6 +520,22 @@ public class NetworkObjectIndex {
         }
     }
 
+    void notifyElementRemoved(Identifiable<?> identifiable, Supplier<String> attribute, Object oldValue) {
+        if (!network.getListeners().isEmpty()) {
+            notifyElementRemoved(identifiable, attribute.get(), oldValue);
+        }
+    }
+
+    void notifyElementRemoved(Identifiable<?> identifiable, String attribute, Object oldValue) {
+        for (NetworkListener listener : network.getListeners()) {
+            try {
+                listener.onElementRemoved(identifiable, attribute, oldValue);
+            } catch (Exception e) {
+                LOGGER.error(e.toString(), e);
+            }
+        }
+    }
+
     // substation
 
     Optional<SubstationImpl> getSubstation(String id) {

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/PropertiesTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/PropertiesTest.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.network.store.iidm.impl;
+
+import com.powsybl.iidm.network.DefaultNetworkListener;
+import com.powsybl.iidm.network.Load;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.NetworkListener;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Set;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author David Braquart <david.braquart at rte-france.com>
+ */
+public class PropertiesTest {
+
+    @Test
+    public void testPropertiesChangesNotification() {
+        NetworkListener mockedListener = Mockito.mock(DefaultNetworkListener.class);
+        Network network = CreateNetworksUtil.createNodeBreakerNetworkWithLine();
+        network.addListener(mockedListener);
+        Load load = network.getLoad("L");
+
+        load.setProperty("k", "v");
+        Mockito.verify(mockedListener, Mockito.times(1)).onElementAdded(load, "properties[k]", "v");
+        load.setProperty("k", "v-update");
+        Mockito.verify(mockedListener, Mockito.times(1)).onElementReplaced(load, "properties[k]", "v", "v-update");
+        load.setProperty("k2", "v2");
+        Mockito.verify(mockedListener, Mockito.times(1)).onElementAdded(load, "properties[k2]", "v2");
+        assertEquals(Set.of("k", "k2"), load.getPropertyNames());
+
+        assertTrue(load.removeProperty("k"));
+        Mockito.verify(mockedListener, Mockito.times(1)).onElementRemoved(load, "properties[k]", "v-update");
+        assertTrue(load.removeProperty("k2"));
+        Mockito.verify(mockedListener, Mockito.times(1)).onElementRemoved(load, "properties[k2]", "v2");
+        assertFalse(load.removeProperty("k"));
+        Mockito.verifyNoMoreInteractions(mockedListener);
+        assertFalse(load.removeProperty("unknown"));
+        Mockito.verifyNoMoreInteractions(mockedListener);
+
+        assertEquals(Set.of(), load.getPropertyNames());
+    }
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
no



**What kind of change does this PR introduce?**
This is bug fix about resource update and notification. When we remove a property from a given Identifiable object, the change is not persistent when we flush the network, and we got no notification (we should create onElementRemoved).



**Does this PR introduce a breaking change or deprecate an API?**
no


**Other information**:
no
