### PR TITLE
Fix getOperationalLimitsGroups1

### DIFF
--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractBranchImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractBranchImpl.java
@@ -333,7 +333,7 @@ public abstract class AbstractBranchImpl<T extends Branch<T> & Connectable<T>, U
     @Override
     public Collection<OperationalLimitsGroup> getOperationalLimitsGroups1() {
         return getResource().getAttributes().getOperationalLimitsGroups1().values().stream()
-                .map(group -> new OperationalLimitsGroupImpl<>(this, TwoSides.TWO, group))
+                .map(group -> new OperationalLimitsGroupImpl<>(this, TwoSides.ONE, group))
                 .collect(Collectors.toList());
     }
 

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/OperationalLimitsTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/OperationalLimitsTest.java
@@ -9,6 +9,8 @@ package com.powsybl.network.store.iidm.impl;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Optional;
+
+import com.powsybl.iidm.network.TwoSides;
 import org.junit.jupiter.api.Test;
 
 import com.powsybl.iidm.network.Network;
@@ -37,6 +39,8 @@ class OperationalLimitsTest {
         l1.newOperationalLimitsGroup1("group1");
         l1.setSelectedOperationalLimitsGroup1("group");
         assertEquals("group", l1.getSelectedOperationalLimitsGroupId1().get());
+        OperationalLimitsGroup olg = l1.getOperationalLimitsGroups1().stream().findFirst().get();
+        assertEquals(TwoSides.ONE, ((OperationalLimitsGroupImpl) olg).side);
         l1.cancelSelectedOperationalLimitsGroup1();
         assertEquals(Optional.empty(), l1.getSelectedOperationalLimitsGroupId1());
         l1.setSelectedOperationalLimitsGroup1("group1");


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)


**What kind of change does this PR introduce?**
Bug fix


**What is the current behavior?**
getOperationalLimitsGroups1() returns operational limits of side TWO.


**What is the new behavior (if this is a feature change)?**
getOperationalLimitsGroups1() returns operational limits of side ONE.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

