### PR TITLE
Fix get feeder position from extension

### DIFF
--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/ConnectablePositionImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/ConnectablePositionImpl.java
@@ -91,8 +91,8 @@ public class ConnectablePositionImpl<C extends Connectable<C>> extends AbstractE
     }
 
     private FeederImpl getFeeder(Function<Connectable<C>, ConnectablePositionAttributes> positionAttributesGetter) {
-        var attributes = positionAttributesGetter.apply(getExtendable());
-        return attributes != null ? new FeederImpl(positionAttributesGetter) : null;
+        return (positionAttributesGetter != null && positionAttributesGetter.apply(getExtendable()) != null) ?
+                new FeederImpl(positionAttributesGetter) : null;
     }
 
     @Override

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/LoadTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/LoadTest.java
@@ -6,8 +6,16 @@
  */
 package com.powsybl.network.store.iidm.impl;
 
+import com.powsybl.iidm.network.Load;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.extensions.ConnectablePosition;
+import com.powsybl.iidm.network.extensions.ConnectablePositionAdder;
 import com.powsybl.iidm.network.tck.AbstractLoadTest;
 import org.junit.Test;
+
+import static com.powsybl.network.store.iidm.impl.CreateNetworksUtil.createNodeBreakerNetworkWithLine;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
@@ -17,5 +25,24 @@ public class LoadTest extends AbstractLoadTest {
     @Test
     public void testSetterGetterInMultiVariants() {
         // FIXME variant difference with core
+    }
+
+    @Test
+    public void testAddConnectablePositionExtension() {
+        Network network = createNodeBreakerNetworkWithLine();
+        Load load = network.getLoad("LD");
+
+        load.newExtension(ConnectablePositionAdder.class)
+                .newFeeder()
+                .withName("cpa")
+                .withOrder(0)
+                .withDirection(ConnectablePosition.Direction.TOP)
+                .add()
+                .add();
+
+        assertEquals("cpa", load.getExtension(ConnectablePosition.class).getFeeder().getName().orElseThrow());
+        assertNull(load.getExtension(ConnectablePosition.class).getFeeder1());
+        assertNull(load.getExtension(ConnectablePosition.class).getFeeder2());
+        assertNull(load.getExtension(ConnectablePosition.class).getFeeder3());
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)



**What kind of change does this PR introduce?**
Bug fix


**What is the current behavior?**
When we try to get feeder1, feeder2, and feeder3 for a load, we get an NullPointerException 


**What is the new behavior (if this is a feature change)?**
When we try to get feeder1, feeder2, and feeder3 for a load, we get null 


