### PR TITLE
Fix node breaker disconnect

### DIFF
--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/NodeBreakerDisconnectionDiamondPathBugTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/NodeBreakerDisconnectionDiamondPathBugTest.java
@@ -18,13 +18,14 @@ import static org.junit.Assert.assertTrue;
 public class NodeBreakerDisconnectionDiamondPathBugTest {
 
     /**
-     *     L
-     *     |
-     *  ---1---
-     *  |     |
-     * BR1   BR2
-     *  |     |
-     *  ---0--- BBS1
+     *     L                         LA
+     *     |                         |
+     *  ---1---                      4
+     *  |     |                      |
+     * BR1   BR2                    BR4
+     *  |     |                      |
+     *  ---0---   -----BR3-----   ---3---
+     *   BBS1                      BBS2
      */
     private Network createNetwork() {
         Network network = Network.create("test", "test");
@@ -40,6 +41,28 @@ public class NodeBreakerDisconnectionDiamondPathBugTest {
         vl.getNodeBreakerView().newBusbarSection()
                 .setId("BBS1")
                 .setNode(0)
+                .add();
+        vl.getNodeBreakerView().newBusbarSection()
+                .setId("BBS2")
+                .setNode(3)
+                .add();
+        vl.getNodeBreakerView().newBreaker()
+                .setId("BR3")
+                .setNode1(0)
+                .setNode2(3)
+                .setOpen(false)
+                .add();
+        vl.getNodeBreakerView().newBreaker()
+                .setId("BR4")
+                .setNode1(3)
+                .setNode2(4)
+                .setOpen(false)
+                .add();
+        vl.newLoad()
+                .setId("LA")
+                .setNode(4)
+                .setP0(1)
+                .setQ0(1)
                 .add();
         vl.newLoad()
                 .setId("L")
@@ -69,13 +92,14 @@ public class NodeBreakerDisconnectionDiamondPathBugTest {
      *     |      |
      *  -------   |
      *  |     |   D1
-     * BR1   D2   |
-     *  |     |   |
-     *  ---1---   |
-     *     |      |
-     *    BR2     |
-     *     |      |
-     *  ---0------- BBS1
+     * BR1   D2   |                      LA
+     *  |     |   |                      |
+     *  ---1---   |                      4
+     *     |      |                      |
+     *    BR2     |                     BR4
+     *     |      |                      |
+     *  ---0-------   -----BR3-----   ---3---
+     *    BBS1                         BBS2
      */
     private Network createNetwork2() {
         Network network = Network.create("test", "test");
@@ -91,6 +115,28 @@ public class NodeBreakerDisconnectionDiamondPathBugTest {
         vl.getNodeBreakerView().newBusbarSection()
                 .setId("BBS1")
                 .setNode(0)
+                .add();
+        vl.getNodeBreakerView().newBusbarSection()
+                .setId("BBS2")
+                .setNode(3)
+                .add();
+        vl.getNodeBreakerView().newBreaker()
+                .setId("BR3")
+                .setNode1(0)
+                .setNode2(3)
+                .setOpen(false)
+                .add();
+        vl.getNodeBreakerView().newBreaker()
+                .setId("BR4")
+                .setNode1(3)
+                .setNode2(4)
+                .setOpen(false)
+                .add();
+        vl.newLoad()
+                .setId("LA")
+                .setNode(4)
+                .setP0(1)
+                .setQ0(1)
                 .add();
         vl.newLoad()
                 .setId("L")
@@ -128,18 +174,26 @@ public class NodeBreakerDisconnectionDiamondPathBugTest {
     @Test
     public void testDisconnect() {
         Network network = createNetwork();
+        Switch s = network.getSwitch("BR3");
+        assertFalse(s.isOpen());
         Load l = network.getLoad("L");
+        assertTrue(l.getTerminal().isConnected());
         assertTrue(l.getTerminal().isConnected());
         assertTrue(l.getTerminal().disconnect());
         assertFalse(l.getTerminal().isConnected());
+        assertFalse(l.getTerminal().isConnected());
+        assertFalse(s.isOpen());
     }
 
     @Test
     public void testDisconnect2() {
         Network network = createNetwork2();
+        Switch s = network.getSwitch("BR3");
+        assertFalse(s.isOpen());
         Load l = network.getLoad("L");
         assertTrue(l.getTerminal().isConnected());
         assertFalse(l.getTerminal().disconnect());
+        assertFalse(s.isOpen());
         assertTrue(l.getTerminal().isConnected()); // because of D1 which is not openable
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
- Disconnect may open non-related breakers
- Disconnect may return true when not disconnected
- Map node to aggregate node is duplicated


**What is the new behavior (if this is a feature change)?**
- Disconnect does not open non-related breakers
- Disconnect does return true only if disconnect successful
- Reusing the node to aggregate node map of ConnectivityInspector


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
No