### PR TITLE
Fix traverseFromTerminal when terminalNode2 already in traversedTerminals

### DIFF
--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NodeBreakerViewImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NodeBreakerViewImpl.java
@@ -258,20 +258,7 @@ public class NodeBreakerViewImpl implements VoltageLevel.NodeBreakerView {
                 }
             }
 
-            Terminal terminalNode2 = getTerminal(node2);
-            if (terminalNode2 != null) {
-                if (traversedTerminals.contains(terminalNode2)) {
-                    return TraverseResult.TERMINATE_PATH;
-                }
-                traversedTerminals.add(terminalNode2);
-                TraverseResult result = traverser.traverse(terminalNode2, true);
-                if (result != TraverseResult.CONTINUE) {
-                    return result;
-                }
-                nexTerminals.addAll(((TerminalImpl<?>) terminalNode2).getOtherSideTerminals());
-            }
-
-            return TraverseResult.CONTINUE;
+            return traverseTerminal(getTerminal(node2), traverser, traversedTerminals, nexTerminals);
         })) {
             return false;
         }
@@ -283,6 +270,22 @@ public class NodeBreakerViewImpl implements VoltageLevel.NodeBreakerView {
         }
 
         return true;
+    }
+
+    private TraverseResult traverseTerminal(Terminal terminal, Terminal.TopologyTraverser traverser, Set<Terminal> traversedTerminals, List<Terminal> nexTerminals) {
+        if (terminal != null) {
+            if (traversedTerminals.contains(terminal)) {
+                return TraverseResult.TERMINATE_PATH;
+            }
+            traversedTerminals.add(terminal);
+            TraverseResult result = traverser.traverse(terminal, true);
+            if (result != TraverseResult.CONTINUE) {
+                return result;
+            }
+            nexTerminals.addAll(((TerminalImpl<?>) terminal).getOtherSideTerminals());
+        }
+
+        return TraverseResult.CONTINUE;
     }
 
     @Override

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NodeBreakerViewImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NodeBreakerViewImpl.java
@@ -259,7 +259,10 @@ public class NodeBreakerViewImpl implements VoltageLevel.NodeBreakerView {
             }
 
             Terminal terminalNode2 = getTerminal(node2);
-            if (terminalNode2 != null && !traversedTerminals.contains(terminalNode2)) {
+            if (terminalNode2 != null) {
+                if (traversedTerminals.contains(terminalNode2)) {
+                    return TraverseResult.TERMINATE_PATH;
+                }
                 traversedTerminals.add(terminalNode2);
                 TraverseResult result = traverser.traverse(terminalNode2, true);
                 if (result != TraverseResult.CONTINUE) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No


**What kind of change does this PR introduce?**
Bug fix


**What is the current behavior?**
When traversing a graph, the algorithm look at what is on the other side of switches. If there is a terminal and if it is not already in the set of traversed terminals, it is added to it and then it is "traversed" to see if the algorithm has to continue to traverse behind the terminal.
If there is no terminal on the other side of the switch or if the terminal is already in the set, the algorithm continue to traverse behind the node on the other side of the switch (be there a terminal or not).

The problem is that since #363, the edges of the graph are doubled (in order to have the two directions available). This causes the algorithm to go twice on each terminal, which means always traversing the terminals and the graph behind.

**What is the new behavior (if this is a feature change)?**
In the method `traverseFromTerminal`, if there is a terminal, the algorithm will check if the terminal is already in the set. If it is in the set, it will return a `TraverseResult.TERMINATE_PATH` instead of the `TraverseResult.CONTINUE` so that it does not traverse a terminal that has already been traversed.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
