### PR TITLE
Fix pb in tck tests finding terminals.

### DIFF
--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/tck/TerminalFinderTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/tck/TerminalFinderTest.java
@@ -13,13 +13,4 @@ import com.powsybl.iidm.network.tck.AbstractTerminalFinderTest;
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public class TerminalFinderTest extends AbstractTerminalFinderTest {
-    @Override
-    public void testLineTerminal1() {
-        // FIXME
-    }
-
-    @Override
-    public void testLineTerminal2() {
-        // FIXME
-    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
In TerminalFinderTest tck test class : methods testLineTerminal1 and testLineTerminal2
These 2 tests fail, because there is no explicit order defined for branch equipment (Line and TwoWindingsTransformer) in TerminalFinder class, when building the default rules.
see PR : https://github.com/powsybl/powsybl-core/pull/3117

**What is the new behavior (if this is a feature change)?**
 These 2 tests now succeed.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
