### PR TITLE
add regulating terminal to converter station

### DIFF
--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/VscConverterStationImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/VscConverterStationImpl.java
@@ -154,4 +154,21 @@ public class VscConverterStationImpl extends AbstractHvdcConverterStationImpl<Vs
         index.removeVscConverterStation(resource.getId());
         index.notifyAfterRemoval(resource.getId());
     }
+
+    @Override
+    public Terminal getRegulatingTerminal() {
+        var resource = getResource();
+        TerminalRefAttributes terminalRefAttributes = resource.getAttributes().getRegulatingTerminal();
+        Terminal regulatingTerminal = TerminalRefUtils.getTerminal(index, terminalRefAttributes);
+        return regulatingTerminal != null ? regulatingTerminal : terminal;
+    }
+
+    @Override
+    public VscConverterStation setRegulatingTerminal(Terminal regulatingTerminal) {
+        ValidationUtil.checkRegulatingTerminal(this, regulatingTerminal, getNetwork());
+        TerminalRefAttributes oldValue = getResource().getAttributes().getRegulatingTerminal();
+        updateResource(res -> res.getAttributes().setRegulatingTerminal(TerminalRefUtils.getTerminalRefAttributes(regulatingTerminal)));
+        index.notifyUpdate(this, "regulatingTerminal", oldValue, TerminalRefUtils.getTerminalRefAttributes(regulatingTerminal));
+        return this;
+    }
 }

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/tck/VscTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/tck/VscTest.java
@@ -12,13 +12,4 @@ import com.powsybl.iidm.network.tck.AbstractVscTest;
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public class VscTest extends AbstractVscTest {
-    @Override
-    public void testRegulatingTerminal() {
-        // FIXME implement VscConverterStation.setRegulatingTerminal
-    }
-
-    @Override
-    public void testVscConverterStationAdder() {
-        // FIXME implement VscConverterStation.setRegulatingTerminal
-    }
 }

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/VscConverterStationAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/VscConverterStationAttributes.java
@@ -59,4 +59,7 @@ public class VscConverterStationAttributes extends AbstractIdentifiableAttribute
 
     @Schema(description = "Connectable position (for substation diagram)")
     private ConnectablePositionAttributes position;
+
+    @Schema(description = "Regulating terminal")
+    private TerminalRefAttributes regulatingTerminal;
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**

2 TCK tests are KO (commented) because VscConverterStation.setRegulatingTerminal is not implemented. This PR adds persistent implementation for getRegulatingTerminal/setRegulatingTerminal in VscConverterStation.



**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
