### PR TITLE
Fix busbar section get p and get q

### DIFF
--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/BusbarSectionToInjectionAdapter.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/BusbarSectionToInjectionAdapter.java
@@ -104,7 +104,7 @@ public class BusbarSectionToInjectionAdapter implements InjectionAttributes {
 
     @Override
     public double getP() {
-        throw new AssertionError();
+        return 0;
     }
 
     @Override
@@ -114,7 +114,7 @@ public class BusbarSectionToInjectionAdapter implements InjectionAttributes {
 
     @Override
     public double getQ() {
-        throw new AssertionError();
+        return 0;
     }
 
     @Override

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/TerminalImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/TerminalImpl.java
@@ -112,7 +112,7 @@ public class TerminalImpl<U extends IdentifiableAttributes> implements Terminal,
     @Override
     public Terminal setP(double p) {
         if (connectable.getType() == IdentifiableType.BUSBAR_SECTION) {
-            throw new ValidationException(this, "cannot set active power on a busbar section");
+            throw new ValidationException(this, " cannot set active power on a busbar section");
         }
         getAbstractIdentifiable().updateResource(r -> getAttributes().setP(p), AttributeFilter.SV);
         return this;
@@ -126,7 +126,7 @@ public class TerminalImpl<U extends IdentifiableAttributes> implements Terminal,
     @Override
     public Terminal setQ(double q) {
         if (connectable.getType() == IdentifiableType.BUSBAR_SECTION) {
-            throw new ValidationException(this, "cannot set reactive power on a busbar section");
+            throw new ValidationException(this, " cannot set reactive power on a busbar section");
         }
         getAbstractIdentifiable().updateResource(r -> getAttributes().setQ(q), AttributeFilter.SV);
         return this;

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/BusbarSectionGetPqTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/BusbarSectionGetPqTest.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.network.store.iidm.impl;
+
+import com.powsybl.commons.PowsyblException;
+import com.powsybl.iidm.network.BusbarSection;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.Terminal;
+import com.powsybl.iidm.network.test.FourSubstationsNodeBreakerFactory;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+class BusbarSectionGetPqTest {
+
+    @Test
+    void test() {
+        Network network = FourSubstationsNodeBreakerFactory.create();
+        BusbarSection bbs = network.getBusbarSection("S1VL1_BBS");
+        Terminal terminal = bbs.getTerminal();
+        assertEquals(0, terminal.getP());
+        assertEquals(0, terminal.getQ());
+        PowsyblException e = assertThrows(PowsyblException.class, () -> terminal.setP(1));
+        assertEquals("Terminal of connectable : S1VL1_BBS cannot set active power on a busbar section", e.getMessage());
+        e = assertThrows(PowsyblException.class, () -> terminal.setQ(1));
+        assertEquals("Terminal of connectable : S1VL1_BBS cannot set reactive power on a busbar section", e.getMessage());
+    }
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
busbar section get p and get q throw an exception


**What is the new behavior (if this is a feature change)?**
busbar section get p and get q return a 0 as in core implementation


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
