### PR TITLE
Ensure existing resources/extension attributes in the cache are not overwritten when loading from server

### DIFF
--- a/network-store-client/src/test/java/com/powsybl/network/store/client/PreloadingNetworkStoreClientTest.java
+++ b/network-store-client/src/test/java/com/powsybl/network/store/client/PreloadingNetworkStoreClientTest.java
@@ -516,16 +516,11 @@ public class PreloadingNetworkStoreClientTest {
         assertEquals(1, vl2Grounds.get(0).getAttributes().getP(), 0.001);
         assertEquals(2, vl2Grounds.get(0).getAttributes().getQ(), 0.001);
 
-        Resource<GroundAttributes> updateGround = Resource.groundBuilder()
-                .id("groundId")
-                .attributes(GroundAttributes.builder()
-                        .voltageLevelId("vl2")
-                        .p(5)
-                        .q(6)
-                        .bus("bus")
-                        .build())
-                .build();
-        cachedClient.updateGrounds(networkUuid, List.of(updateGround), null);
+        // Update grounds with new values in the resource
+        vl2Grounds.get(0).getAttributes().setP(5);
+        vl2Grounds.get(0).getAttributes().setQ(6);
+        cachedClient.updateGrounds(networkUuid, vl2Grounds, null);
+        // Retrieve grounds by container and ensure that vl2Grounds is up to date
         vl2Grounds = cachedClient.getVoltageLevelGrounds(networkUuid, Resource.INITIAL_VARIANT_NUM, "vl2");
         assertEquals(1, vl2Grounds.size());
         assertEquals(5, vl2Grounds.get(0).getAttributes().getP(), 0.001);

--- a/network-store-client/src/test/java/com/powsybl/network/store/client/PreloadingNetworkStoreClientTest.java
+++ b/network-store-client/src/test/java/com/powsybl/network/store/client/PreloadingNetworkStoreClientTest.java
@@ -516,11 +516,16 @@ public class PreloadingNetworkStoreClientTest {
         assertEquals(1, vl2Grounds.get(0).getAttributes().getP(), 0.001);
         assertEquals(2, vl2Grounds.get(0).getAttributes().getQ(), 0.001);
 
-        // Update grounds with new values in the resource
-        vl2Grounds.get(0).getAttributes().setP(5);
-        vl2Grounds.get(0).getAttributes().setQ(6);
-        cachedClient.updateGrounds(networkUuid, vl2Grounds, null);
-        // Retrieve grounds by container and ensure that vl2Grounds is up to date
+        Resource<GroundAttributes> updateGround = Resource.groundBuilder()
+                .id("groundId")
+                .attributes(GroundAttributes.builder()
+                        .voltageLevelId("vl2")
+                        .p(5)
+                        .q(6)
+                        .bus("bus")
+                        .build())
+                .build();
+        cachedClient.updateGrounds(networkUuid, List.of(updateGround), null);
         vl2Grounds = cachedClient.getVoltageLevelGrounds(networkUuid, Resource.INITIAL_VARIANT_NUM, "vl2");
         assertEquals(1, vl2Grounds.size());
         assertEquals(5, vl2Grounds.get(0).getAttributes().getP(), 0.001);

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/CachedNetworkStoreClient.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/CachedNetworkStoreClient.java
@@ -1013,7 +1013,7 @@ public class CachedNetworkStoreClient extends AbstractForwardingNetworkStoreClie
         Optional<Resource<IdentifiableAttributes>> resource = delegate.getIdentifiable(networkUuid, variantNum, id);
         resource.ifPresent(r -> {
             CollectionCache<IdentifiableAttributes> collection = (CollectionCache<IdentifiableAttributes>) networkContainersCaches.get(r.getType()).getCollection(networkUuid, variantNum);
-            collection.addResource(r, false);
+            collection.addResourceIfAbsent(r);
         });
 
         identifiableCallCountByNetworkVariant.computeIfAbsent(p, k -> new MutableInt())

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/CachedNetworkStoreClient.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/CachedNetworkStoreClient.java
@@ -274,6 +274,16 @@ public class CachedNetworkStoreClient extends AbstractForwardingNetworkStoreClie
         }
     }
 
+    @Override
+    public void updateNetworks(List<Resource<NetworkAttributes>> networkResources, AttributeFilter attributeFilter) {
+        delegate.updateNetworks(networkResources, attributeFilter);
+        for (Resource<NetworkAttributes> networkResource : networkResources) {
+            UUID networkUuid = networkResource.getAttributes().getUuid();
+            int variantNum = networkResource.getVariantNum();
+            networksCache.getCollection(networkUuid, variantNum).updateResource(networkResource);
+        }
+    }
+
     private static <T extends IdentifiableAttributes> void cloneCollection(NetworkCollectionIndex<CollectionCache<T>> cache, UUID networkUuid,
                                                                            int sourceVariantNum, int targetVariantNum, ObjectMapper objectMapper,
                                                                            Consumer<Resource<T>> resourcePostProcessor) {
@@ -348,6 +358,14 @@ public class CachedNetworkStoreClient extends AbstractForwardingNetworkStoreClie
     }
 
     @Override
+    public void updateSubstations(UUID networkUuid, List<Resource<SubstationAttributes>> substationResources, AttributeFilter attributeFilter) {
+        delegate.updateSubstations(networkUuid, substationResources, attributeFilter);
+        for (Resource<SubstationAttributes> substationResource : substationResources) {
+            substationsCache.getCollection(networkUuid, substationResource.getVariantNum()).updateResource(substationResource);
+        }
+    }
+
+    @Override
     public void removeSubstations(UUID networkUuid, int variantNum, List<String> substationsId) {
         delegate.removeSubstations(networkUuid, variantNum, substationsId);
         substationsCache.getCollection(networkUuid, variantNum).removeResources(substationsId);
@@ -378,6 +396,14 @@ public class CachedNetworkStoreClient extends AbstractForwardingNetworkStoreClie
     @Override
     public List<Resource<VoltageLevelAttributes>> getVoltageLevels(UUID networkUuid, int variantNum) {
         return voltageLevelsCache.getCollection(networkUuid, variantNum).getResources(networkUuid, variantNum);
+    }
+
+    @Override
+    public void updateVoltageLevels(UUID networkUuid, List<Resource<VoltageLevelAttributes>> voltageLevelResources, AttributeFilter attributeFilter) {
+        delegate.updateVoltageLevels(networkUuid, voltageLevelResources, attributeFilter);
+        for (Resource<VoltageLevelAttributes> voltageLevelResource : voltageLevelResources) {
+            voltageLevelsCache.getCollection(networkUuid, voltageLevelResource.getVariantNum()).updateResource(voltageLevelResource);
+        }
     }
 
     @Override
@@ -547,6 +573,14 @@ public class CachedNetworkStoreClient extends AbstractForwardingNetworkStoreClie
     }
 
     @Override
+    public void updateSwitches(UUID networkUuid, List<Resource<SwitchAttributes>> switchResources, AttributeFilter attributeFilter) {
+        delegate.updateSwitches(networkUuid, switchResources, attributeFilter);
+        for (Resource<SwitchAttributes> switchResource : switchResources) {
+            switchesCache.getCollection(networkUuid, switchResource.getVariantNum()).updateResource(switchResource);
+        }
+    }
+
+    @Override
     public void removeSwitches(UUID networkUuid, int variantNum, List<String> switchesId) {
         delegate.removeSwitches(networkUuid, variantNum, switchesId);
         switchesCache.getCollection(networkUuid, variantNum).removeResources(switchesId);
@@ -580,6 +614,14 @@ public class CachedNetworkStoreClient extends AbstractForwardingNetworkStoreClie
     }
 
     @Override
+    public void updateBusbarSections(UUID networkUuid, List<Resource<BusbarSectionAttributes>> busbarSectionResources, AttributeFilter attributeFilter) {
+        delegate.updateBusbarSections(networkUuid, busbarSectionResources, attributeFilter);
+        for (Resource<BusbarSectionAttributes> busbarSectionResource : busbarSectionResources) {
+            busbarSectionsCache.getCollection(networkUuid, busbarSectionResource.getVariantNum()).updateResource(busbarSectionResource);
+        }
+    }
+
+    @Override
     public List<Resource<BusbarSectionAttributes>> getVoltageLevelBusbarSections(UUID networkUuid, int variantNum, String voltageLevelId) {
         return busbarSectionsCache.getCollection(networkUuid, variantNum).getContainerResources(networkUuid, variantNum, voltageLevelId);
     }
@@ -604,6 +646,14 @@ public class CachedNetworkStoreClient extends AbstractForwardingNetworkStoreClie
     }
 
     @Override
+    public void updateLoads(UUID networkUuid, List<Resource<LoadAttributes>> loadResources, AttributeFilter attributeFilter) {
+        delegate.updateLoads(networkUuid, loadResources, attributeFilter);
+        for (Resource<LoadAttributes> loadResource : loadResources) {
+            loadsCache.getCollection(networkUuid, loadResource.getVariantNum()).updateResource(loadResource);
+        }
+    }
+
+    @Override
     public void createGenerators(UUID networkUuid, List<Resource<GeneratorAttributes>> generatorResources) {
         delegate.createGenerators(networkUuid, generatorResources);
         for (Resource<GeneratorAttributes> generatorResource : generatorResources) {
@@ -620,6 +670,14 @@ public class CachedNetworkStoreClient extends AbstractForwardingNetworkStoreClie
     @Override
     public Optional<Resource<GeneratorAttributes>> getGenerator(UUID networkUuid, int variantNum, String generatorId) {
         return generatorsCache.getCollection(networkUuid, variantNum).getResource(networkUuid, variantNum, generatorId);
+    }
+
+    @Override
+    public void updateGenerators(UUID networkUuid, List<Resource<GeneratorAttributes>> generatorResources, AttributeFilter attributeFilter) {
+        delegate.updateGenerators(networkUuid, generatorResources, attributeFilter);
+        for (Resource<GeneratorAttributes> generatorResource : generatorResources) {
+            generatorsCache.getCollection(networkUuid, generatorResource.getVariantNum()).updateResource(generatorResource);
+        }
     }
 
     @Override
@@ -642,6 +700,14 @@ public class CachedNetworkStoreClient extends AbstractForwardingNetworkStoreClie
     }
 
     @Override
+    public void updateBatteries(UUID networkUuid, List<Resource<BatteryAttributes>> batteryResources, AttributeFilter attributeFilter) {
+        delegate.updateBatteries(networkUuid, batteryResources, attributeFilter);
+        for (Resource<BatteryAttributes> batteryResource : batteryResources) {
+            batteriesCache.getCollection(networkUuid, batteryResource.getVariantNum()).updateResource(batteryResource);
+        }
+    }
+
+    @Override
     public void createTwoWindingsTransformers(UUID networkUuid, List<Resource<TwoWindingsTransformerAttributes>> twoWindingsTransformerResources) {
         delegate.createTwoWindingsTransformers(networkUuid, twoWindingsTransformerResources);
         for (Resource<TwoWindingsTransformerAttributes> twoWindingsTransformerResource : twoWindingsTransformerResources) {
@@ -658,6 +724,14 @@ public class CachedNetworkStoreClient extends AbstractForwardingNetworkStoreClie
     @Override
     public Optional<Resource<TwoWindingsTransformerAttributes>> getTwoWindingsTransformer(UUID networkUuid, int variantNum, String twoWindingsTransformerId) {
         return twoWindingsTransformerCache.getCollection(networkUuid, variantNum).getResource(networkUuid, variantNum, twoWindingsTransformerId);
+    }
+
+    @Override
+    public void updateTwoWindingsTransformers(UUID networkUuid, List<Resource<TwoWindingsTransformerAttributes>> twoWindingsTransformerResources, AttributeFilter attributeFilter) {
+        delegate.updateTwoWindingsTransformers(networkUuid, twoWindingsTransformerResources, attributeFilter);
+        for (Resource<TwoWindingsTransformerAttributes> twoWindingsTransformerResource : twoWindingsTransformerResources) {
+            twoWindingsTransformerCache.getCollection(networkUuid, twoWindingsTransformerResource.getVariantNum()).updateResource(twoWindingsTransformerResource);
+        }
     }
 
     // 3 windings transformer
@@ -682,6 +756,14 @@ public class CachedNetworkStoreClient extends AbstractForwardingNetworkStoreClie
     }
 
     @Override
+    public void updateThreeWindingsTransformers(UUID networkUuid, List<Resource<ThreeWindingsTransformerAttributes>> threeWindingsTransformerResources, AttributeFilter attributeFilter) {
+        delegate.updateThreeWindingsTransformers(networkUuid, threeWindingsTransformerResources, attributeFilter);
+        for (Resource<ThreeWindingsTransformerAttributes> threeWindingsTransformerResource : threeWindingsTransformerResources) {
+            threeWindingsTransformerCache.getCollection(networkUuid, threeWindingsTransformerResource.getVariantNum()).updateResource(threeWindingsTransformerResource);
+        }
+    }
+
+    @Override
     public void createLines(UUID networkUuid, List<Resource<LineAttributes>> lineResources) {
         delegate.createLines(networkUuid, lineResources);
         for (Resource<LineAttributes> lineResource : lineResources) {
@@ -698,6 +780,14 @@ public class CachedNetworkStoreClient extends AbstractForwardingNetworkStoreClie
     @Override
     public Optional<Resource<LineAttributes>> getLine(UUID networkUuid, int variantNum, String lineId) {
         return linesCache.getCollection(networkUuid, variantNum).getResource(networkUuid, variantNum, lineId);
+    }
+
+    @Override
+    public void updateLines(UUID networkUuid, List<Resource<LineAttributes>> lineResources, AttributeFilter attributeFilter) {
+        delegate.updateLines(networkUuid, lineResources, attributeFilter);
+        for (Resource<LineAttributes> lineResource : lineResources) {
+            linesCache.getCollection(networkUuid, lineResource.getVariantNum()).updateResource(lineResource);
+        }
     }
 
     @Override
@@ -720,6 +810,14 @@ public class CachedNetworkStoreClient extends AbstractForwardingNetworkStoreClie
     }
 
     @Override
+    public void updateShuntCompensators(UUID networkUuid, List<Resource<ShuntCompensatorAttributes>> shuntCompensatorResources, AttributeFilter attributeFilter) {
+        delegate.updateShuntCompensators(networkUuid, shuntCompensatorResources, attributeFilter);
+        for (Resource<ShuntCompensatorAttributes> shuntCompensatorResource : shuntCompensatorResources) {
+            shuntCompensatorsCache.getCollection(networkUuid, shuntCompensatorResource.getVariantNum()).updateResource(shuntCompensatorResource);
+        }
+    }
+
+    @Override
     public void createVscConverterStations(UUID networkUuid, List<Resource<VscConverterStationAttributes>> vscConverterStationResources) {
         delegate.createVscConverterStations(networkUuid, vscConverterStationResources);
         for (Resource<VscConverterStationAttributes> vscConverterStationResource : vscConverterStationResources) {
@@ -736,6 +834,14 @@ public class CachedNetworkStoreClient extends AbstractForwardingNetworkStoreClie
     @Override
     public Optional<Resource<VscConverterStationAttributes>> getVscConverterStation(UUID networkUuid, int variantNum, String vscConverterStationId) {
         return vscConverterStationCache.getCollection(networkUuid, variantNum).getResource(networkUuid, variantNum, vscConverterStationId);
+    }
+
+    @Override
+    public void updateVscConverterStations(UUID networkUuid, List<Resource<VscConverterStationAttributes>> vscConverterStationResources, AttributeFilter attributeFilter) {
+        delegate.updateVscConverterStations(networkUuid, vscConverterStationResources, attributeFilter);
+        for (Resource<VscConverterStationAttributes> vscConverterStationResource : vscConverterStationResources) {
+            vscConverterStationCache.getCollection(networkUuid, vscConverterStationResource.getVariantNum()).updateResource(vscConverterStationResource);
+        }
     }
 
     @Override
@@ -758,6 +864,14 @@ public class CachedNetworkStoreClient extends AbstractForwardingNetworkStoreClie
     }
 
     @Override
+    public void updateLccConverterStations(UUID networkUuid, List<Resource<LccConverterStationAttributes>> lccConverterStationResources, AttributeFilter attributeFilter) {
+        delegate.updateLccConverterStations(networkUuid, lccConverterStationResources, attributeFilter);
+        for (Resource<LccConverterStationAttributes> lccConverterStationResource : lccConverterStationResources) {
+            lccConverterStationCache.getCollection(networkUuid, lccConverterStationResource.getVariantNum()).updateResource(lccConverterStationResource);
+        }
+    }
+
+    @Override
     public void createStaticVarCompensators(UUID networkUuid, List<Resource<StaticVarCompensatorAttributes>> svcResources) {
         delegate.createStaticVarCompensators(networkUuid, svcResources);
         for (Resource<StaticVarCompensatorAttributes> svcResource : svcResources) {
@@ -777,6 +891,14 @@ public class CachedNetworkStoreClient extends AbstractForwardingNetworkStoreClie
     }
 
     @Override
+    public void updateStaticVarCompensators(UUID networkUuid, List<Resource<StaticVarCompensatorAttributes>> svcResources, AttributeFilter attributeFilter) {
+        delegate.updateStaticVarCompensators(networkUuid, svcResources, attributeFilter);
+        for (Resource<StaticVarCompensatorAttributes> svcResource : svcResources) {
+            staticVarCompensatorCache.getCollection(networkUuid, svcResource.getVariantNum()).updateResource(svcResource);
+        }
+    }
+
+    @Override
     public void createHvdcLines(UUID networkUuid, List<Resource<HvdcLineAttributes>> hvdcLineResources) {
         delegate.createHvdcLines(networkUuid, hvdcLineResources);
         for (Resource<HvdcLineAttributes> hvdcLineResource : hvdcLineResources) {
@@ -793,6 +915,14 @@ public class CachedNetworkStoreClient extends AbstractForwardingNetworkStoreClie
     @Override
     public Optional<Resource<HvdcLineAttributes>> getHvdcLine(UUID networkUuid, int variantNum, String hvdcLineId) {
         return hvdcLinesCache.getCollection(networkUuid, variantNum).getResource(networkUuid, variantNum, hvdcLineId);
+    }
+
+    @Override
+    public void updateHvdcLines(UUID networkUuid, List<Resource<HvdcLineAttributes>> hvdcLineResources, AttributeFilter attributeFilter) {
+        delegate.updateHvdcLines(networkUuid, hvdcLineResources, attributeFilter);
+        for (Resource<HvdcLineAttributes> hvdcLineResource : hvdcLineResources) {
+            hvdcLinesCache.getCollection(networkUuid, hvdcLineResource.getVariantNum()).updateResource(hvdcLineResource);
+        }
     }
 
     @Override
@@ -819,6 +949,14 @@ public class CachedNetworkStoreClient extends AbstractForwardingNetworkStoreClie
     @Override
     public Optional<Resource<DanglingLineAttributes>> getDanglingLine(UUID networkUuid, int variantNum, String danglingLineId) {
         return danglingLinesCache.getCollection(networkUuid, variantNum).getResource(networkUuid, variantNum, danglingLineId);
+    }
+
+    @Override
+    public void updateDanglingLines(UUID networkUuid, List<Resource<DanglingLineAttributes>> danglingLineResources, AttributeFilter attributeFilter) {
+        delegate.updateDanglingLines(networkUuid, danglingLineResources, attributeFilter);
+        for (Resource<DanglingLineAttributes> danglingLineResource : danglingLineResources) {
+            danglingLinesCache.getCollection(networkUuid, danglingLineResource.getVariantNum()).updateResource(danglingLineResource);
+        }
     }
 
     @Override
@@ -855,6 +993,14 @@ public class CachedNetworkStoreClient extends AbstractForwardingNetworkStoreClie
     }
 
     @Override
+    public void updateTieLines(UUID networkUuid, List<Resource<TieLineAttributes>> tieLineResources, AttributeFilter attributeFilter) {
+        delegate.updateTieLines(networkUuid, tieLineResources, attributeFilter);
+        for (Resource<TieLineAttributes> tieLineResource : tieLineResources) {
+            tieLinesCache.getCollection(networkUuid, tieLineResource.getVariantNum()).updateResource(tieLineResource);
+        }
+    }
+
+    @Override
     public void createGrounds(UUID networkUuid, List<Resource<GroundAttributes>> groundResources) {
         delegate.createGrounds(networkUuid, groundResources);
         for (Resource<GroundAttributes> groundResource : groundResources) {
@@ -870,6 +1016,14 @@ public class CachedNetworkStoreClient extends AbstractForwardingNetworkStoreClie
     @Override
     public Optional<Resource<GroundAttributes>> getGround(UUID networkUuid, int variantNum, String groundId) {
         return groundsCache.getCollection(networkUuid, variantNum).getResource(networkUuid, variantNum, groundId);
+    }
+
+    @Override
+    public void updateGrounds(UUID networkUuid, List<Resource<GroundAttributes>> groundAttributes, AttributeFilter attributeFilter) {
+        delegate.updateGrounds(networkUuid, groundAttributes, attributeFilter);
+        for (Resource<GroundAttributes> groundResource : groundAttributes) {
+            groundsCache.getCollection(networkUuid, groundResource.getVariantNum()).updateResource(groundResource);
+        }
     }
 
     @Override
@@ -900,6 +1054,14 @@ public class CachedNetworkStoreClient extends AbstractForwardingNetworkStoreClie
     @Override
     public Optional<Resource<ConfiguredBusAttributes>> getConfiguredBus(UUID networkUuid, int variantNum, String busId) {
         return configuredBusesCache.getCollection(networkUuid, variantNum).getResource(networkUuid, variantNum, busId);
+    }
+
+    @Override
+    public void updateConfiguredBuses(UUID networkUuid, List<Resource<ConfiguredBusAttributes>> busResources, AttributeFilter attributeFilter) {
+        delegate.updateConfiguredBuses(networkUuid, busResources, attributeFilter);
+        for (Resource<ConfiguredBusAttributes> busResource : busResources) {
+            configuredBusesCache.getCollection(networkUuid, busResource.getVariantNum()).updateResource(busResource);
+        }
     }
 
     @Override

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/CachedNetworkStoreClient.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/CachedNetworkStoreClient.java
@@ -1175,7 +1175,8 @@ public class CachedNetworkStoreClient extends AbstractForwardingNetworkStoreClie
         Optional<Resource<IdentifiableAttributes>> resource = delegate.getIdentifiable(networkUuid, variantNum, id);
         resource.ifPresent(r -> {
             CollectionCache<IdentifiableAttributes> collection = (CollectionCache<IdentifiableAttributes>) networkContainersCaches.get(r.getType()).getCollection(networkUuid, variantNum);
-            collection.addResourceIfAbsent(r);
+            // we already checked that the resource is not in the cache so we can directly put it in the cache
+            collection.addOrReplaceResource(r);
         });
 
         identifiableCallCountByNetworkVariant.computeIfAbsent(p, k -> new MutableInt())

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/CachedNetworkStoreClient.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/CachedNetworkStoreClient.java
@@ -274,16 +274,6 @@ public class CachedNetworkStoreClient extends AbstractForwardingNetworkStoreClie
         }
     }
 
-    @Override
-    public void updateNetworks(List<Resource<NetworkAttributes>> networkResources, AttributeFilter attributeFilter) {
-        delegate.updateNetworks(networkResources, attributeFilter);
-        for (Resource<NetworkAttributes> networkResource : networkResources) {
-            UUID networkUuid = networkResource.getAttributes().getUuid();
-            int variantNum = networkResource.getVariantNum();
-            networksCache.getCollection(networkUuid, variantNum).updateResource(networkResource);
-        }
-    }
-
     private static <T extends IdentifiableAttributes> void cloneCollection(NetworkCollectionIndex<CollectionCache<T>> cache, UUID networkUuid,
                                                                            int sourceVariantNum, int targetVariantNum, ObjectMapper objectMapper,
                                                                            Consumer<Resource<T>> resourcePostProcessor) {
@@ -358,14 +348,6 @@ public class CachedNetworkStoreClient extends AbstractForwardingNetworkStoreClie
     }
 
     @Override
-    public void updateSubstations(UUID networkUuid, List<Resource<SubstationAttributes>> substationResources, AttributeFilter attributeFilter) {
-        delegate.updateSubstations(networkUuid, substationResources, attributeFilter);
-        for (Resource<SubstationAttributes> substationResource : substationResources) {
-            substationsCache.getCollection(networkUuid, substationResource.getVariantNum()).updateResource(substationResource);
-        }
-    }
-
-    @Override
     public void removeSubstations(UUID networkUuid, int variantNum, List<String> substationsId) {
         delegate.removeSubstations(networkUuid, variantNum, substationsId);
         substationsCache.getCollection(networkUuid, variantNum).removeResources(substationsId);
@@ -396,14 +378,6 @@ public class CachedNetworkStoreClient extends AbstractForwardingNetworkStoreClie
     @Override
     public List<Resource<VoltageLevelAttributes>> getVoltageLevels(UUID networkUuid, int variantNum) {
         return voltageLevelsCache.getCollection(networkUuid, variantNum).getResources(networkUuid, variantNum);
-    }
-
-    @Override
-    public void updateVoltageLevels(UUID networkUuid, List<Resource<VoltageLevelAttributes>> voltageLevelResources, AttributeFilter attributeFilter) {
-        delegate.updateVoltageLevels(networkUuid, voltageLevelResources, attributeFilter);
-        for (Resource<VoltageLevelAttributes> voltageLevelResource : voltageLevelResources) {
-            voltageLevelsCache.getCollection(networkUuid, voltageLevelResource.getVariantNum()).updateResource(voltageLevelResource);
-        }
     }
 
     @Override
@@ -573,14 +547,6 @@ public class CachedNetworkStoreClient extends AbstractForwardingNetworkStoreClie
     }
 
     @Override
-    public void updateSwitches(UUID networkUuid, List<Resource<SwitchAttributes>> switchResources, AttributeFilter attributeFilter) {
-        delegate.updateSwitches(networkUuid, switchResources, attributeFilter);
-        for (Resource<SwitchAttributes> switchResource : switchResources) {
-            switchesCache.getCollection(networkUuid, switchResource.getVariantNum()).updateResource(switchResource);
-        }
-    }
-
-    @Override
     public void removeSwitches(UUID networkUuid, int variantNum, List<String> switchesId) {
         delegate.removeSwitches(networkUuid, variantNum, switchesId);
         switchesCache.getCollection(networkUuid, variantNum).removeResources(switchesId);
@@ -614,14 +580,6 @@ public class CachedNetworkStoreClient extends AbstractForwardingNetworkStoreClie
     }
 
     @Override
-    public void updateBusbarSections(UUID networkUuid, List<Resource<BusbarSectionAttributes>> busbarSectionResources, AttributeFilter attributeFilter) {
-        delegate.updateBusbarSections(networkUuid, busbarSectionResources, attributeFilter);
-        for (Resource<BusbarSectionAttributes> busbarSectionResource : busbarSectionResources) {
-            busbarSectionsCache.getCollection(networkUuid, busbarSectionResource.getVariantNum()).updateResource(busbarSectionResource);
-        }
-    }
-
-    @Override
     public List<Resource<BusbarSectionAttributes>> getVoltageLevelBusbarSections(UUID networkUuid, int variantNum, String voltageLevelId) {
         return busbarSectionsCache.getCollection(networkUuid, variantNum).getContainerResources(networkUuid, variantNum, voltageLevelId);
     }
@@ -646,14 +604,6 @@ public class CachedNetworkStoreClient extends AbstractForwardingNetworkStoreClie
     }
 
     @Override
-    public void updateLoads(UUID networkUuid, List<Resource<LoadAttributes>> loadResources, AttributeFilter attributeFilter) {
-        delegate.updateLoads(networkUuid, loadResources, attributeFilter);
-        for (Resource<LoadAttributes> loadResource : loadResources) {
-            loadsCache.getCollection(networkUuid, loadResource.getVariantNum()).updateResource(loadResource);
-        }
-    }
-
-    @Override
     public void createGenerators(UUID networkUuid, List<Resource<GeneratorAttributes>> generatorResources) {
         delegate.createGenerators(networkUuid, generatorResources);
         for (Resource<GeneratorAttributes> generatorResource : generatorResources) {
@@ -670,14 +620,6 @@ public class CachedNetworkStoreClient extends AbstractForwardingNetworkStoreClie
     @Override
     public Optional<Resource<GeneratorAttributes>> getGenerator(UUID networkUuid, int variantNum, String generatorId) {
         return generatorsCache.getCollection(networkUuid, variantNum).getResource(networkUuid, variantNum, generatorId);
-    }
-
-    @Override
-    public void updateGenerators(UUID networkUuid, List<Resource<GeneratorAttributes>> generatorResources, AttributeFilter attributeFilter) {
-        delegate.updateGenerators(networkUuid, generatorResources, attributeFilter);
-        for (Resource<GeneratorAttributes> generatorResource : generatorResources) {
-            generatorsCache.getCollection(networkUuid, generatorResource.getVariantNum()).updateResource(generatorResource);
-        }
     }
 
     @Override
@@ -700,14 +642,6 @@ public class CachedNetworkStoreClient extends AbstractForwardingNetworkStoreClie
     }
 
     @Override
-    public void updateBatteries(UUID networkUuid, List<Resource<BatteryAttributes>> batteryResources, AttributeFilter attributeFilter) {
-        delegate.updateBatteries(networkUuid, batteryResources, attributeFilter);
-        for (Resource<BatteryAttributes> batteryResource : batteryResources) {
-            batteriesCache.getCollection(networkUuid, batteryResource.getVariantNum()).updateResource(batteryResource);
-        }
-    }
-
-    @Override
     public void createTwoWindingsTransformers(UUID networkUuid, List<Resource<TwoWindingsTransformerAttributes>> twoWindingsTransformerResources) {
         delegate.createTwoWindingsTransformers(networkUuid, twoWindingsTransformerResources);
         for (Resource<TwoWindingsTransformerAttributes> twoWindingsTransformerResource : twoWindingsTransformerResources) {
@@ -724,14 +658,6 @@ public class CachedNetworkStoreClient extends AbstractForwardingNetworkStoreClie
     @Override
     public Optional<Resource<TwoWindingsTransformerAttributes>> getTwoWindingsTransformer(UUID networkUuid, int variantNum, String twoWindingsTransformerId) {
         return twoWindingsTransformerCache.getCollection(networkUuid, variantNum).getResource(networkUuid, variantNum, twoWindingsTransformerId);
-    }
-
-    @Override
-    public void updateTwoWindingsTransformers(UUID networkUuid, List<Resource<TwoWindingsTransformerAttributes>> twoWindingsTransformerResources, AttributeFilter attributeFilter) {
-        delegate.updateTwoWindingsTransformers(networkUuid, twoWindingsTransformerResources, attributeFilter);
-        for (Resource<TwoWindingsTransformerAttributes> twoWindingsTransformerResource : twoWindingsTransformerResources) {
-            twoWindingsTransformerCache.getCollection(networkUuid, twoWindingsTransformerResource.getVariantNum()).updateResource(twoWindingsTransformerResource);
-        }
     }
 
     // 3 windings transformer
@@ -756,14 +682,6 @@ public class CachedNetworkStoreClient extends AbstractForwardingNetworkStoreClie
     }
 
     @Override
-    public void updateThreeWindingsTransformers(UUID networkUuid, List<Resource<ThreeWindingsTransformerAttributes>> threeWindingsTransformerResources, AttributeFilter attributeFilter) {
-        delegate.updateThreeWindingsTransformers(networkUuid, threeWindingsTransformerResources, attributeFilter);
-        for (Resource<ThreeWindingsTransformerAttributes> threeWindingsTransformerResource : threeWindingsTransformerResources) {
-            threeWindingsTransformerCache.getCollection(networkUuid, threeWindingsTransformerResource.getVariantNum()).updateResource(threeWindingsTransformerResource);
-        }
-    }
-
-    @Override
     public void createLines(UUID networkUuid, List<Resource<LineAttributes>> lineResources) {
         delegate.createLines(networkUuid, lineResources);
         for (Resource<LineAttributes> lineResource : lineResources) {
@@ -780,14 +698,6 @@ public class CachedNetworkStoreClient extends AbstractForwardingNetworkStoreClie
     @Override
     public Optional<Resource<LineAttributes>> getLine(UUID networkUuid, int variantNum, String lineId) {
         return linesCache.getCollection(networkUuid, variantNum).getResource(networkUuid, variantNum, lineId);
-    }
-
-    @Override
-    public void updateLines(UUID networkUuid, List<Resource<LineAttributes>> lineResources, AttributeFilter attributeFilter) {
-        delegate.updateLines(networkUuid, lineResources, attributeFilter);
-        for (Resource<LineAttributes> lineResource : lineResources) {
-            linesCache.getCollection(networkUuid, lineResource.getVariantNum()).updateResource(lineResource);
-        }
     }
 
     @Override
@@ -810,14 +720,6 @@ public class CachedNetworkStoreClient extends AbstractForwardingNetworkStoreClie
     }
 
     @Override
-    public void updateShuntCompensators(UUID networkUuid, List<Resource<ShuntCompensatorAttributes>> shuntCompensatorResources, AttributeFilter attributeFilter) {
-        delegate.updateShuntCompensators(networkUuid, shuntCompensatorResources, attributeFilter);
-        for (Resource<ShuntCompensatorAttributes> shuntCompensatorResource : shuntCompensatorResources) {
-            shuntCompensatorsCache.getCollection(networkUuid, shuntCompensatorResource.getVariantNum()).updateResource(shuntCompensatorResource);
-        }
-    }
-
-    @Override
     public void createVscConverterStations(UUID networkUuid, List<Resource<VscConverterStationAttributes>> vscConverterStationResources) {
         delegate.createVscConverterStations(networkUuid, vscConverterStationResources);
         for (Resource<VscConverterStationAttributes> vscConverterStationResource : vscConverterStationResources) {
@@ -834,14 +736,6 @@ public class CachedNetworkStoreClient extends AbstractForwardingNetworkStoreClie
     @Override
     public Optional<Resource<VscConverterStationAttributes>> getVscConverterStation(UUID networkUuid, int variantNum, String vscConverterStationId) {
         return vscConverterStationCache.getCollection(networkUuid, variantNum).getResource(networkUuid, variantNum, vscConverterStationId);
-    }
-
-    @Override
-    public void updateVscConverterStations(UUID networkUuid, List<Resource<VscConverterStationAttributes>> vscConverterStationResources, AttributeFilter attributeFilter) {
-        delegate.updateVscConverterStations(networkUuid, vscConverterStationResources, attributeFilter);
-        for (Resource<VscConverterStationAttributes> vscConverterStationResource : vscConverterStationResources) {
-            vscConverterStationCache.getCollection(networkUuid, vscConverterStationResource.getVariantNum()).updateResource(vscConverterStationResource);
-        }
     }
 
     @Override
@@ -864,14 +758,6 @@ public class CachedNetworkStoreClient extends AbstractForwardingNetworkStoreClie
     }
 
     @Override
-    public void updateLccConverterStations(UUID networkUuid, List<Resource<LccConverterStationAttributes>> lccConverterStationResources, AttributeFilter attributeFilter) {
-        delegate.updateLccConverterStations(networkUuid, lccConverterStationResources, attributeFilter);
-        for (Resource<LccConverterStationAttributes> lccConverterStationResource : lccConverterStationResources) {
-            lccConverterStationCache.getCollection(networkUuid, lccConverterStationResource.getVariantNum()).updateResource(lccConverterStationResource);
-        }
-    }
-
-    @Override
     public void createStaticVarCompensators(UUID networkUuid, List<Resource<StaticVarCompensatorAttributes>> svcResources) {
         delegate.createStaticVarCompensators(networkUuid, svcResources);
         for (Resource<StaticVarCompensatorAttributes> svcResource : svcResources) {
@@ -891,14 +777,6 @@ public class CachedNetworkStoreClient extends AbstractForwardingNetworkStoreClie
     }
 
     @Override
-    public void updateStaticVarCompensators(UUID networkUuid, List<Resource<StaticVarCompensatorAttributes>> svcResources, AttributeFilter attributeFilter) {
-        delegate.updateStaticVarCompensators(networkUuid, svcResources, attributeFilter);
-        for (Resource<StaticVarCompensatorAttributes> svcResource : svcResources) {
-            staticVarCompensatorCache.getCollection(networkUuid, svcResource.getVariantNum()).updateResource(svcResource);
-        }
-    }
-
-    @Override
     public void createHvdcLines(UUID networkUuid, List<Resource<HvdcLineAttributes>> hvdcLineResources) {
         delegate.createHvdcLines(networkUuid, hvdcLineResources);
         for (Resource<HvdcLineAttributes> hvdcLineResource : hvdcLineResources) {
@@ -915,14 +793,6 @@ public class CachedNetworkStoreClient extends AbstractForwardingNetworkStoreClie
     @Override
     public Optional<Resource<HvdcLineAttributes>> getHvdcLine(UUID networkUuid, int variantNum, String hvdcLineId) {
         return hvdcLinesCache.getCollection(networkUuid, variantNum).getResource(networkUuid, variantNum, hvdcLineId);
-    }
-
-    @Override
-    public void updateHvdcLines(UUID networkUuid, List<Resource<HvdcLineAttributes>> hvdcLineResources, AttributeFilter attributeFilter) {
-        delegate.updateHvdcLines(networkUuid, hvdcLineResources, attributeFilter);
-        for (Resource<HvdcLineAttributes> hvdcLineResource : hvdcLineResources) {
-            hvdcLinesCache.getCollection(networkUuid, hvdcLineResource.getVariantNum()).updateResource(hvdcLineResource);
-        }
     }
 
     @Override
@@ -949,14 +819,6 @@ public class CachedNetworkStoreClient extends AbstractForwardingNetworkStoreClie
     @Override
     public Optional<Resource<DanglingLineAttributes>> getDanglingLine(UUID networkUuid, int variantNum, String danglingLineId) {
         return danglingLinesCache.getCollection(networkUuid, variantNum).getResource(networkUuid, variantNum, danglingLineId);
-    }
-
-    @Override
-    public void updateDanglingLines(UUID networkUuid, List<Resource<DanglingLineAttributes>> danglingLineResources, AttributeFilter attributeFilter) {
-        delegate.updateDanglingLines(networkUuid, danglingLineResources, attributeFilter);
-        for (Resource<DanglingLineAttributes> danglingLineResource : danglingLineResources) {
-            danglingLinesCache.getCollection(networkUuid, danglingLineResource.getVariantNum()).updateResource(danglingLineResource);
-        }
     }
 
     @Override
@@ -993,14 +855,6 @@ public class CachedNetworkStoreClient extends AbstractForwardingNetworkStoreClie
     }
 
     @Override
-    public void updateTieLines(UUID networkUuid, List<Resource<TieLineAttributes>> tieLineResources, AttributeFilter attributeFilter) {
-        delegate.updateTieLines(networkUuid, tieLineResources, attributeFilter);
-        for (Resource<TieLineAttributes> tieLineResource : tieLineResources) {
-            tieLinesCache.getCollection(networkUuid, tieLineResource.getVariantNum()).updateResource(tieLineResource);
-        }
-    }
-
-    @Override
     public void createGrounds(UUID networkUuid, List<Resource<GroundAttributes>> groundResources) {
         delegate.createGrounds(networkUuid, groundResources);
         for (Resource<GroundAttributes> groundResource : groundResources) {
@@ -1016,14 +870,6 @@ public class CachedNetworkStoreClient extends AbstractForwardingNetworkStoreClie
     @Override
     public Optional<Resource<GroundAttributes>> getGround(UUID networkUuid, int variantNum, String groundId) {
         return groundsCache.getCollection(networkUuid, variantNum).getResource(networkUuid, variantNum, groundId);
-    }
-
-    @Override
-    public void updateGrounds(UUID networkUuid, List<Resource<GroundAttributes>> groundAttributes, AttributeFilter attributeFilter) {
-        delegate.updateGrounds(networkUuid, groundAttributes, attributeFilter);
-        for (Resource<GroundAttributes> groundResource : groundAttributes) {
-            groundsCache.getCollection(networkUuid, groundResource.getVariantNum()).updateResource(groundResource);
-        }
     }
 
     @Override
@@ -1054,14 +900,6 @@ public class CachedNetworkStoreClient extends AbstractForwardingNetworkStoreClie
     @Override
     public Optional<Resource<ConfiguredBusAttributes>> getConfiguredBus(UUID networkUuid, int variantNum, String busId) {
         return configuredBusesCache.getCollection(networkUuid, variantNum).getResource(networkUuid, variantNum, busId);
-    }
-
-    @Override
-    public void updateConfiguredBuses(UUID networkUuid, List<Resource<ConfiguredBusAttributes>> busResources, AttributeFilter attributeFilter) {
-        delegate.updateConfiguredBuses(networkUuid, busResources, attributeFilter);
-        for (Resource<ConfiguredBusAttributes> busResource : busResources) {
-            configuredBusesCache.getCollection(networkUuid, busResource.getVariantNum()).updateResource(busResource);
-        }
     }
 
     @Override
@@ -1175,7 +1013,7 @@ public class CachedNetworkStoreClient extends AbstractForwardingNetworkStoreClie
         Optional<Resource<IdentifiableAttributes>> resource = delegate.getIdentifiable(networkUuid, variantNum, id);
         resource.ifPresent(r -> {
             CollectionCache<IdentifiableAttributes> collection = (CollectionCache<IdentifiableAttributes>) networkContainersCaches.get(r.getType()).getCollection(networkUuid, variantNum);
-            collection.addResource(r);
+            collection.addResource(r, false);
         });
 
         identifiableCallCountByNetworkVariant.computeIfAbsent(p, k -> new MutableInt())

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/CollectionCache.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/CollectionCache.java
@@ -294,6 +294,15 @@ public class CollectionCache<T extends IdentifiableAttributes> {
     }
 
     /**
+     * Replace resource of the collection with {@code resource}.
+     *
+     * @param resource the resource to update
+     */
+    public void updateResource(Resource<T> resource) {
+        addOrReplaceResource(resource);
+    }
+
+    /**
      * Remove a resource from the collection.
      *
      * @param id the id of the resource to remove

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/CollectionCache.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/CollectionCache.java
@@ -407,7 +407,7 @@ public class CollectionCache<T extends IdentifiableAttributes> {
     /**
      * Add extension attributes in the cache for single extension attributes loading.<br/>
      * This method is only used to get extension attributes from the server so even if it adds some checks and reduces performance by a tiny bit,
-     * we avoid to overwrite already loaded extension attributes because they are referenced in the resources or resourcesByContainerId map,
+     * we avoid to overwrite already loaded extension attributes because they are referenced in the extensionAttributes field of the resources or resourcesByContainerId map,
      * but also directly in any identifiable with the iidm api.
      */
     private void addExtensionAttributesToCache(String identifiableId, String extensionName, ExtensionAttributes extensionAttributes) {
@@ -457,7 +457,7 @@ public class CollectionCache<T extends IdentifiableAttributes> {
             Map<String, ExtensionAttributes> extensionAttributes = delegate.getAllExtensionsAttributesByIdentifiableId(networkUuid, variantNum, type, identifiableId);
             if (extensionAttributes != null) {
                 addAllExtensionAttributesToCache(identifiableId, extensionAttributes);
-                return extensionAttributes;
+                return getCachedExtensionAttributes(identifiableId);
             }
         }
         return Map.of();
@@ -474,7 +474,7 @@ public class CollectionCache<T extends IdentifiableAttributes> {
     /**
      * Add extension attributes to the cache when loading all the extension attributes of an identifiable.<br/>
      * This method is only used to get extension attributes from the server so even if it adds some checks and reduces performance by a tiny bit,
-     * we avoid to overwrite already loaded extension attributes because they are referenced in the resources or resourcesByContainerId map,
+     * we avoid to overwrite already loaded extension attributes because they are referenced in the extensionAttributes field of the resources or resourcesByContainerId map,
      * but also directly in any identifiable with the iidm api.
      */
     private void addAllExtensionAttributesToCache(String id, Map<String, ExtensionAttributes> extensionAttributes) {

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/CollectionCacheTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/CollectionCacheTest.java
@@ -246,23 +246,24 @@ public class CollectionCacheTest {
     }
 
     @Test
-    public void getThenUpdateThenGetContainerTest() {
+    public void updateResourceTest() {
         assertFalse(oneLoaderCalled);
         assertFalse(containerLoaderCalled);
         assertFalse(allLoaderCalled);
-        Resource<LoadAttributes> resource = collectionCache.getResource(NETWORK_UUID, Resource.INITIAL_VARIANT_NUM, "l1").orElseThrow(IllegalStateException::new);
-        assertEquals("vl1", resource.getAttributes().getVoltageLevelId());
-        assertTrue(oneLoaderCalled);
+        Resource<LoadAttributes> newL1 = Resource.loadBuilder()
+                .id("l1")
+                .attributes(LoadAttributes.builder()
+                        .voltageLevelId("vl999")
+                        .build())
+                .build();
+        collectionCache.updateResource(newL1);
+        assertFalse(oneLoaderCalled);
         assertFalse(containerLoaderCalled);
         assertFalse(allLoaderCalled);
-        resource.getAttributes().setVoltageLevelId("vl999");
-        List<Resource<LoadAttributes>> containerResources = collectionCache.getContainerResources(NETWORK_UUID, Resource.INITIAL_VARIANT_NUM, "vl1");
-        oneLoaderCalled = false;
+        assertEquals("vl999", collectionCache.getResource(NETWORK_UUID, Resource.INITIAL_VARIANT_NUM, "l1").orElseThrow(IllegalStateException::new).getAttributes().getVoltageLevelId());
         assertFalse(oneLoaderCalled);
-        assertTrue(containerLoaderCalled);
+        assertFalse(containerLoaderCalled);
         assertFalse(allLoaderCalled);
-        Resource<LoadAttributes> modifiedL1 = createResource("l1", "vl999");
-        assertEquals(Arrays.asList(modifiedL1, l2), containerResources);
     }
 
     @Test
@@ -270,18 +271,22 @@ public class CollectionCacheTest {
         assertFalse(oneLoaderCalled);
         assertFalse(containerLoaderCalled);
         assertFalse(allLoaderCalled);
-        Resource<LoadAttributes> resource = collectionCache.getResource(NETWORK_UUID, Resource.INITIAL_VARIANT_NUM, "l1").orElseThrow(IllegalStateException::new);
-        assertEquals("vl1", resource.getAttributes().getVoltageLevelId());
+        assertEquals("vl1", collectionCache.getResource(NETWORK_UUID, Resource.INITIAL_VARIANT_NUM, "l1").orElseThrow(IllegalStateException::new).getAttributes().getVoltageLevelId());
         assertTrue(oneLoaderCalled);
         assertFalse(containerLoaderCalled);
         assertFalse(allLoaderCalled);
-        resource.getAttributes().setVoltageLevelId("vl999");
-        resource = collectionCache.getResource(NETWORK_UUID, Resource.INITIAL_VARIANT_NUM, "l1").orElseThrow(IllegalStateException::new);
+        Resource<LoadAttributes> newL1 = Resource.loadBuilder()
+                .id("l1")
+                .attributes(LoadAttributes.builder()
+                        .voltageLevelId("vl999")
+                        .build())
+                .build();
         oneLoaderCalled = false;
+        collectionCache.updateResource(newL1);
         assertFalse(oneLoaderCalled);
         assertFalse(containerLoaderCalled);
         assertFalse(allLoaderCalled);
-        assertEquals("vl999", resource.getAttributes().getVoltageLevelId());
+        assertEquals("vl999", collectionCache.getResource(NETWORK_UUID, Resource.INITIAL_VARIANT_NUM, "l1").orElseThrow(IllegalStateException::new).getAttributes().getVoltageLevelId());
     }
 
     @Test

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/CollectionCacheTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/CollectionCacheTest.java
@@ -539,4 +539,16 @@ public class CollectionCacheTest {
         assertFalse(mockNetworkStoreClient.isExtensionAttributesLoaderByIdCalled());
         assertFalse(mockNetworkStoreClient.isExtensionAttributesLoaderByResourceTypeCalled());
     }
+
+    @Test
+    public void createThrowTest() {
+        assertFalse(oneLoaderCalled);
+        assertFalse(containerLoaderCalled);
+        assertFalse(allLoaderCalled);
+        // Create a resource in the cache
+        collectionCache.createResource(l4);
+        // Create it again, it should throw because the resource already exists in the cache
+        // This does not happen when we use the IIDM api because we check if the resource already exists in the network
+        assertThrows(PowsyblException.class, () -> collectionCache.createResource(l4));
+    }
 }

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/MockNetworkStoreClient.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/MockNetworkStoreClient.java
@@ -21,30 +21,21 @@ import java.util.UUID;
 @Getter
 @Setter
 class MockNetworkStoreClient implements NetworkStoreClient {
-    private final ActivePowerControlAttributes apc1;
-    private final ActivePowerControlAttributes apc2;
-    private final OperatingStatusAttributes os1;
     private boolean extensionAttributeLoaderCalled = false;
     private boolean extensionAttributesLoaderByResourceTypeAndNameCalled = false;
     private boolean extensionAttributesLoaderByIdCalled = false;
     private boolean extensionAttributesLoaderByResourceTypeCalled = false;
-
-    public MockNetworkStoreClient(ActivePowerControlAttributes apc1, ActivePowerControlAttributes apc2, OperatingStatusAttributes os1) {
-        this.apc1 = apc1;
-        this.apc2 = apc2;
-        this.os1 = os1;
-    }
 
     // Methods used in tests
     @Override
     public Optional<ExtensionAttributes> getExtensionAttributes(UUID networkUuid, int variantNum, ResourceType resourceType, String identifiableId, String extensionName) {
         extensionAttributeLoaderCalled = true;
         if (identifiableId.equals("l1") && extensionName.equals("operatingStatus")) {
-            return Optional.of(os1);
+            return Optional.of(createOperatinStatusAttributes());
         } else if (identifiableId.equals("l1") && extensionName.equals("activePowerControl")) {
-            return Optional.of(apc1);
+            return Optional.of(createActivePowerControlAttributes1());
         } else if (identifiableId.equals("l2") && extensionName.equals("activePowerControl")) {
-            return Optional.of(apc2);
+            return Optional.of(createActivePowerControlAttributes2());
         }
         return Optional.empty();
     }
@@ -53,7 +44,7 @@ class MockNetworkStoreClient implements NetworkStoreClient {
     public Map<String, ExtensionAttributes> getAllExtensionsAttributesByResourceTypeAndExtensionName(UUID networkUuid, int variantNum, ResourceType resourceType, String extensionName) {
         extensionAttributesLoaderByResourceTypeAndNameCalled = true;
         if (extensionName.equals("activePowerControl")) {
-            return Map.of("l1", apc1, "l2", apc2);
+            return Map.of("l1", createActivePowerControlAttributes1(), "l2", createActivePowerControlAttributes2());
         }
         return Map.of();
     }
@@ -62,9 +53,9 @@ class MockNetworkStoreClient implements NetworkStoreClient {
     public Map<String, ExtensionAttributes> getAllExtensionsAttributesByIdentifiableId(UUID networkUuid, int variantNum, ResourceType resourceType, String identifiableId) {
         extensionAttributesLoaderByIdCalled = true;
         if (identifiableId.equals("l1")) {
-            return Map.of("activePowerControl", apc1, "operatingStatus", os1);
+            return Map.of("activePowerControl", createActivePowerControlAttributes1(), "operatingStatus", createOperatinStatusAttributes());
         } else if (identifiableId.equals("l2")) {
-            return Map.of("activePowerControl", apc2);
+            return Map.of("activePowerControl", createActivePowerControlAttributes2());
         }
         return Map.of();
     }
@@ -73,9 +64,31 @@ class MockNetworkStoreClient implements NetworkStoreClient {
     public Map<String, Map<String, ExtensionAttributes>> getAllExtensionsAttributesByResourceType(UUID networkUuid, int variantNum, ResourceType resourceType) {
         extensionAttributesLoaderByResourceTypeCalled = true;
         if (resourceType == ResourceType.LOAD) {
-            return Map.of("l1", Map.of("activePowerControl", apc1, "operatingStatus", os1), "l2", Map.of("activePowerControl", apc2));
+            return Map.of("l1", Map.of("activePowerControl", createActivePowerControlAttributes1(), "operatingStatus", createOperatinStatusAttributes()), "l2", Map.of("activePowerControl", createActivePowerControlAttributes2()));
         }
         return Map.of();
+    }
+
+    private ActivePowerControlAttributes createActivePowerControlAttributes1() {
+        return ActivePowerControlAttributes.builder()
+                .droop(5.2)
+                .participate(true)
+                .participationFactor(0.5)
+                .build();
+    }
+
+    private ActivePowerControlAttributes createActivePowerControlAttributes2() {
+        return ActivePowerControlAttributes.builder()
+                .droop(6)
+                .participate(false)
+                .participationFactor(0.5)
+                .build();
+    }
+
+    private OperatingStatusAttributes createOperatinStatusAttributes() {
+        return OperatingStatusAttributes.builder()
+                .operatingStatus("foo")
+                .build();
     }
 
     // Methods below are not used in tests


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
In CollectionCache, we sometimes overwrite the existing resource in the cache with the one retrieved from the server. This leads to bugs and inconsistencies especially with extensions. For example, if we load an equipment in the resources cache (Generator@1), then override this equipment in the cache (by loading it a second time by container => Generator@2).  
After that, when we load the extension attributes in the current cached equipment Generator@2, changes are not reflected in the initial reference (Generator@1).

I made a simple repeat here:
```java
    @Test
    public void testExtensionContainer() {
        try (NetworkStoreService service = createNetworkStoreService(randomServerPort)) {
            Network network = EurostagTutorialExample1Factory.create(service.getNetworkFactory());
            Generator gen = network.getGenerator("GEN");
            gen.newExtension(ActivePowerControlAdder.class)
                    .withParticipate(true)
                    .withDroop(6.3f)
                    .add();
            service.flush(network);
        }

        try (NetworkStoreService service = createNetworkStoreService(randomServerPort)) {
            Network network = service.getNetwork(service.getNetworkIds().keySet().iterator().next());
            // Load generator in CollectionCache (stored in resources map as Generator@1)
            Generator gen = network.getGenerator("GEN");
            // When loading all generators of voltage level, it overwrite the generator previously loaded and store it again in CollectionCache (it's now stored in resources map as Generator@2)
            // The synchronization between gen and the resources map is lost as the reference changed, any changes done in CollectionCache to Generator@2 won't affect gen
            // as it does not reference the same object anymore.
            // If instead, I load the extension before traversing the network, it works fine as the extension attributes is loaded in the correct reference
            // assertNotNull(gen.getExtension(ActivePowerControl.class)); working assertion
            gen.getTerminal().getVoltageLevel().getGenerators();
            // When we load the extension attributes in the cache, "gen" is not updated as the extension attributes are loaded in Generator@2.
            assertNotNull(gen.getExtension(ActivePowerControl.class));
        }
    }
```
It also happened before implementation of lazy loading of extensions in some specific edge cases like (these cases are less visible):
```java
    @Test
    public void testCloneVariantCache() {
        try (NetworkStoreService service = createNetworkStoreService(randomServerPort)) {
            Network network = EurostagTutorialExample1Factory.create(service.getNetworkFactory());
            service.flush(network);
        }

        try (NetworkStoreService service = createNetworkStoreService(randomServerPort)) {
            Network network = service.getNetwork(service.getNetworkIds().keySet().iterator().next());
            Generator gen = network.getGenerator("GEN"); //resource 1
            gen.newExtension(ActivePowerControlAdder.class)
                    .withParticipate(true)
                    .withDroop(6.3f)
                    .add();
            assertNotNull(gen.getExtension(ActivePowerControl.class));
            gen.getTerminal().getVoltageLevel().getGenerators(); // resource1 => resource2
            gen.setMaxP(12.5);
            assertNotNull(gen.getExtension(ActivePowerControl.class));
            network.getVariantManager().cloneVariant(VariantManagerConstants.INITIAL_VARIANT_ID, "newvariant");
            network.getVariantManager().setWorkingVariant("newvariant");
            assertNotNull(gen.getExtension(ActivePowerControl.class));
            service.flush(network);
        }
  }
```
**What is the current behavior?**
Already cached resources and extensions can be overwritten in the cache in some cases. For example when loading an identifiable then loading all identifiables of the voltage level or collection. As explained above, it can create inconsistencies (see regression test added in this PR).


**What is the new behavior (if this is a feature change)?**
* This PR changes the current behavior so that we never overwrite resources in the cache except on createResource() or updateResource(). For example, all methods retrieving resources from server (getGenerators, getVoltageLevelGenerators, etc.) add the resource to the cache only if it does not already exist 
* createResource() should always create new resources, we added a check to ensure that it does not try to add a resource existing in the cache
* For the moment, updateResource() is always called in the IIDM api with a modified resource, there is no way to pass a new resource for now: https://github.com/powsybl/powsybl-network-store/blob/6a31f41a02fd143a59f706e211f6d101bcaf707e/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractIdentifiableImpl.java#L47-L54
Thus, the IIDM object is always the same as the cached resource object.
To maintain the API consistency, we covered the case where we could pass a new Resource to updateResource(new Resource()). In this case, we want to update the resource cache with this new resource and we don't want to keep the synchronisation with the IIDM object in the NetworkObjectIndex (as it's not the same anymore). Also it guarantees consistency between cached resources and server resources. This needs further implementation in NetworkObjectIndex to be fully supported and used.
* In order to avoid overwriting resources in the cache, we use Map.putIfAbsent() which has an overhead compared with Map.put() or Map.putAll(). From testing in the application, there is no visible performance drop, so it seems reasonable.  

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No