### PR TITLE
Cache implementation for busview.getBus(id)

### DIFF
--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/VoltageLevelImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/VoltageLevelImpl.java
@@ -55,6 +55,7 @@ public class VoltageLevelImpl extends AbstractIdentifiableImpl<VoltageLevel, Vol
     void invalidateCalculatedBuses() {
         updateResource(res -> res.getAttributes().setCalculatedBusesValid(false));
         getNetwork().invalidateComponents();
+        getNetwork().getBusView().invalidateCache();
     }
 
     @Override

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/NodeBreakerCalculatedBusTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/NodeBreakerCalculatedBusTest.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 import java.util.Arrays;
 
 import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotEquals;
 
 /**
  * @author Slimane Amar <slimane.amar at rte-france.com>
@@ -490,5 +491,19 @@ public class NodeBreakerCalculatedBusTest {
             bus.getConnectedComponent();
             bus.getSynchronousComponent();
         }
+    }
+
+    @Test
+    public void testGetBusCacheInvalidation() {
+        Network network = CreateNetworksUtil.createNodeBreakerNetworkWithLine();
+        VoltageLevel vl1 = network.getVoltageLevel("VL1");
+        CreateNetworksUtil.addBusBarSection(vl1);
+
+        // creating the cache and checking VL1_10 is not existing yet
+        assertNull(network.getBusView().getBus("VL1_10"));
+        // creating a new calculated bus by opening a switch, the cache should be invalidated
+        vl1.getNodeBreakerView().getSwitch("BRS12").setOpen(true);
+        // checking the cache has been invalidated and returns the new bus
+        assertNotNull(network.getBusView().getBus("VL1_10"));
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
Feature



**What is the current behavior?**
When getting bus from its id, the current implementation search it among the voltage levels within the network



**What is the new behavior (if this is a feature change)?**
When getting bus from its id, the new implementation creates a cache linking the bus to their ids, that will be used to improve the overall performance
When the topology changes, the cache is invalidated


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No