### PR TITLE
Do not select operationalLimitsGroup in setCurrentLimits

### DIFF
--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractBranchImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractBranchImpl.java
@@ -110,7 +110,6 @@ public abstract class AbstractBranchImpl<T extends Branch<T> & Connectable<T>, U
             var operationalLimitsGroup = attributes.getOperationalLimitsGroup1(operationalLimitsGroupId);
             var oldCurrentLimits = operationalLimitsGroup != null ? operationalLimitsGroup.getCurrentLimits() : null;
             if (currentLimits != oldCurrentLimits) {
-                updateSelectedOperationalLimitsGroupIdIfNull(side, operationalLimitsGroupId);
                 updateResource(res -> res.getAttributes().getOrCreateOperationalLimitsGroup1(operationalLimitsGroupId).setCurrentLimits(currentLimits));
                 index.notifyUpdate(this, "currentLimits1", oldCurrentLimits, currentLimits);
             }
@@ -118,7 +117,6 @@ public abstract class AbstractBranchImpl<T extends Branch<T> & Connectable<T>, U
             var operationalLimitsGroup = attributes.getOperationalLimitsGroup2(operationalLimitsGroupId);
             var oldCurrentLimits = operationalLimitsGroup != null ? operationalLimitsGroup.getCurrentLimits() : null;
             if (currentLimits != oldCurrentLimits) {
-                updateSelectedOperationalLimitsGroupIdIfNull(side, operationalLimitsGroupId);
                 updateResource(res -> res.getAttributes().getOrCreateOperationalLimitsGroup2(operationalLimitsGroupId).setCurrentLimits(currentLimits));
                 index.notifyUpdate(this, "currentLimits2", oldCurrentLimits, currentLimits);
             }
@@ -132,21 +130,25 @@ public abstract class AbstractBranchImpl<T extends Branch<T> & Connectable<T>, U
 
     @Override
     public CurrentLimitsAdder newCurrentLimits1() {
+        updateSelectedOperationalLimitsGroupIdIfNull(TwoSides.ONE, getSelectedOperationalLimitsGroupId(TwoSides.ONE));
         return new CurrentLimitsAdderImpl<>(TwoSides.ONE, this, getSelectedOperationalLimitsGroupId(TwoSides.ONE));
     }
 
     @Override
     public CurrentLimitsAdder newCurrentLimits2() {
+        updateSelectedOperationalLimitsGroupIdIfNull(TwoSides.TWO, getSelectedOperationalLimitsGroupId(TwoSides.TWO));
         return new CurrentLimitsAdderImpl<>(TwoSides.TWO, this, getSelectedOperationalLimitsGroupId(TwoSides.TWO));
     }
 
     @Override
     public ApparentPowerLimitsAdder newApparentPowerLimits1() {
+        updateSelectedOperationalLimitsGroupIdIfNull(TwoSides.ONE, getSelectedOperationalLimitsGroupId(TwoSides.ONE));
         return new ApparentPowerLimitsAdderImpl<>(TwoSides.ONE, this, getSelectedOperationalLimitsGroupId(TwoSides.ONE));
     }
 
     @Override
     public ApparentPowerLimitsAdder newApparentPowerLimits2() {
+        updateSelectedOperationalLimitsGroupIdIfNull(TwoSides.TWO, getSelectedOperationalLimitsGroupId(TwoSides.TWO));
         return new ApparentPowerLimitsAdderImpl<>(TwoSides.TWO, this, getSelectedOperationalLimitsGroupId(TwoSides.TWO));
     }
 
@@ -196,7 +198,6 @@ public abstract class AbstractBranchImpl<T extends Branch<T> & Connectable<T>, U
             var operationalLimitsGroup = attributes.getOperationalLimitsGroup1(operationalLimitsGroupId);
             var oldApparentPowerLimits = operationalLimitsGroup != null ? operationalLimitsGroup.getApparentPowerLimits() : null;
             if (apparentPowerLimitsAttributes != oldApparentPowerLimits) {
-                updateSelectedOperationalLimitsGroupIdIfNull(side, operationalLimitsGroupId);
                 updateResource(res -> res.getAttributes().getOrCreateOperationalLimitsGroup1(operationalLimitsGroupId).setApparentPowerLimits(apparentPowerLimitsAttributes));
                 index.notifyUpdate(this, "apparentPowerLimits1", oldApparentPowerLimits, apparentPowerLimitsAttributes);
             }
@@ -204,7 +205,6 @@ public abstract class AbstractBranchImpl<T extends Branch<T> & Connectable<T>, U
             var operationalLimitsGroup = attributes.getOperationalLimitsGroup2(operationalLimitsGroupId);
             var oldApparentPowerLimits = operationalLimitsGroup != null ? operationalLimitsGroup.getApparentPowerLimits() : null;
             if (apparentPowerLimitsAttributes != oldApparentPowerLimits) {
-                updateSelectedOperationalLimitsGroupIdIfNull(side, operationalLimitsGroupId);
                 updateResource(res -> res.getAttributes().getOrCreateOperationalLimitsGroup2(operationalLimitsGroupId).setApparentPowerLimits(apparentPowerLimitsAttributes));
                 index.notifyUpdate(this, "apparentPowerLimits2", oldApparentPowerLimits, apparentPowerLimitsAttributes);
             }
@@ -213,11 +213,13 @@ public abstract class AbstractBranchImpl<T extends Branch<T> & Connectable<T>, U
 
     @Override
     public ActivePowerLimitsAdder newActivePowerLimits1() {
+        updateSelectedOperationalLimitsGroupIdIfNull(TwoSides.ONE, getSelectedOperationalLimitsGroupId(TwoSides.ONE));
         return new ActivePowerLimitsAdderImpl<>(TwoSides.ONE, this, getSelectedOperationalLimitsGroupId(TwoSides.ONE));
     }
 
     @Override
     public ActivePowerLimitsAdder newActivePowerLimits2() {
+        updateSelectedOperationalLimitsGroupIdIfNull(TwoSides.TWO, getSelectedOperationalLimitsGroupId(TwoSides.TWO));
         return new ActivePowerLimitsAdderImpl<>(TwoSides.TWO, this, getSelectedOperationalLimitsGroupId(TwoSides.TWO));
     }
 
@@ -276,7 +278,6 @@ public abstract class AbstractBranchImpl<T extends Branch<T> & Connectable<T>, U
             var operationalLimitsGroup = attributes.getOperationalLimitsGroup1(operationalLimitsGroupId);
             var oldActivePowerLimits = operationalLimitsGroup != null ? operationalLimitsGroup.getActivePowerLimits() : null;
             if (activePowerLimitsAttributes != oldActivePowerLimits) {
-                updateSelectedOperationalLimitsGroupIdIfNull(side, operationalLimitsGroupId);
                 updateResource(res -> res.getAttributes().getOrCreateOperationalLimitsGroup1(operationalLimitsGroupId).setActivePowerLimits(activePowerLimitsAttributes));
                 index.notifyUpdate(this, "activePowerLimits1", oldActivePowerLimits, activePowerLimitsAttributes);
             }
@@ -284,7 +285,6 @@ public abstract class AbstractBranchImpl<T extends Branch<T> & Connectable<T>, U
             var operationalLimitsGroup = attributes.getOperationalLimitsGroup2(operationalLimitsGroupId);
             var oldActivePowerLimits = operationalLimitsGroup != null ? operationalLimitsGroup.getActivePowerLimits() : null;
             if (activePowerLimitsAttributes != oldActivePowerLimits) {
-                updateSelectedOperationalLimitsGroupIdIfNull(side, operationalLimitsGroupId);
                 updateResource(res -> res.getAttributes().getOrCreateOperationalLimitsGroup2(operationalLimitsGroupId).setActivePowerLimits(activePowerLimitsAttributes));
                 index.notifyUpdate(this, "activePowerLimits2", oldActivePowerLimits, activePowerLimitsAttributes);
             }

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/DanglingLineImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/DanglingLineImpl.java
@@ -358,7 +358,6 @@ public class DanglingLineImpl extends AbstractInjectionImpl<DanglingLine, Dangli
     public void setCurrentLimits(Void side, LimitsAttributes currentLimits, String operationalLimitsGroupId) {
         var operationalLimitsGroup = getResource().getAttributes().getOperationalLimitsGroup(operationalLimitsGroupId);
         LimitsAttributes oldValue = operationalLimitsGroup != null ? operationalLimitsGroup.getCurrentLimits() : null;
-        updateSelectedOperationalLimitsGroupIdIfNull(operationalLimitsGroupId);
         updateResource(res -> res.getAttributes().getOrCreateOperationalLimitsGroup(operationalLimitsGroupId).setCurrentLimits(currentLimits));
         notifyUpdate("currentLimits", oldValue, currentLimits);
     }
@@ -415,16 +414,19 @@ public class DanglingLineImpl extends AbstractInjectionImpl<DanglingLine, Dangli
 
     @Override
     public CurrentLimitsAdder newCurrentLimits() {
+        updateSelectedOperationalLimitsGroupIdIfNull(getSelectedLimitsGroupId());
         return new CurrentLimitsAdderImpl<>(null, this, getSelectedLimitsGroupId());
     }
 
     @Override
     public ApparentPowerLimitsAdder newApparentPowerLimits() {
+        updateSelectedOperationalLimitsGroupIdIfNull(getSelectedLimitsGroupId());
         return new ApparentPowerLimitsAdderImpl<>(null, this, getSelectedLimitsGroupId());
     }
 
     @Override
     public ActivePowerLimitsAdder newActivePowerLimits() {
+        updateSelectedOperationalLimitsGroupIdIfNull(getSelectedLimitsGroupId());
         return new ActivePowerLimitsAdderImpl<>(null, this, getSelectedLimitsGroupId());
     }
 
@@ -432,7 +434,6 @@ public class DanglingLineImpl extends AbstractInjectionImpl<DanglingLine, Dangli
     public void setApparentPowerLimits(Void unused, LimitsAttributes apparentPowerLimitsAttributes, String operationalLimitsGroupId) {
         var operationalLimitsGroup = getResource().getAttributes().getOperationalLimitsGroup(operationalLimitsGroupId);
         LimitsAttributes oldValue = operationalLimitsGroup != null ? operationalLimitsGroup.getApparentPowerLimits() : null;
-        updateSelectedOperationalLimitsGroupIdIfNull(operationalLimitsGroupId);
         updateResource(res -> res.getAttributes().getOrCreateOperationalLimitsGroup(operationalLimitsGroupId).setApparentPowerLimits(apparentPowerLimitsAttributes));
         notifyUpdate("apparentLimits", oldValue, apparentPowerLimitsAttributes);
     }
@@ -441,7 +442,6 @@ public class DanglingLineImpl extends AbstractInjectionImpl<DanglingLine, Dangli
     public void setActivePowerLimits(Void unused, LimitsAttributes activePowerLimitsAttributes, String operationalLimitsGroupId) {
         var operationalLimitsGroup = getResource().getAttributes().getOperationalLimitsGroup(operationalLimitsGroupId);
         LimitsAttributes oldValue = operationalLimitsGroup != null ? operationalLimitsGroup.getActivePowerLimits() : null;
-        updateSelectedOperationalLimitsGroupIdIfNull(operationalLimitsGroupId);
         updateResource(res -> res.getAttributes().getOrCreateOperationalLimitsGroup(operationalLimitsGroupId).setActivePowerLimits(activePowerLimitsAttributes));
         notifyUpdate("activeLimits", oldValue, activePowerLimitsAttributes);
     }

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/ThreeWindingsTransformerImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/ThreeWindingsTransformerImpl.java
@@ -216,16 +216,19 @@ public class ThreeWindingsTransformerImpl extends AbstractIdentifiableImpl<Three
 
         @Override
         public CurrentLimitsAdder newCurrentLimits() {
+            updateSelectedOperationalLimitsGroupIdIfNull(getSelectedGroupId());
             return new CurrentLimitsAdderImpl<>(null, this, getSelectedGroupId());
         }
 
         @Override
         public ApparentPowerLimitsAdder newApparentPowerLimits() {
+            updateSelectedOperationalLimitsGroupIdIfNull(getSelectedGroupId());
             return new ApparentPowerLimitsAdderImpl<>(null, this, getSelectedGroupId());
         }
 
         @Override
         public ActivePowerLimitsAdder newActivePowerLimits() {
+            updateSelectedOperationalLimitsGroupIdIfNull(getSelectedGroupId());
             return new ActivePowerLimitsAdderImpl<>(null, this, getSelectedGroupId());
         }
 
@@ -271,7 +274,6 @@ public class ThreeWindingsTransformerImpl extends AbstractIdentifiableImpl<Three
         public void setCurrentLimits(Void side, LimitsAttributes currentLimits, String operationalLimitsGroupId) {
             var operationalLimitsGroup = getLegAttributes().getOperationalLimitsGroup(operationalLimitsGroupId);
             LimitsAttributes oldValue = operationalLimitsGroup != null ? operationalLimitsGroup.getCurrentLimits() : null;
-            updateSelectedOperationalLimitsGroupIdIfNull(operationalLimitsGroupId);
             transformer.updateResource(res -> legGetter.apply(res.getAttributes()).getOrCreateOperationalLimitsGroup(operationalLimitsGroupId).setCurrentLimits(currentLimits));
             notifyUpdate("currentLimits", oldValue, currentLimits);
         }
@@ -285,7 +287,6 @@ public class ThreeWindingsTransformerImpl extends AbstractIdentifiableImpl<Three
         public void setApparentPowerLimits(Void side, LimitsAttributes apparentPowerLimitsAttributes, String operationalLimitsGroupId) {
             var operationalLimitsGroup = getLegAttributes().getOperationalLimitsGroup(operationalLimitsGroupId);
             LimitsAttributes oldValue = operationalLimitsGroup != null ? operationalLimitsGroup.getApparentPowerLimits() : null;
-            updateSelectedOperationalLimitsGroupIdIfNull(operationalLimitsGroupId);
             transformer.updateResource(res -> legGetter.apply(res.getAttributes()).getOrCreateOperationalLimitsGroup(operationalLimitsGroupId).setApparentPowerLimits(apparentPowerLimitsAttributes));
             notifyUpdate("apparentLimits", oldValue, apparentPowerLimitsAttributes);
         }
@@ -294,7 +295,6 @@ public class ThreeWindingsTransformerImpl extends AbstractIdentifiableImpl<Three
         public void setActivePowerLimits(Void side, LimitsAttributes activePowerLimitsAttributes, String operationalLimitsGroupId) {
             var operationalLimitsGroup = getLegAttributes().getOperationalLimitsGroup(operationalLimitsGroupId);
             LimitsAttributes oldValue = operationalLimitsGroup != null ? operationalLimitsGroup.getActivePowerLimits() : null;
-            updateSelectedOperationalLimitsGroupIdIfNull(operationalLimitsGroupId);
             transformer.updateResource(res -> legGetter.apply(res.getAttributes()).getOrCreateOperationalLimitsGroup(operationalLimitsGroupId).setActivePowerLimits(activePowerLimitsAttributes));
             notifyUpdate("activePowerLimits", oldValue, activePowerLimitsAttributes);
         }

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/LineTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/LineTest.java
@@ -46,14 +46,22 @@ public class LineTest {
         assertFalse(l1.isOverloaded());
 
         l1.getTerminal1().setP(400);
-        l1.newCurrentLimits1().setPermanentLimit(40).add();
+
+        l1.setCurrentLimits(TwoSides.ONE, new LimitsAttributes("PermaLimit1", 600, null), "PermaLimit1");
+        assertNull(l1.getNullableCurrentLimits1());
+        l1.setSelectedOperationalLimitsGroup1("PermaLimit1");
         assertTrue(l1.getNullableCurrentLimits1().getTemporaryLimits().isEmpty());
+        assertFalse(l1.isOverloaded());
+
+        l1.newCurrentLimits1().setPermanentLimit(50).add();
         assertTrue(l1.isOverloaded());
 
         TreeMap<Integer, TemporaryLimitAttributes> temporaryLimits = new TreeMap<>();
         temporaryLimits.put(5, TemporaryLimitAttributes.builder().name("TempLimit5").value(1000).acceptableDuration(5).fictitious(false).build());
-        l1.setCurrentLimits(TwoSides.ONE, new LimitsAttributes("DEFAULT", 40, temporaryLimits), "DEFAULT");
-        l1.setCurrentLimits(TwoSides.TWO, new LimitsAttributes("DEFAULT", 40, temporaryLimits), "DEFAULT");
+        l1.setCurrentLimits(TwoSides.ONE, new LimitsAttributes("PermaLimit1", 40, temporaryLimits), "PermaLimit1");
+        l1.setCurrentLimits(TwoSides.TWO, new LimitsAttributes("PermaLimit1", 40, temporaryLimits), "PermaLimit1");
+        l1.setSelectedOperationalLimitsGroup1("PermaLimit1");
+        l1.setSelectedOperationalLimitsGroup2("PermaLimit1");
         assertEquals(5, l1.getOverloadDuration());
 
         assertTrue(l1.checkPermanentLimit(TwoSides.ONE, LimitType.CURRENT));

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/LineTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/LineTest.java
@@ -46,7 +46,7 @@ public class LineTest {
         assertFalse(l1.isOverloaded());
 
         l1.getTerminal1().setP(400);
-        l1.setCurrentLimits(TwoSides.ONE, new LimitsAttributes("DEFAULT", 40, null), "DEFAULT");
+        l1.newCurrentLimits1().setPermanentLimit(40).add();
         assertTrue(l1.getNullableCurrentLimits1().getTemporaryLimits().isEmpty());
         assertTrue(l1.isOverloaded());
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No.



**What kind of change does this PR introduce?**
Bug fix



**What is the current behavior?**
It is not possible to add an OperationalLimitGroup to a branch, 3WT or danglingLine without selecting it. It is a problem when we import a case file that have OperationalLimitGroup on one branch's side but none is selected.



**What is the new behavior (if this is a feature change)?**
The OperationalLimitGroup is not selected when setCurrentLimits() is called. So we can use an AbstractLoadingLimitsAdder without activating the created OperationalLimitGroup. This bevahior fits to powsybl-core's one.

