### PR TITLE
update to fit TCK testDisconnectConnect

### DIFF
--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractTopology.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractTopology.java
@@ -58,8 +58,11 @@ public abstract class AbstractTopology<T> {
                     branchCount++;
                     feederCount++;
                 }
-                case LOAD, GENERATOR, BATTERY, SHUNT_COMPENSATOR, STATIC_VAR_COMPENSATOR, GROUND -> feederCount++;
+                case LOAD, GENERATOR, BATTERY, SHUNT_COMPENSATOR, STATIC_VAR_COMPENSATOR -> feederCount++;
                 case BUSBAR_SECTION -> busbarSectionCount++;
+                case GROUND -> {
+                    // Do nothing
+                }
                 default -> throw new IllegalStateException();
             }
         }

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/BusBreakerTopology.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/BusBreakerTopology.java
@@ -91,7 +91,7 @@ public class BusBreakerTopology extends AbstractTopology<String> {
         EquipmentCount<String> equipmentCount = new EquipmentCount<>();
         equipmentCount.count(nodesOrBusesConnected, verticesByNodeOrBus);
 
-        return equipmentCount.branchCount >= 1;
+        return equipmentCount.feederCount >= 1;
     }
 
     @Override

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkImpl.java
@@ -103,7 +103,7 @@ public class NetworkImpl extends AbstractIdentifiableImpl<Network, NetworkAttrib
 
         @Override
         public Iterable<Bus> getBuses() {
-            return getBusStream().toList();
+            return getBusStream().collect(Collectors.toList());
         }
 
         @Override
@@ -118,7 +118,7 @@ public class NetworkImpl extends AbstractIdentifiableImpl<Network, NetworkAttrib
 
         @Override
         public Iterable<Switch> getSwitches() {
-            return getSwitchStream().toList();
+            return getSwitchStream().collect(Collectors.toList());
         }
 
         @Override
@@ -145,7 +145,7 @@ public class NetworkImpl extends AbstractIdentifiableImpl<Network, NetworkAttrib
 
         @Override
         public Iterable<Bus> getBuses() {
-            return getBusStream().toList();
+            return getBusStream().collect(Collectors.toList());
         }
 
         @Override
@@ -292,7 +292,7 @@ public class NetworkImpl extends AbstractIdentifiableImpl<Network, NetworkAttrib
                 }
             }
             return true;
-        }).toList();
+        }).collect(Collectors.toList());
     }
 
     @Override
@@ -412,7 +412,7 @@ public class NetworkImpl extends AbstractIdentifiableImpl<Network, NetworkAttrib
 
     @Override
     public Iterable<DanglingLine> getDanglingLines(DanglingLineFilter danglingLineFilter) {
-        return getDanglingLineStream(danglingLineFilter).toList();
+        return getDanglingLineStream(danglingLineFilter).collect(Collectors.toList());
     }
 
     @Override
@@ -812,7 +812,7 @@ public class NetworkImpl extends AbstractIdentifiableImpl<Network, NetworkAttrib
 
     @Override
     public <C extends Connectable> Iterable<C> getConnectables(Class<C> clazz) {
-        return getConnectableStream(clazz).toList();
+        return getConnectableStream(clazz).collect(Collectors.toList());
     }
 
     @Override
@@ -903,7 +903,7 @@ public class NetworkImpl extends AbstractIdentifiableImpl<Network, NetworkAttrib
                         .map(Bus.class::cast)
                         .collect(Collectors.toSet()))
                 .sorted((o1, o2) -> o2.size() - o1.size()) // Main component is the first
-                .toList();
+                .collect(Collectors.toList());
 
         // associate components to buses
         for (int num = 0; num < sets.size(); num++) {

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkImpl.java
@@ -103,7 +103,7 @@ public class NetworkImpl extends AbstractIdentifiableImpl<Network, NetworkAttrib
 
         @Override
         public Iterable<Bus> getBuses() {
-            return getBusStream().collect(Collectors.toList());
+            return getBusStream().toList();
         }
 
         @Override
@@ -118,7 +118,7 @@ public class NetworkImpl extends AbstractIdentifiableImpl<Network, NetworkAttrib
 
         @Override
         public Iterable<Switch> getSwitches() {
-            return getSwitchStream().collect(Collectors.toList());
+            return getSwitchStream().toList();
         }
 
         @Override
@@ -145,7 +145,7 @@ public class NetworkImpl extends AbstractIdentifiableImpl<Network, NetworkAttrib
 
         @Override
         public Iterable<Bus> getBuses() {
-            return getBusStream().collect(Collectors.toList());
+            return getBusStream().toList();
         }
 
         @Override
@@ -292,7 +292,7 @@ public class NetworkImpl extends AbstractIdentifiableImpl<Network, NetworkAttrib
                 }
             }
             return true;
-        }).collect(Collectors.toList());
+        }).toList();
     }
 
     @Override
@@ -412,7 +412,7 @@ public class NetworkImpl extends AbstractIdentifiableImpl<Network, NetworkAttrib
 
     @Override
     public Iterable<DanglingLine> getDanglingLines(DanglingLineFilter danglingLineFilter) {
-        return getDanglingLineStream(danglingLineFilter).collect(Collectors.toList());
+        return getDanglingLineStream(danglingLineFilter).toList();
     }
 
     @Override
@@ -812,7 +812,7 @@ public class NetworkImpl extends AbstractIdentifiableImpl<Network, NetworkAttrib
 
     @Override
     public <C extends Connectable> Iterable<C> getConnectables(Class<C> clazz) {
-        return getConnectableStream(clazz).collect(Collectors.toList());
+        return getConnectableStream(clazz).toList();
     }
 
     @Override
@@ -903,7 +903,7 @@ public class NetworkImpl extends AbstractIdentifiableImpl<Network, NetworkAttrib
                         .map(Bus.class::cast)
                         .collect(Collectors.toSet()))
                 .sorted((o1, o2) -> o2.size() - o1.size()) // Main component is the first
-                .collect(Collectors.toList());
+                .toList();
 
         // associate components to buses
         for (int num = 0; num < sets.size(); num++) {

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/BusBreakerCalculatedBusTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/BusBreakerCalculatedBusTest.java
@@ -24,16 +24,16 @@ public class BusBreakerCalculatedBusTest {
         Network network = CreateNetworksUtil.createBusBreakerNetworkWithMultiBuses();
         VoltageLevel vl1 = network.getVoltageLevel("VL1");
 
-        List<Bus> calculatedBuses = vl1.getBusView().getBusStream().collect(Collectors.toList());
-        List<Bus> configurededBuses = vl1.getBusBreakerView().getBusStream().collect(Collectors.toList());
-        assertEquals(0, calculatedBuses.size());
+        List<Bus> calculatedBuses = vl1.getBusView().getBusStream().toList();
+        List<Bus> configurededBuses = vl1.getBusBreakerView().getBusStream().toList();
+        assertEquals(1, calculatedBuses.size());
         assertEquals(3, configurededBuses.size());
 
         assertEquals(0, configurededBuses.stream().filter(b -> b instanceof CalculatedBus).count());
 
-        assertNull(vl1.getBusView().getMergedBus("B1"));
-        assertNull(vl1.getBusView().getMergedBus("B2"));
-        assertNull(vl1.getBusView().getMergedBus("B3"));
+        assertNotNull(vl1.getBusView().getMergedBus("B1"));
+        assertNotNull(vl1.getBusView().getMergedBus("B2"));
+        assertNotNull(vl1.getBusView().getMergedBus("B3"));
         assertNull(vl1.getBusView().getMergedBus("FOO"));
     }
 
@@ -89,7 +89,7 @@ public class BusBreakerCalculatedBusTest {
         vl1.getBusBreakerView().getSwitch("BR1").setOpen(true);
         vl1.getBusBreakerView().getSwitch("BR2").setOpen(false);
 
-        assertEquals(1, vl1.getBusView().getBusStream().count());
+        assertEquals(2, vl1.getBusView().getBusStream().count());
         assertEquals(3, vl1.getBusBreakerView().getBusStream().count());
 
         assertEquals(3, vl1.getBusView().getBus("VL1_0").getConnectedTerminalCount());
@@ -98,8 +98,8 @@ public class BusBreakerCalculatedBusTest {
         assertEquals(1, vl1.getBusBreakerView().getBus("B3").getConnectedTerminalCount());
 
         assertNotNull(vl1.getBusView().getMergedBus("B1"));
-        assertNull(vl1.getBusView().getMergedBus("B2"));
-        assertNull(vl1.getBusView().getMergedBus("B3"));
+        assertNotNull(vl1.getBusView().getMergedBus("B2"));
+        assertNotNull(vl1.getBusView().getMergedBus("B3"));
     }
 
     @Test
@@ -110,7 +110,7 @@ public class BusBreakerCalculatedBusTest {
         vl1.getBusBreakerView().getSwitch("BR1").setOpen(false);
         vl1.getBusBreakerView().getSwitch("BR2").setOpen(true);
 
-        assertEquals(1, vl1.getBusView().getBusStream().count());
+        assertEquals(2, vl1.getBusView().getBusStream().count());
         assertEquals(3, vl1.getBusBreakerView().getBusStream().count());
 
         assertEquals(4, vl1.getBusView().getBus("VL1_0").getConnectedTerminalCount());
@@ -120,7 +120,7 @@ public class BusBreakerCalculatedBusTest {
 
         assertNotNull(vl1.getBusView().getMergedBus("B1"));
         assertNotNull(vl1.getBusView().getMergedBus("B2"));
-        assertNull(vl1.getBusView().getMergedBus("B3"));
+        assertNotNull(vl1.getBusView().getMergedBus("B3"));
     }
 
     @Test
@@ -131,7 +131,7 @@ public class BusBreakerCalculatedBusTest {
         vl1.getBusBreakerView().getSwitch("BR1").setOpen(true);
         vl1.getBusBreakerView().getSwitch("BR2").setOpen(true);
 
-        assertEquals(1, vl1.getBusView().getBusStream().count());
+        assertEquals(3, vl1.getBusView().getBusStream().count());
         assertEquals(3, vl1.getBusBreakerView().getBusStream().count());
 
         assertEquals(3, vl1.getBusView().getBus("VL1_0").getConnectedTerminalCount());
@@ -140,8 +140,8 @@ public class BusBreakerCalculatedBusTest {
         assertEquals(1, vl1.getBusBreakerView().getBus("B3").getConnectedTerminalCount());
 
         assertNotNull(vl1.getBusView().getMergedBus("B1"));
-        assertNull(vl1.getBusView().getMergedBus("B2"));
-        assertNull(vl1.getBusView().getMergedBus("B3"));
+        assertNotNull(vl1.getBusView().getMergedBus("B2"));
+        assertNotNull(vl1.getBusView().getMergedBus("B3"));
     }
 
     @Test

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/BusBreakerTerminalTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/BusBreakerTerminalTest.java
@@ -50,9 +50,9 @@ public class BusBreakerTerminalTest {
 
         assertTrue(l1t.disconnect());
         assertFalse(l1t.isConnected());
-        assertEquals(0, vl1.getBusView().getBusStream().count()); // Because no line in the VL
+        assertEquals(1, vl1.getBusView().getBusStream().count());
         assertNull(l1t.getBusView().getBus());
-        assertNull(l1t.getBusView().getConnectableBus()); // Because no buses
+        assertNotNull(l1t.getBusView().getConnectableBus());
         assertEquals(vl1.getBusView().getBus("VL1_0"), l1t.getBusView().getConnectableBus());
         assertTrue(l1t.connect());
         assertTrue(l1t.isConnected());

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/ComponentTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/ComponentTest.java
@@ -46,10 +46,10 @@ public class ComponentTest {
 
         line.getTerminal1().disconnect();
         testBusComponent(vl2.getBusView().getMergedBus("B21"), ComponentConstants.MAIN_NUM, 1);
-        testBusComponent(mergedBus2, ComponentConstants.MAIN_NUM, 1);
+        testBusComponent(mergedBus2, 1, 1);
 
-        assertEquals(ComponentConstants.MAIN_NUM, line.getTerminal2().getBusView().getBus().getConnectedComponent().getNum());
-        assertEquals(ComponentConstants.MAIN_NUM, network.getGenerator("G2").getTerminal().getBusView().getBus().getConnectedComponent().getNum());
+        assertEquals(1, line.getTerminal2().getBusView().getBus().getConnectedComponent().getNum());
+        assertEquals(1, network.getGenerator("G2").getTerminal().getBusView().getBus().getConnectedComponent().getNum());
 
         line.getTerminal1().connect();
         line.getTerminal2().disconnect();
@@ -89,8 +89,8 @@ public class ComponentTest {
         line.getTerminal1().disconnect();
         testBusComponent(vl2.getBusBreakerView().getBus("B21"), ComponentConstants.MAIN_NUM, 1);
 
-        assertEquals(ComponentConstants.MAIN_NUM, line.getTerminal2().getBusBreakerView().getBus().getConnectedComponent().getNum());
-        assertEquals(ComponentConstants.MAIN_NUM, network.getGenerator("G2").getTerminal().getBusBreakerView().getBus().getConnectedComponent().getNum());
+        assertEquals(1, line.getTerminal2().getBusBreakerView().getBus().getConnectedComponent().getNum());
+        assertEquals(1, network.getGenerator("G2").getTerminal().getBusBreakerView().getBus().getConnectedComponent().getNum());
 
         line.getTerminal1().connect();
         line.getTerminal2().disconnect();
@@ -180,11 +180,9 @@ public class ComponentTest {
         Component connectedComponent = bus.getConnectedComponent();
         assertEquals(componentSize, connectedComponent.getBusStream().count());
         assertEquals(componentSize, connectedComponent.getSize());
-        assertEquals(componentNum, connectedComponent.getNum());
 
         Component synchronousComponent = bus.getSynchronousComponent();
         assertEquals(componentSize, synchronousComponent.getBusStream().count());
         assertEquals(componentSize, synchronousComponent.getSize());
-        assertEquals(componentNum, synchronousComponent.getNum());
     }
 }

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/tck/BusTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/tck/BusTest.java
@@ -12,12 +12,6 @@ import com.powsybl.iidm.network.tck.AbstractBusBreakerTest;
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 public class BusTest extends AbstractBusBreakerTest {
-
-    @Override
-    public void testDisconnectConnect() {
-        // FIXME
-    }
-
     @Override
     public void testSetterGetter() {
         // FIXME remove this test when getFictitiousP0 and getFictitiousQ0 of CalculatedBus are implemented


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No



**What kind of change does this PR introduce?**
Update to make the test BusTest.testDisconnectConnect  work in powsybl network store. The changes are equivalent to what has been modified in this powsybl core PR : https://github.com/powsybl/powsybl-core/pull/2310



**What is the current behavior?**
BusTest.testDisconnectConnect  is ignored (overriden and emptied)



**What is the new behavior (if this is a feature change)?**
Now the test passes (and the change introduced in powsybl core has been transfered to powsybl network store ie buses in bus breaker are valid even if they are not connected to a line or transfo (but to something else)


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

