### PR TITLE
Fix Identifiable.getProperty with default value

### DIFF
--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractIdentifiableImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractIdentifiableImpl.java
@@ -220,7 +220,7 @@ public abstract class AbstractIdentifiableImpl<I extends Identifiable<I>, D exte
 
     public String getProperty(String key, String defaultValue) {
         Map<String, String> properties = getResource().getAttributes().getProperties();
-        return properties != null ? properties.getOrDefault(key, defaultValue) : null;
+        return properties != null ? properties.getOrDefault(key, defaultValue) : defaultValue;
     }
 
     public Set<String> getPropertyNames() {

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/AbstractIdentifiableImplTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/AbstractIdentifiableImplTest.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.network.store.iidm.impl;
+
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+class AbstractIdentifiableImplTest {
+
+    @Test
+    void test() {
+        Network network = EurostagTutorialExample1Factory.create();
+        var gen = network.getGenerator("GEN");
+        assertEquals("def", gen.getProperty("foo", "def"));
+    }
+}

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/IdentifiableImplTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/IdentifiableImplTest.java
@@ -22,5 +22,7 @@ class IdentifiableImplTest {
         Network network = EurostagTutorialExample1Factory.create();
         var gen = network.getGenerator("GEN");
         assertEquals("def", gen.getProperty("foo", "def"));
+        gen.setProperty("bar", "aaa");
+        assertEquals("def", gen.getProperty("foo", "def")); // properties now exists but there is still no value for foo
     }
 }

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/IdentifiableImplTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/IdentifiableImplTest.java
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
-class AbstractIdentifiableImplTest {
+class IdentifiableImplTest {
 
     @Test
     void test() {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
`Identifiable.getProperty` when a default value is given is not working as expecting.


**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
