### PR TITLE
Fix active power control modification, notify when update droop or participate

### DIFF
--- a/network-store-client-distribution/pom.xml
+++ b/network-store-client-distribution/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-network-store-client-parent</artifactId>
-        <version>1.6.0</version>
+        <version>1.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-network-store-client-distribution</artifactId>

--- a/network-store-client-distribution/pom.xml
+++ b/network-store-client-distribution/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-network-store-client-parent</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>1.6.0</version>
     </parent>
 
     <artifactId>powsybl-network-store-client-distribution</artifactId>

--- a/network-store-client/pom.xml
+++ b/network-store-client/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-network-store-client-parent</artifactId>
-        <version>1.6.0</version>
+        <version>1.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-network-store-client</artifactId>

--- a/network-store-client/pom.xml
+++ b/network-store-client/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-network-store-client-parent</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>1.6.0</version>
     </parent>
 
     <artifactId>powsybl-network-store-client</artifactId>

--- a/network-store-iidm-impl/pom.xml
+++ b/network-store-iidm-impl/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <artifactId>powsybl-network-store-client-parent</artifactId>
         <groupId>com.powsybl</groupId>
-        <version>1.6.0</version>
+        <version>1.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-network-store-iidm-impl</artifactId>

--- a/network-store-iidm-impl/pom.xml
+++ b/network-store-iidm-impl/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <artifactId>powsybl-network-store-client-parent</artifactId>
         <groupId>com.powsybl</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>1.6.0</version>
     </parent>
 
     <artifactId>powsybl-network-store-iidm-impl</artifactId>

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkObjectIndex.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkObjectIndex.java
@@ -485,7 +485,7 @@ public class NetworkObjectIndex {
         }
     }
 
-    void notifyUpdate(Identifiable<?> identifiable, String attribute, String variantId, Object oldValue, Object newValue) {
+    public void notifyUpdate(Identifiable<?> identifiable, String attribute, String variantId, Object oldValue, Object newValue) {
         if (!Objects.equals(oldValue, newValue)) {
             for (NetworkListener listener : network.getListeners()) {
                 try {

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/extensions/ActivePowerControlImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/extensions/ActivePowerControlImpl.java
@@ -27,7 +27,12 @@ public class ActivePowerControlImpl<I extends Injection<I>> extends AbstractExte
 
     @Override
     public void setParticipate(boolean participate) {
-        getInjection().updateResource(res -> res.getAttributes().getActivePowerControl().setParticipate(participate));
+        boolean oldValue = getInjection().getResource().getAttributes().getActivePowerControl().isParticipate();
+        if (oldValue != participate) {
+            getInjection().updateResource(res -> res.getAttributes().getActivePowerControl().setParticipate(participate));
+            String variantId = getInjection().getNetwork().getVariantManager().getWorkingVariantId();
+            getInjection().getNetwork().getIndex().notifyUpdate(getInjection(), "participate", variantId, oldValue, participate);
+        }
     }
 
     @Override
@@ -37,7 +42,12 @@ public class ActivePowerControlImpl<I extends Injection<I>> extends AbstractExte
 
     @Override
     public void setDroop(double droop) {
-        getInjection().updateResource(res -> res.getAttributes().getActivePowerControl().setDroop(droop));
+        double oldValue = getInjection().getResource().getAttributes().getActivePowerControl().getDroop();
+        if (oldValue != droop) {
+            getInjection().updateResource(res -> res.getAttributes().getActivePowerControl().setDroop(droop));
+            String variantId = getInjection().getNetwork().getVariantManager().getWorkingVariantId();
+            getInjection().getNetwork().getIndex().notifyUpdate(getInjection(), "droop", variantId, oldValue, droop);
+        }
     }
 
     @Override

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/ActivePowerControlExtensionTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/ActivePowerControlExtensionTest.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.network.store.iidm.impl;
+
+import com.powsybl.iidm.network.*;
+import com.powsybl.iidm.network.extensions.ActivePowerControl;
+import com.powsybl.iidm.network.extensions.ActivePowerControlAdder;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class ActivePowerControlExtensionTest {
+
+    private class DummyNetworkListener implements NetworkListener {
+
+        private int nbUpdatedEquipments = 0;
+
+        @Override
+        public void onCreation(Identifiable identifiable) {
+            // Not tested here
+        }
+
+        @Override
+        public void beforeRemoval(Identifiable identifiable) {
+            // Not tested here
+        }
+
+        @Override
+        public void afterRemoval(String id) {
+            // Not tested here
+        }
+
+        @Override
+        public void onUpdate(Identifiable identifiable, String s, Object o, Object o1) {
+            nbUpdatedEquipments++;
+        }
+
+        public void onUpdate(Identifiable identifiable, String attribute, String variantId, Object oldValue,
+                             Object newValue) {
+            nbUpdatedEquipments++;
+        }
+
+        @Override
+        public void onVariantCreated(String sourceVariantId, String targetVariantId) {
+            // Not tested here
+        }
+
+        @Override
+        public void onVariantRemoved(String variantId) {
+            // Not tested here
+        }
+        public int getNbUpdatedEquipments() {
+            return nbUpdatedEquipments;
+        }
+    }
+
+    @Test
+    public void testBatteryActivePowerControlExtension() {
+        Network network = CreateNetworksUtil.createNodeBreakerNetwokWithMultipleEquipments();
+
+        // add dummy listener to check notification
+        DummyNetworkListener listener = new DummyNetworkListener();
+        network.addListener(listener);
+
+        Battery battery = network.getBattery("battery");
+        assertNotNull(battery);
+
+        assertNull(battery.getExtension(ActivePowerControl.class));
+        assertEquals(0, battery.getExtensions().size());
+
+        battery.newExtension(ActivePowerControlAdder.class)
+                .withParticipate(true)
+                .withDroop(0.1)
+                .add();
+
+        ActivePowerControl apc = battery.getExtension(ActivePowerControl.class);
+        assertNotNull(apc);
+        assertEquals(1, battery.getExtensions().size());
+        assertEquals(true, apc.isParticipate());
+        assertEquals(0.1, apc.getDroop(), 0.0);
+
+        // test update of droop and check notification
+        BatteryImpl batteryImpl = (BatteryImpl) battery;
+        List<NetworkListener> listeners = batteryImpl.getNetwork().getListeners();
+        assertEquals(1, listeners.size());
+        assertEquals(0, listener.getNbUpdatedEquipments());
+
+        apc.setDroop(0.2);
+        assertEquals(0.2, apc.getDroop(), 0.0);
+        assertEquals(1, listener.getNbUpdatedEquipments());
+
+        // test update of participate and check notification
+        apc.setParticipate(false);
+        assertEquals(false, apc.isParticipate());
+        assertEquals(2, listener.getNbUpdatedEquipments());
+    }
+}

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/ActivePowerControlExtensionTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/ActivePowerControlExtensionTest.java
@@ -55,6 +55,7 @@ public class ActivePowerControlExtensionTest {
         public void onVariantRemoved(String variantId) {
             // Not tested here
         }
+
         public int getNbUpdatedEquipments() {
             return nbUpdatedEquipments;
         }

--- a/network-store-model/pom.xml
+++ b/network-store-model/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-network-store-client-parent</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>1.6.0</version>
     </parent>
 
     <artifactId>powsybl-network-store-model</artifactId>

--- a/network-store-model/pom.xml
+++ b/network-store-model/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-network-store-client-parent</artifactId>
-        <version>1.6.0</version>
+        <version>1.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>powsybl-network-store-model</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     </parent>
 
     <artifactId>powsybl-network-store-client-parent</artifactId>
-    <version>1.6.0</version>
+    <version>1.7.0-SNAPSHOT</version>
 
     <packaging>pom</packaging>
     <name>Network store client parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -49,8 +49,8 @@
     <properties>
         <springboot.version>3.1.2</springboot.version>
         <commons-lang3.version>3.9</commons-lang3.version>
-        <powsybl-dependencies.version>2023.3.1</powsybl-dependencies.version>
-        <powsybl-ws-commons.version>1.6.0</powsybl-ws-commons.version>
+        <powsybl-dependencies.version>2023.3.2</powsybl-dependencies.version>
+        <powsybl-ws-commons.version>1.7.0</powsybl-ws-commons.version>
         <slf4j.version>2.0.4</slf4j.version>
         <logback.version>1.4.5</logback.version>
         <sonar.coverage.jacoco.xmlReportPaths>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     </parent>
 
     <artifactId>powsybl-network-store-client-parent</artifactId>
-    <version>1.6.0-SNAPSHOT</version>
+    <version>1.6.0</version>
 
     <packaging>pom</packaging>
     <name>Network store client parent</name>


### PR DESCRIPTION
Fix active poswer control modification, notify when update droop or participate.

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->



**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
