### PR TITLE
Strict type check in getExtension

### DIFF
--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractIdentifiableImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractIdentifiableImpl.java
@@ -293,11 +293,21 @@ public abstract class AbstractIdentifiableImpl<I extends Identifiable<I>, D exte
     }
 
     public <E extends Extension<I>> E getExtension(Class<? super E> type) {
-        return resource.getAttributes().getExtensionAttributes().keySet().stream()
+        List<E> matchingExtensions = resource.getAttributes().getExtensionAttributes().keySet().stream()
                 .map(ExtensionLoaders::findLoader)
-                .filter(loader -> type.isAssignableFrom(loader.getType()))
+                .filter(loader -> type == loader.getType())
                 .map(loader -> (E) loader.load(this))
-                .findFirst().orElse(null);
+                .collect(Collectors.toList());
+
+        if (matchingExtensions.isEmpty()) {
+            return null;
+        }
+
+        if (matchingExtensions.size() > 1) {
+            throw new PowsyblException("More than one extension found for type: " + type.getSimpleName());
+        }
+
+        return matchingExtensions.get(0);
     }
 
     public <E extends Extension<I>> E getExtensionByName(String name) {

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/ActivePowerControlExtensionTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/ActivePowerControlExtensionTest.java
@@ -7,7 +7,10 @@
 package com.powsybl.network.store.iidm.impl;
 
 import com.powsybl.commons.extensions.Extension;
-import com.powsybl.iidm.network.*;
+import com.powsybl.iidm.network.Battery;
+import com.powsybl.iidm.network.Identifiable;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.NetworkListener;
 import com.powsybl.iidm.network.extensions.ActivePowerControl;
 import com.powsybl.iidm.network.extensions.ActivePowerControlAdder;
 import org.junit.Test;
@@ -131,5 +134,26 @@ public class ActivePowerControlExtensionTest {
         assertEquals(2, listener.getNbUpdatedEquipments());
         apc.setParticipate(false);
         assertEquals(2, listener.getNbUpdatedEquipments());
+    }
+
+    @Test
+    public void testActivePowerControlGetExtension() {
+        Network network = CreateNetworksUtil.createNodeBreakerNetwokWithMultipleEquipments();
+
+        Battery battery = network.getBattery("battery");
+        assertNotNull(battery);
+
+        assertNull(battery.getExtension(Object.class));
+        assertNull(battery.getExtensionByName(""));
+        assertEquals(0, battery.getExtensions().size());
+
+        battery.newExtension(ActivePowerControlAdder.class)
+                .withParticipate(true)
+                .withDroop(0.1)
+                .add();
+
+        assertNull(battery.getExtension(Object.class));
+        assertNull(battery.getExtensionByName(""));
+        assertEquals(1, battery.getExtensions().size());
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)

**What is the current behavior?**
When using `identifiable.getExtension(Object.class)`, it matches all the extensions associated to the identifiable while we expect that it returns null. 

**What is the new behavior (if this is a feature change)?**
We need to change to strict type checking as it was done before implementing generalized extensions (see for example https://github.com/powsybl/powsybl-network-store/blob/0440f0d8aa40306b7cd559f889f2146ed70f1439/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/GeneratorImpl.java#L289)
 `identifiable.getExtension(Object.class)` should return null and it should find an extension only if the exact extension class is given as parameter.
