### PR TITLE
Fix casting pb with injection observability extension on BusbarSection.

### DIFF
--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/extensions/InjectionObservabilityAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/extensions/InjectionObservabilityAdderImpl.java
@@ -11,7 +11,7 @@ import com.powsybl.commons.extensions.AbstractExtensionAdder;
 import com.powsybl.iidm.network.Injection;
 import com.powsybl.iidm.network.extensions.InjectionObservability;
 import com.powsybl.iidm.network.extensions.InjectionObservabilityAdder;
-import com.powsybl.network.store.iidm.impl.AbstractInjectionImpl;
+import com.powsybl.network.store.iidm.impl.AbstractIdentifiableImpl;
 import com.powsybl.network.store.model.InjectionObservabilityAttributes;
 import com.powsybl.network.store.model.ObservabilityQualityAttributes;
 
@@ -57,7 +57,7 @@ public class InjectionObservabilityAdderImpl<I extends Injection<I>>
                 .redundant(redundantV)
                 .build() : null)
             .build();
-        ((AbstractInjectionImpl<?, ?>) extendable).updateResource(res -> res.getAttributes().getExtensionAttributes().put(InjectionObservability.NAME, attributes));
+        ((AbstractIdentifiableImpl<?, ?>) extendable).updateResource(res -> res.getAttributes().getExtensionAttributes().put(InjectionObservability.NAME, attributes));
         return new InjectionObservabilityImpl<>(injection);
     }
 

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/extensions/InjectionObservabilityImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/extensions/InjectionObservabilityImpl.java
@@ -11,7 +11,7 @@ import com.powsybl.commons.extensions.AbstractExtension;
 import com.powsybl.iidm.network.Injection;
 import com.powsybl.iidm.network.extensions.InjectionObservability;
 import com.powsybl.iidm.network.extensions.ObservabilityQuality;
-import com.powsybl.network.store.iidm.impl.AbstractInjectionImpl;
+import com.powsybl.network.store.iidm.impl.AbstractIdentifiableImpl;
 import com.powsybl.network.store.model.InjectionObservabilityAttributes;
 import com.powsybl.network.store.model.ObservabilityQualityAttributes;
 import lombok.NonNull;
@@ -28,8 +28,8 @@ public class InjectionObservabilityImpl<I extends Injection<I>> extends Abstract
         super(injection);
     }
 
-    private AbstractInjectionImpl<?, ?> getInjection() {
-        return (AbstractInjectionImpl<?, ?>) getExtendable();
+    private AbstractIdentifiableImpl<?, ?> getInjection() {
+        return (AbstractIdentifiableImpl<?, ?>) getExtendable();
     }
 
     private InjectionObservabilityAttributes getInjectionObservabilityAttributes() {

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/tck/extensions/InjectionObservabilityTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/tck/extensions/InjectionObservabilityTest.java
@@ -1,15 +1,79 @@
 /**
- * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * Copyright (c) 2024, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 package com.powsybl.network.store.iidm.impl.tck.extensions;
 
+import com.powsybl.iidm.network.BusbarSection;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.extensions.InjectionObservability;
+import com.powsybl.iidm.network.extensions.InjectionObservabilityAdder;
 import com.powsybl.iidm.network.tck.extensions.AbstractInjectionObservabilityTest;
+import com.powsybl.iidm.network.test.FourSubstationsNodeBreakerFactory;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public class InjectionObservabilityTest extends AbstractInjectionObservabilityTest {
+    // TODO : add this test method later in AbstractInjectionObservabilityTest
+    @Test
+    public void testOnBusbarSections() {
+        Network network = FourSubstationsNodeBreakerFactory.create();
+        BusbarSection bbs = network.getBusbarSection("S1VL1_BBS");
+        assertNotNull(bbs);
+        bbs.newExtension(InjectionObservabilityAdder.class)
+            .withObservable(true)
+            .withStandardDeviationP(0.02d)
+            .withRedundantP(true)
+            .withStandardDeviationQ(0.5d)
+            .withRedundantQ(true)
+            .withStandardDeviationV(0.0d)
+            .withRedundantV(true)
+            .add();
+        InjectionObservability<BusbarSection> injectionObservability = bbs.getExtension(InjectionObservability.class);
+        assertEquals("injectionObservability", injectionObservability.getName());
+        assertEquals("S1VL1_BBS", injectionObservability.getExtendable().getId());
+
+        assertTrue(injectionObservability.isObservable());
+        injectionObservability.setObservable(false);
+        assertFalse(injectionObservability.isObservable());
+
+        assertEquals(0.02d, injectionObservability.getQualityP().getStandardDeviation(), 0d);
+        injectionObservability.getQualityP().setStandardDeviation(0.03d);
+        assertEquals(0.03d, injectionObservability.getQualityP().getStandardDeviation(), 0d);
+
+        assertTrue(injectionObservability.getQualityP().isRedundant().isPresent());
+        assertTrue(injectionObservability.getQualityP().isRedundant().get());
+        injectionObservability.getQualityP().setRedundant(false);
+        assertTrue(injectionObservability.getQualityP().isRedundant().isPresent());
+        assertFalse(injectionObservability.getQualityP().isRedundant().get());
+
+        assertEquals(0.5d, injectionObservability.getQualityQ().getStandardDeviation(), 0d);
+        injectionObservability.getQualityQ().setStandardDeviation(0.6d);
+        assertEquals(0.6d, injectionObservability.getQualityQ().getStandardDeviation(), 0d);
+
+        assertTrue(injectionObservability.getQualityQ().isRedundant().isPresent());
+        assertTrue(injectionObservability.getQualityQ().isRedundant().get());
+        injectionObservability.getQualityQ().setRedundant(false);
+        assertTrue(injectionObservability.getQualityQ().isRedundant().isPresent());
+        assertFalse(injectionObservability.getQualityQ().isRedundant().get());
+
+        assertEquals(0.0d, injectionObservability.getQualityV().getStandardDeviation(), 0d);
+        injectionObservability.getQualityV().setStandardDeviation(0.01d);
+        assertEquals(0.01d, injectionObservability.getQualityV().getStandardDeviation(), 0d);
+
+        assertTrue(injectionObservability.getQualityV().isRedundant().isPresent());
+        assertTrue(injectionObservability.getQualityV().isRedundant().get());
+        injectionObservability.getQualityV().setRedundant(false);
+        assertTrue(injectionObservability.getQualityV().isRedundant().isPresent());
+        assertFalse(injectionObservability.getQualityV().isRedundant().get());
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
An InjectionObservability extension cannot be added to a busbar section.


**What is the new behavior (if this is a feature change)?**
An InjectionObservability extension can now be added to a busbar section.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
