### PR TITLE
Synchronize V Value Between CalculatedBus and ConfiguredBus

### DIFF
--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/CalculatedBus.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/CalculatedBus.java
@@ -636,4 +636,8 @@ public final class CalculatedBus implements BaseBus {
         ExtensionAdderProvider provider = ExtensionAdderProviders.findCachedProvider(getImplementationName(), type);
         return (B) provider.newAdder(this);
     }
+
+    public int getCalculatedBusNum() {
+        return calculatedBusNum;
+    }
 }

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/ConfiguredBusImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/ConfiguredBusImpl.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.*;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 /**
@@ -166,8 +167,15 @@ public class ConfiguredBusImpl extends AbstractIdentifiableImpl<Bus, ConfiguredB
                         .getCalculatedBusesForBusView();
 
                 if (CollectionUtils.isNotEmpty(calculatedBusAttributesList)) {
-                    updater.accept(newValue, calculatedBusAttributesList);
-                    index.updateVoltageLevelResource(voltageLevel.getResource(), AttributeFilter.SV);
+                    List<Integer> calculatedBusesNum = getAllTerminals().stream().map(t -> ((CalculatedBus) t.getBusView().getBus()).getCalculatedBusNum()).distinct().toList();
+                    List<CalculatedBusAttributes> busesToUpdateList = IntStream.range(0, calculatedBusAttributesList.size())
+                        .filter(calculatedBusesNum::contains)
+                        .mapToObj(calculatedBusAttributesList::get)
+                        .toList();
+                    if (CollectionUtils.isNotEmpty(busesToUpdateList)) {
+                        updater.accept(newValue, busesToUpdateList);
+                        index.updateVoltageLevelResource(voltageLevel.getResource(), AttributeFilter.SV);
+                    }
                 }
             }
         });

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/ConfiguredBusImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/ConfiguredBusImpl.java
@@ -62,9 +62,9 @@ public class ConfiguredBusImpl extends AbstractIdentifiableImpl<Bus, ConfiguredB
         return getBusAttribute(this::getConfiguredBusAngle, this::getCalculatedBusAngle);
     }
 
-    private double getBusAttribute(Supplier<Double> configuredBusGetter, Supplier<Optional<Double>> calculatedBusGetter) {
+    private double getBusAttribute(DoubleSupplier configuredBusGetter, Supplier<Optional<Double>> calculatedBusGetter) {
         // Attempt to get the attribute from configuredBus
-        Double configuredValue = configuredBusGetter.get();
+        Double configuredValue = configuredBusGetter.getAsDouble();
         if (!Double.isNaN(configuredValue)) {
             return configuredValue;
         }
@@ -149,7 +149,7 @@ public class ConfiguredBusImpl extends AbstractIdentifiableImpl<Bus, ConfiguredB
         }
     }
 
-    private void updateAttribute(double newValue, double oldValue, String attributeName, Consumer<Double> setter) {
+    private void updateAttribute(double newValue, double oldValue, String attributeName, DoubleConsumer setter) {
         updateResource(res -> setter.accept(newValue));
         String variantId = index.getNetwork().getVariantManager().getWorkingVariantId();
         index.notifyUpdate(this, attributeName, variantId, oldValue, newValue);

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/LineTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/LineTest.java
@@ -13,14 +13,11 @@ import com.powsybl.commons.PowsyblException;
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.extensions.ConnectablePosition;
 import com.powsybl.iidm.network.extensions.ConnectablePositionAdder;
-import com.powsybl.network.store.model.LimitsAttributes;
-import com.powsybl.network.store.model.TemporaryLimitAttributes;
 
 import org.junit.Test;
 
 import java.util.List;
 import java.util.Properties;
-import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.*;
@@ -33,49 +30,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @author Etienne Homer <etienne.homer at rte-france.com>
  */
 public class LineTest {
-
-    //TODO: there is a similar test in the TCK tests. A CurrentLimitsTest extends AbstractCurrentLimitsTest should be created and this test can be deleted.
-    @Test
-    public void isOverloadedTest() {
-        Network network = CreateNetworksUtil.createNodeBreakerNetworkWithLine();
-        LineImpl l1 = (LineImpl) network.getLine("L1");
-        l1.getTerminal1().setP(10);
-        l1.getTerminal1().setQ(0);
-        l1.getTerminal1().getBusView().getBus().setV(400.0);
-        assertFalse(l1.isOverloaded());
-
-        l1.getTerminal1().setP(400);
-        l1.setCurrentLimits(TwoSides.ONE, new LimitsAttributes("DEFAULT", 40, null), "DEFAULT");
-        assertTrue(l1.getNullableCurrentLimits1().getTemporaryLimits().isEmpty());
-        assertTrue(l1.isOverloaded());
-
-        TreeMap<Integer, TemporaryLimitAttributes> temporaryLimits = new TreeMap<>();
-        temporaryLimits.put(5, TemporaryLimitAttributes.builder().name("TempLimit5").value(1000).acceptableDuration(5).fictitious(false).build());
-        l1.setCurrentLimits(TwoSides.ONE, new LimitsAttributes("DEFAULT", 40, temporaryLimits), "DEFAULT");
-        l1.setCurrentLimits(TwoSides.TWO, new LimitsAttributes("DEFAULT", 40, temporaryLimits), "DEFAULT");
-        assertEquals(5, l1.getOverloadDuration());
-
-        assertTrue(l1.checkPermanentLimit(TwoSides.ONE, LimitType.CURRENT));
-        assertTrue(l1.checkPermanentLimit1(LimitType.CURRENT));
-        assertFalse(l1.checkPermanentLimit(TwoSides.TWO, LimitType.CURRENT));
-        assertFalse(l1.checkPermanentLimit2(LimitType.CURRENT));
-        assertFalse(l1.checkPermanentLimit(TwoSides.ONE, LimitType.APPARENT_POWER));
-        assertFalse(l1.checkPermanentLimit(TwoSides.TWO, LimitType.ACTIVE_POWER));
-        assertThrows(UnsupportedOperationException.class, () -> l1.checkPermanentLimit(TwoSides.TWO, LimitType.VOLTAGE));
-
-        Overload overload = l1.checkTemporaryLimits(TwoSides.ONE, LimitType.CURRENT);
-        assertEquals("TempLimit5", overload.getTemporaryLimit().getName());
-        assertEquals(40.0, overload.getPreviousLimit(), 0);
-        assertEquals(5, overload.getTemporaryLimit().getAcceptableDuration());
-        assertNull(l1.checkTemporaryLimits(TwoSides.TWO, LimitType.CURRENT));
-
-        temporaryLimits.put(5, TemporaryLimitAttributes.builder().name("TempLimit5").value(20).acceptableDuration(5).fictitious(false).build());
-        assertEquals(Integer.MAX_VALUE, l1.getOverloadDuration());
-
-        temporaryLimits.put(10, TemporaryLimitAttributes.builder().name("TempLimit10").value(8).acceptableDuration(10).fictitious(false).build());
-        // check duration sorting order: first entry has the highest duration
-        assertEquals(10., l1.getNullableCurrentLimits1().getTemporaryLimits().iterator().next().getAcceptableDuration(), 0);
-    }
 
     @Test
     public void testAddConnectablePositionExtensionToLine() {

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/LineTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/LineTest.java
@@ -35,7 +35,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class LineTest {
 
     //TODO: there is a similar test in the TCK tests. A CurrentLimitsTest extends AbstractCurrentLimitsTest should be created and this test can be deleted.
-    // The TCK test doesn't pass yet. As is, the network-store implementation of setV(v) on buses is not consistent. We have problems with the views we are working on (BusBreakerView or BusView).
     @Test
     public void isOverloadedTest() {
         Network network = CreateNetworksUtil.createNodeBreakerNetworkWithLine();

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/VoltageLevelTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/VoltageLevelTest.java
@@ -18,6 +18,42 @@ import static org.junit.Assert.*;
 public class VoltageLevelTest {
 
     @Test
+    public void testBusBreakerSetVUpdateVoltageLevel() {
+        Network network = CreateNetworksUtil.createBusBreakerNetworkWithLine();
+        LineImpl l1 = (LineImpl) network.getLine("L1");
+
+        // Update voltage using BusView
+        l1.getTerminal1().getBusView().getBus().setV(222);
+
+        // Verify the voltage update in BusBreakerView
+        assertEquals("Voltage should match in BusView after update in BusBreakerView", 222, l1.getTerminal1().getBusBreakerView().getBus().getV(), 0.0);
+
+        // Set voltage using BusBreakerView
+        l1.getTerminal1().getBusBreakerView().getBus().setV(400.0);
+
+        // Verify voltage update in BusView
+        assertEquals("Voltage should match in BusView after update in BusBreakerView", 400.0, l1.getTerminal1().getBusView().getBus().getV(), 0.0);
+    }
+
+    @Test
+    public void testNodeBreakerSetVUpdateVoltageLevel() {
+        Network network = CreateNetworksUtil.createNodeBreakerNetworkWithLine();
+        LineImpl l1 = (LineImpl) network.getLine("L1");
+
+        // Update voltage again using BusBreakerView
+        l1.getTerminal1().getBusBreakerView().getBus().setV(222);
+
+        // Verify the voltage update in BusView
+        assertEquals("Voltage should match in BusBreakerView after second update in BusView", 222, l1.getTerminal1().getBusView().getBus().getV(), 0.0);
+
+        // Set voltage using BusView
+        l1.getTerminal1().getBusView().getBus().setV(400.0);
+
+        // Verify voltage update in BusBreakerView
+        assertEquals("Voltage should match in BusBreakerView after update in BusView", 400.0, l1.getTerminal1().getBusBreakerView().getBus().getV(), 0.0);
+    }
+
+    @Test
     public void testBusBreakerConnectables() {
         Network network = CreateNetworksUtil.createBusBreakerNetworkWithLine();
 

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/VoltageLevelTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/VoltageLevelTest.java
@@ -40,7 +40,7 @@ public class VoltageLevelTest {
         Network network = CreateNetworksUtil.createNodeBreakerNetworkWithLine();
         LineImpl l1 = (LineImpl) network.getLine("L1");
 
-        // Update voltage again using BusBreakerView
+        // Update voltage using BusBreakerView
         l1.getTerminal1().getBusBreakerView().getBus().setV(222);
 
         // Verify the voltage update in BusView
@@ -51,6 +51,42 @@ public class VoltageLevelTest {
 
         // Verify voltage update in BusBreakerView
         assertEquals("Voltage should match in BusBreakerView after update in BusView", 400.0, l1.getTerminal1().getBusBreakerView().getBus().getV(), 0.0);
+    }
+
+    @Test
+    public void testBusBreakerSetAngleUpdateVoltageLevel() {
+        Network network = CreateNetworksUtil.createBusBreakerNetworkWithLine();
+        LineImpl l1 = (LineImpl) network.getLine("L1");
+
+        // Update angle using BusView
+        l1.getTerminal1().getBusView().getBus().setAngle(111);
+
+        // Verify the angle update in BusBreakerView
+        assertEquals("Angle should match in BusView after update in BusBreakerView", 111, l1.getTerminal1().getBusBreakerView().getBus().getAngle(), 0.0);
+
+        // Set angle using BusBreakerView
+        l1.getTerminal1().getBusBreakerView().getBus().setAngle(400.0);
+
+        // Verify Angle update in BusView
+        assertEquals("Angle should match in BusView after update in BusBreakerView", 400.0, l1.getTerminal1().getBusView().getBus().getAngle(), 0.0);
+    }
+
+    @Test
+    public void testNodeBreakerSetAngleUpdateVoltageLevel() {
+        Network network = CreateNetworksUtil.createNodeBreakerNetworkWithLine();
+        LineImpl l1 = (LineImpl) network.getLine("L1");
+
+        // Update angle using BusBreakerView
+        l1.getTerminal1().getBusBreakerView().getBus().setAngle(222);
+
+        // Verify the angle update in BusView
+        assertEquals("Angle should match in BusBreakerView after second update in BusView", 222, l1.getTerminal1().getBusView().getBus().getAngle(), 0.0);
+
+        // Set angle using BusView
+        l1.getTerminal1().getBusView().getBus().setAngle(400.0);
+
+        // Verify angle update in BusBreakerView
+        assertEquals("Angle should match in BusBreakerView after update in BusView", 400.0, l1.getTerminal1().getBusBreakerView().getBus().getAngle(), 0.0);
     }
 
     @Test

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/tck/CurrentLimitsTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/tck/CurrentLimitsTest.java
@@ -12,33 +12,4 @@ import com.powsybl.iidm.network.tck.AbstractCurrentLimitsTest;
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public class CurrentLimitsTest extends AbstractCurrentLimitsTest {
-    @Override
-    public void test() {
-        // FIXME delete this test when we fix Bus.getV/setV not getting/updating correctly the V in all views
-    }
-
-    @Override
-    public void testForThreeWindingsTransformerLeg1() {
-        // FIXME delete this test when we fix Bus.getV/setV not getting/updating correctly the V in all views
-    }
-
-    @Override
-    public void testForThreeWindingsTransformerLeg2() {
-        // FIXME delete this test when we fix Bus.getV/setV not getting/updating correctly the V in all views
-    }
-
-    @Override
-    public void testForThreeWindingsTransformerLeg3() {
-        // FIXME delete this test when we fix Bus.getV/setV not getting/updating correctly the V in all views
-    }
-
-    @Override
-    public void testLimitWithoutTempLimit() {
-        // FIXME delete this test when we fix Bus.getV/setV not getting/updating correctly the V in all views
-    }
-
-    @Override
-    public void testSetterGetter() {
-        // FIXME delete this test when we fix Bus.getV/setV not getting/updating correctly the V in all views
-    }
 }

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/tck/MainConnectedComponentWithSwitchTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/tck/MainConnectedComponentWithSwitchTest.java
@@ -13,8 +13,8 @@ import com.powsybl.iidm.network.tck.AbstractMainConnectedComponentWithSwitchTest
  */
 public class MainConnectedComponentWithSwitchTest extends AbstractMainConnectedComponentWithSwitchTest {
 
-    @Override
+   /* @Override
     public void test() {
         // FIXME remove this test when we stop losing the Angle of buses / use the right views
-    }
+    }*/
 }

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/tck/MainConnectedComponentWithSwitchTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/tck/MainConnectedComponentWithSwitchTest.java
@@ -12,9 +12,4 @@ import com.powsybl.iidm.network.tck.AbstractMainConnectedComponentWithSwitchTest
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public class MainConnectedComponentWithSwitchTest extends AbstractMainConnectedComponentWithSwitchTest {
-
-   /* @Override
-    public void test() {
-        // FIXME remove this test when we stop losing the Angle of buses / use the right views
-    }*/
 }

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/tck/MainConnectedComponentWithSwitchTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/tck/MainConnectedComponentWithSwitchTest.java
@@ -15,6 +15,6 @@ public class MainConnectedComponentWithSwitchTest extends AbstractMainConnectedC
 
     @Override
     public void test() {
-        // FIXME remove this test when we stop losing the v of buses / use the right views
+        // FIXME remove this test when we stop losing the Angle of buses / use the right views
     }
 }


### PR DESCRIPTION


**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix



**What is the current behavior?**
<!-- You can also link to an open issue here -->
Currently, when updating the V value in different topologies (NodeBreaker or BusBreaker), the synchronization between CalculatedBus and ConfiguredBus is not consistently handled across views, leading to potential inconsistencies in voltage values.



**What is the new behavior (if this is a feature change)?**

- When setV is called on getBus() from getBusBreakerView() in a NodeBreaker topology (which by default updates calculatedBusForBusBreakerView), calculatedBusForBusView should also be updated if it is not null.

- When setV is called on getBus() from getBusView() in a NodeBreaker topology (which by default updates calculatedBusForBusView), calculatedBusesForBusBreakerView should also be updated if it is not null.

- When setV is called on getBus() from getBusView() in a BusBreaker topology (which by default updates calculatedBusForBusView), configuredBus should also be updated.

- When setV is called on getBus() from getBusBreakerView() in a BusBreaker topology (which by default updates configuredBus), calculatedBusForBusView should also be updated if it is not null.

And when calculating a new view, the v and theta values should be taken from the other source (NodeBreaker: busview/busbreakerview; BusBreaker: busview/configuredbus).



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
