### PR TITLE
Fix duplication when getting network busview connected and synchronous components

### DIFF
--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkImpl.java
@@ -30,6 +30,10 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.util.Comparator.comparingInt;
+import static java.util.stream.Collectors.collectingAndThen;
+import static java.util.stream.Collectors.toCollection;
+
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
@@ -148,13 +152,15 @@ public class NetworkImpl extends AbstractIdentifiableImpl<Network, NetworkAttrib
         }
 
         @Override
-        public Collection<Component> getConnectedComponents() { // FIXME : need a reference bus by component
-            return getBusStream().map(Bus::getConnectedComponent).collect(Collectors.toList());
+        public Collection<Component> getConnectedComponents() {
+            return getBusStream().map(Bus::getConnectedComponent)
+                .collect(collectingAndThen(toCollection(() -> new TreeSet<>(comparingInt(Component::getNum))), ArrayList::new));
         }
 
         @Override
-        public Collection<Component> getSynchronousComponents() { // FIXME : need a reference bus by component
-            return getBusStream().map(Bus::getSynchronousComponent).collect(Collectors.toList());
+        public Collection<Component> getSynchronousComponents() {
+            return getBusStream().map(Bus::getSynchronousComponent)
+                .collect(collectingAndThen(toCollection(() -> new TreeSet<>(comparingInt(Component::getNum))), ArrayList::new));
         }
     }
 

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/NetworkTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/NetworkTest.java
@@ -34,6 +34,7 @@ public class NetworkTest extends AbstractNetworkTest {
         assertEquals(1, Iterables.size(network.getSubstations(Country.FR, "TSO1", "region1")));
 
         assertEquals(1, network.getBusView().getConnectedComponents().size());
+        assertEquals(1, network.getBusView().getSynchronousComponents().size());
         assertNotNull(network.getBusView().getBus("VL1_0"));
         assertNotNull(network.getBusView().getBus("VL2_0"));
     }
@@ -54,6 +55,7 @@ public class NetworkTest extends AbstractNetworkTest {
         assertEquals(1, Iterables.size(network.getSubstations(Country.FR, "TSO2", "region2")));
 
         assertEquals(1, network.getBusView().getConnectedComponents().size());
+        assertEquals(1, network.getBusView().getSynchronousComponents().size());
         assertNotNull(network.getBusView().getBus("VL1_0"));
         assertNotNull(network.getBusView().getBus("VL2_0"));
     }

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/NetworkTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/NetworkTest.java
@@ -33,7 +33,7 @@ public class NetworkTest extends AbstractNetworkTest {
 
         assertEquals(1, Iterables.size(network.getSubstations(Country.FR, "TSO1", "region1")));
 
-        assertEquals(2, network.getBusView().getConnectedComponents().size()); // FIXME : normally should be 1
+        assertEquals(1, network.getBusView().getConnectedComponents().size());
         assertNotNull(network.getBusView().getBus("VL1_0"));
         assertNotNull(network.getBusView().getBus("VL2_0"));
     }
@@ -53,7 +53,7 @@ public class NetworkTest extends AbstractNetworkTest {
         assertEquals(1, Iterables.size(network.getSubstations(Country.FR, "TSO1", "region12")));
         assertEquals(1, Iterables.size(network.getSubstations(Country.FR, "TSO2", "region2")));
 
-        assertEquals(2, network.getBusView().getConnectedComponents().size());  // FIXME : normally should be 1
+        assertEquals(1, network.getBusView().getConnectedComponents().size());
         assertNotNull(network.getBusView().getBus("VL1_0"));
         assertNotNull(network.getBusView().getBus("VL2_0"));
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
getConnectedComponents and getSynchronousComponents method implementations in Network.BusView add the same component multiple times in the returned List.


**What is the new behavior (if this is a feature change)?**
A connected or synchronous component is now returned only once.


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
