### PR TITLE
fix regulating by setting phasetapchanger equals and hashcode

### DIFF
--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractTapChanger.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractTapChanger.java
@@ -41,6 +41,10 @@ abstract class AbstractTapChanger<H extends TapChangerParent, C extends Abstract
         return parent.getTransformer();
     }
 
+    protected H getParent() {
+        return parent;
+    }
+
     protected Resource<?> getResource() {
         return getTransformer().getResource();
     }

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/PhaseTapChangerImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/PhaseTapChangerImpl.java
@@ -147,10 +147,10 @@ public class PhaseTapChangerImpl extends AbstractTapChanger<TapChangerParent, Ph
         }
     }
 
-      // equals and hashCode are overridden to ensure correct behavior of the PhaseTapChanger 
-      // in hash table-based collections (e.g., HashSet, HashMap). Without these overrides, the default 
-      // implementations include this.attributesGetter, which can lead to incorrect behavior in 
-      // hash-based collections by affecting instance identification, retrieval and removal.
+    // equals and hashCode are overridden to ensure correct behavior of the PhaseTapChanger
+    // in hash table-based collections (e.g., HashSet, HashMap). Without these overrides, the default
+    // implementations include this.attributesGetter, which can lead to incorrect behavior in
+    // hash-based collections by affecting instance identification, retrieval and removal.
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/PhaseTapChangerImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/PhaseTapChangerImpl.java
@@ -148,7 +148,7 @@ public class PhaseTapChangerImpl extends AbstractTapChanger<TapChangerParent, Ph
     }
 
     // equals and hashcode are override because of ValidationUtil.checkPhaseTapChangerRegulation that
-    // remove the tap changer of the list of allRegulatingTapChanger
+    // remove the tap changer of the list of getAllTapChangers()
     // and it does not work if equals and hascode check this.attributesGetter
     @Override
     public boolean equals(Object o) {
@@ -159,10 +159,10 @@ public class PhaseTapChangerImpl extends AbstractTapChanger<TapChangerParent, Ph
             return false;
         }
         PhaseTapChangerImpl that = (PhaseTapChangerImpl) o;
-        // check phase tap changer are on same leg
         if (!Objects.equals(that.getTransformer().getClass(), getTransformer().getClass())) {
             return false;
         }
+        // check phase tap changer are on same leg
         if (that.getTransformer() instanceof ThreeWindingsTransformerImpl &&
             !Objects.equals(((ThreeWindingsTransformerImpl.LegImpl) parent).getSide(),
                 ((ThreeWindingsTransformerImpl.LegImpl) that.getParent()).getSide())) {

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/PhaseTapChangerImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/PhaseTapChangerImpl.java
@@ -147,9 +147,10 @@ public class PhaseTapChangerImpl extends AbstractTapChanger<TapChangerParent, Ph
         }
     }
 
-    // equals and hashcode are override because of ValidationUtil.checkPhaseTapChangerRegulation that
-    // remove the tap changer of the list of getAllTapChangers()
-    // and it does not work if equals and hascode check this.attributesGetter
+      // equals and hashCode are overridden to ensure correct behavior of the PhaseTapChanger 
+      // in hash table-based collections (e.g., HashSet, HashMap). Without these overrides, the default 
+      // implementations include this.attributesGetter, which can lead to incorrect behavior in 
+      // hash-based collections by affecting instance identification, retrieval and removal.
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/PhaseTapChangerImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/PhaseTapChangerImpl.java
@@ -9,9 +9,7 @@ package com.powsybl.network.store.iidm.impl;
 import com.powsybl.iidm.network.*;
 import com.powsybl.network.store.model.*;
 
-import java.util.HashSet;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Function;
 
 /**
@@ -147,5 +145,36 @@ public class PhaseTapChangerImpl extends AbstractTapChanger<TapChangerParent, Ph
         if (Double.isNaN(step.getAlpha())) {
             throw new ValidationException(parent, "step alpha is not set");
         }
+    }
+
+    // equals and hashcode are override because of ValidationUtil.checkPhaseTapChangerRegulation that
+    // remove the tap changer of the list of allRegulatingTapChanger
+    // and it does not work if equals and hascode check this.attributesGetter
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PhaseTapChangerImpl that = (PhaseTapChangerImpl) o;
+        // check phase tap changer are on same leg
+        if (!Objects.equals(that.getTransformer().getClass(), getTransformer().getClass())) {
+            return false;
+        }
+        if (that.getTransformer() instanceof ThreeWindingsTransformerImpl &&
+            !Objects.equals(((ThreeWindingsTransformerImpl.LegImpl) parent).getSide(),
+                ((ThreeWindingsTransformerImpl.LegImpl) that.getParent()).getSide())) {
+            return false;
+        }
+        return Objects.equals(getTransformer().getId(), that.getTransformer().getId()) &&
+            Objects.equals(getRegulationMode(), that.getRegulationMode()) &&
+            Objects.equals(getRegulationValue(), that.getRegulationValue());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getParent(), getTransformer().getId(), getRegulationMode(), getRegulationValue());
     }
 }

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/RatioTapChangerImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/RatioTapChangerImpl.java
@@ -181,6 +181,10 @@ public class RatioTapChangerImpl extends AbstractTapChanger<TapChangerParent, Ra
         AbstractTapChanger.validateStep(step, parent);
     }
 
+    // equals and hashCode are overridden to ensure correct behavior of the RatioTapChanger
+    // in hash table-based collections (e.g., HashSet, HashMap). Without these overrides, the default
+    // implementations include this.attributesGetter, which can lead to incorrect behavior in
+    // hash-based collections by affecting instance identification, retrieval and removal.
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/RatioTapChangerImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/RatioTapChangerImpl.java
@@ -180,4 +180,32 @@ public class RatioTapChangerImpl extends AbstractTapChanger<TapChangerParent, Ra
     public static void validateStep(TapChangerStepAttributes step, TapChangerParent parent) {
         AbstractTapChanger.validateStep(step, parent);
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RatioTapChangerImpl that = (RatioTapChangerImpl) o;
+        // check phase tap changer are on same leg
+        if (!Objects.equals(that.getTransformer().getClass(), getTransformer().getClass())) {
+            return false;
+        }
+        if (that.getTransformer() instanceof ThreeWindingsTransformerImpl &&
+            !Objects.equals(((ThreeWindingsTransformerImpl.LegImpl) parent).getSide(),
+                ((ThreeWindingsTransformerImpl.LegImpl) that.getParent()).getSide())) {
+            return false;
+        }
+        return Objects.equals(getTransformer().getId(), that.getTransformer().getId()) &&
+            Objects.equals(getRegulationMode(), that.getRegulationMode()) &&
+            Objects.equals(getRegulationValue(), that.getRegulationValue());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getParent(), getTransformer().getId(), getRegulationMode(), getRegulationValue());
+    }
 }

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/RatioTapChangerImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/RatioTapChangerImpl.java
@@ -190,10 +190,10 @@ public class RatioTapChangerImpl extends AbstractTapChanger<TapChangerParent, Ra
             return false;
         }
         RatioTapChangerImpl that = (RatioTapChangerImpl) o;
-        // check phase tap changer are on same leg
         if (!Objects.equals(that.getTransformer().getClass(), getTransformer().getClass())) {
             return false;
         }
+        // check ratio tap changer are on same leg
         if (that.getTransformer() instanceof ThreeWindingsTransformerImpl &&
             !Objects.equals(((ThreeWindingsTransformerImpl.LegImpl) parent).getSide(),
                 ((ThreeWindingsTransformerImpl.LegImpl) that.getParent()).getSide())) {

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/TwoWindingsTransformerTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/TwoWindingsTransformerTest.java
@@ -11,9 +11,7 @@ import com.powsybl.cgmes.conversion.CgmesImport;
 import com.powsybl.iidm.network.*;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Properties;
+import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -35,6 +33,19 @@ class TwoWindingsTransformerTest {
         TwoWindingsTransformer twtWithPhaseTapChanger = network.getTwoWindingsTransformer("a708c3bc-465d-4fe7-b6ef-6fa6408a62b0");
         twtWithPhaseTapChanger.getPhaseTapChanger().remove();
         assertNull(twtWithPhaseTapChanger.getPhaseTapChanger());
+    }
+
+    @Test
+    void testPhaseTapChangerEqualsAndHashCode() {
+        Network network = createNetwork();
+        TwoWindingsTransformer twtWithPhaseTapChanger = network.getTwoWindingsTransformer("a708c3bc-465d-4fe7-b6ef-6fa6408a62b0");
+        Set<PhaseTapChanger> phaseTapChangers = new HashSet<>();
+        phaseTapChangers.add(twtWithPhaseTapChanger.getPhaseTapChanger());
+
+        // use the equals and the hashcode of PhaseTapChangerImpl
+        phaseTapChangers.remove(twtWithPhaseTapChanger.getPhaseTapChanger());
+
+        assertEquals(0, phaseTapChangers.size());
     }
 
     @Test

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/TwoWindingsTransformerTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/TwoWindingsTransformerTest.java
@@ -50,6 +50,7 @@ class TwoWindingsTransformerTest {
         assertEquals(twtWithPhaseTapChanger.getPhaseTapChanger(), twtWithPhaseTapChanger.getPhaseTapChanger());
         assertNotNull(twtWithPhaseTapChanger.getPhaseTapChanger());
         assertNotEquals(twtWithPhaseTapChanger.getPhaseTapChanger(), twtWithRatioTapChanger.getPhaseTapChanger());
+        assertNull(twtWithPhaseTapChanger.getRatioTapChanger());
     }
 
     @Test

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/TwoWindingsTransformerTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/TwoWindingsTransformerTest.java
@@ -39,6 +39,7 @@ class TwoWindingsTransformerTest {
     void testPhaseTapChangerEqualsAndHashCode() {
         Network network = createNetwork();
         TwoWindingsTransformer twtWithPhaseTapChanger = network.getTwoWindingsTransformer("a708c3bc-465d-4fe7-b6ef-6fa6408a62b0");
+        TwoWindingsTransformer twtWithRatioTapChanger = network.getTwoWindingsTransformer("b94318f6-6d24-4f56-96b9-df2531ad6543");
         Set<PhaseTapChanger> phaseTapChangers = new HashSet<>();
         phaseTapChangers.add(twtWithPhaseTapChanger.getPhaseTapChanger());
 
@@ -46,6 +47,9 @@ class TwoWindingsTransformerTest {
         phaseTapChangers.remove(twtWithPhaseTapChanger.getPhaseTapChanger());
 
         assertEquals(0, phaseTapChangers.size());
+        assertTrue(twtWithPhaseTapChanger.getPhaseTapChanger().equals(twtWithPhaseTapChanger.getPhaseTapChanger()));
+        assertFalse(twtWithPhaseTapChanger.getPhaseTapChanger().equals(null));
+        assertFalse(twtWithPhaseTapChanger.getPhaseTapChanger().equals(twtWithRatioTapChanger.getPhaseTapChanger()));
     }
 
     @Test

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/TwoWindingsTransformerTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/TwoWindingsTransformerTest.java
@@ -47,9 +47,9 @@ class TwoWindingsTransformerTest {
         phaseTapChangers.remove(twtWithPhaseTapChanger.getPhaseTapChanger());
 
         assertEquals(0, phaseTapChangers.size());
-        assertTrue(twtWithPhaseTapChanger.getPhaseTapChanger().equals(twtWithPhaseTapChanger.getPhaseTapChanger()));
-        assertFalse(twtWithPhaseTapChanger.getPhaseTapChanger().equals(null));
-        assertFalse(twtWithPhaseTapChanger.getPhaseTapChanger().equals(twtWithRatioTapChanger.getPhaseTapChanger()));
+        assertEquals(twtWithPhaseTapChanger.getPhaseTapChanger(), twtWithPhaseTapChanger.getPhaseTapChanger());
+        assertNotNull(twtWithPhaseTapChanger.getPhaseTapChanger());
+        assertNotEquals(twtWithPhaseTapChanger.getPhaseTapChanger(), twtWithRatioTapChanger.getPhaseTapChanger());
     }
 
     @Test

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/TwoWindingsTransformerTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/TwoWindingsTransformerTest.java
@@ -36,7 +36,7 @@ class TwoWindingsTransformerTest {
     }
 
     @Test
-    void testPhaseTapChangerEqualsAndHashCode() {
+    void testTapChangerEqualsAndHashCode() {
         Network network = createNetwork();
         TwoWindingsTransformer twtWithPhaseTapChanger = network.getTwoWindingsTransformer("a708c3bc-465d-4fe7-b6ef-6fa6408a62b0");
         TwoWindingsTransformer twtWithRatioTapChanger = network.getTwoWindingsTransformer("b94318f6-6d24-4f56-96b9-df2531ad6543");
@@ -47,10 +47,14 @@ class TwoWindingsTransformerTest {
         phaseTapChangers.remove(twtWithPhaseTapChanger.getPhaseTapChanger());
 
         assertEquals(0, phaseTapChangers.size());
-        assertEquals(twtWithPhaseTapChanger.getPhaseTapChanger(), twtWithPhaseTapChanger.getPhaseTapChanger());
-        assertNotNull(twtWithPhaseTapChanger.getPhaseTapChanger());
-        assertNotEquals(twtWithPhaseTapChanger.getPhaseTapChanger(), twtWithRatioTapChanger.getPhaseTapChanger());
-        assertNull(twtWithPhaseTapChanger.getRatioTapChanger());
+        PhaseTapChanger phaseTapChanger = twtWithPhaseTapChanger.getPhaseTapChanger();
+        RatioTapChanger ratioTapChanger = twtWithRatioTapChanger.getRatioTapChanger();
+        assertEquals(phaseTapChanger, phaseTapChanger);
+        assertEquals(ratioTapChanger, ratioTapChanger);
+        assertNotNull(phaseTapChanger);
+        assertNotNull(ratioTapChanger);
+        assertNotEquals(phaseTapChanger, ratioTapChanger);
+        assertNotEquals(ratioTapChanger, phaseTapChanger);
     }
 
     @Test

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/tck/ThreeWindingsTransformerTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/tck/ThreeWindingsTransformerTest.java
@@ -62,19 +62,19 @@ class ThreeWindingsTransformerTest extends AbstractThreeWindingsTransformerTest 
         ratioTapChangers.remove(twt.getLeg2().getRatioTapChanger());
 
         assertEquals(0, ratioTapChangers.size());
-        assertTrue(twt.getLeg2().getRatioTapChanger().equals(twt.getLeg2().getRatioTapChanger()));
+        assertEquals(twt.getLeg2().getRatioTapChanger(), twt.getLeg2().getRatioTapChanger());
         assertNull(twt.getLeg1().getRatioTapChanger());
-        assertFalse(twt.getLeg2().getRatioTapChanger().equals(null));
-        assertFalse(twt.getLeg2().getRatioTapChanger().equals(twt.getLeg3().getRatioTapChanger()));
-        assertFalse(twt2.getRatioTapChanger().equals(twt.getLeg2().getRatioTapChanger()));
-        assertFalse(twt.getLeg2().getRatioTapChanger().equals(twt2.getRatioTapChanger()));
+        assertNotEquals(null, twt.getLeg2().getRatioTapChanger());
+        assertNotEquals(twt.getLeg2().getRatioTapChanger(), twt.getLeg3().getRatioTapChanger());
+        assertNotEquals(twt2.getRatioTapChanger(), twt.getLeg2().getRatioTapChanger());
+        assertNotEquals(twt.getLeg2().getRatioTapChanger(), twt2.getRatioTapChanger());
 
         createPhaseTapChangers(twt);
         //phase tap changer
-        assertTrue(twt.getLeg1().getPhaseTapChanger().equals(twt.getLeg1().getPhaseTapChanger()));
+        assertEquals(twt.getLeg1().getPhaseTapChanger(), twt.getLeg1().getPhaseTapChanger());
         assertNull(twt.getLeg3().getPhaseTapChanger());
-        assertFalse(twt.getLeg2().getPhaseTapChanger().equals(twt.getLeg1().getPhaseTapChanger()));
-        assertFalse(twt2.getPhaseTapChanger().equals(twt.getLeg1().getPhaseTapChanger()));
+        assertNotEquals(twt.getLeg2().getPhaseTapChanger(), twt.getLeg1().getPhaseTapChanger());
+        assertNotEquals(twt2.getPhaseTapChanger(), twt.getLeg1().getPhaseTapChanger());
     }
 
     private void createPhaseTapChangers(ThreeWindingsTransformer twt) {

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/tck/ThreeWindingsTransformerTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/tck/ThreeWindingsTransformerTest.java
@@ -8,6 +8,7 @@ package com.powsybl.network.store.iidm.impl.tck;
 
 import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.tck.AbstractThreeWindingsTransformerTest;
+import com.powsybl.iidm.network.test.FourSubstationsNodeBreakerFactory;
 import com.powsybl.iidm.network.test.ThreeWindingsTransformerNetworkFactory;
 import com.powsybl.network.store.iidm.impl.ThreeWindingsTransformerImpl;
 import org.junit.jupiter.api.Test;
@@ -45,9 +46,11 @@ class ThreeWindingsTransformerTest extends AbstractThreeWindingsTransformerTest 
     }
 
     @Test
-    void testPhaseTapChangerEqualsAndHashCode() {
+    void testTapChangerEqualsAndHashCode() {
         Network network = ThreeWindingsTransformerNetworkFactory.create();
+        Network network2 = FourSubstationsNodeBreakerFactory.create();
         ThreeWindingsTransformer twt = network.getThreeWindingsTransformer("3WT");
+        TwoWindingsTransformer twt2 = network2.getTwoWindingsTransformer("TWT");
         Set<RatioTapChanger> ratioTapChangers = new HashSet<>();
         ratioTapChangers.add(twt.getLeg2().getRatioTapChanger());
         ratioTapChangers.add(twt.getLeg2().getRatioTapChanger());
@@ -60,7 +63,54 @@ class ThreeWindingsTransformerTest extends AbstractThreeWindingsTransformerTest 
 
         assertEquals(0, ratioTapChangers.size());
         assertTrue(twt.getLeg2().getRatioTapChanger().equals(twt.getLeg2().getRatioTapChanger()));
+        assertNull(twt.getLeg1().getRatioTapChanger());
         assertFalse(twt.getLeg2().getRatioTapChanger().equals(null));
         assertFalse(twt.getLeg2().getRatioTapChanger().equals(twt.getLeg3().getRatioTapChanger()));
+        assertFalse(twt2.getRatioTapChanger().equals(twt.getLeg2().getRatioTapChanger()));
+        assertFalse(twt.getLeg2().getRatioTapChanger().equals(twt2.getRatioTapChanger()));
+
+        createPhaseTapChangers(twt);
+        //phase tap changer
+        assertTrue(twt.getLeg1().getPhaseTapChanger().equals(twt.getLeg1().getPhaseTapChanger()));
+        assertNull(twt.getLeg3().getPhaseTapChanger());
+        assertFalse(twt.getLeg2().getPhaseTapChanger().equals(twt.getLeg1().getPhaseTapChanger()));
+    }
+
+    private void createPhaseTapChangers(ThreeWindingsTransformer twt) {
+        twt.getLeg1().newPhaseTapChanger()
+            .setLowTapPosition(0)
+            .setTapPosition(0)
+            .setRegulating(false)
+            .setRegulationMode(PhaseTapChanger.RegulationMode.FIXED_TAP)
+            .setRegulationValue(25)
+            .setRegulationTerminal(twt.getTerminal(ThreeSides.ONE))
+            .setTargetDeadband(22)
+            .beginStep()
+            .setAlpha(-10)
+            .setRho(0.99)
+            .setR(1.)
+            .setX(4.)
+            .setG(0.5)
+            .setB(1.5)
+            .endStep()
+            .add();
+
+        twt.getLeg2().newPhaseTapChanger()
+            .setLowTapPosition(0)
+            .setTapPosition(0)
+            .setRegulating(false)
+            .setRegulationMode(PhaseTapChanger.RegulationMode.FIXED_TAP)
+            .setRegulationValue(25)
+            .setRegulationTerminal(twt.getTerminal(ThreeSides.ONE))
+            .setTargetDeadband(22)
+            .beginStep()
+            .setAlpha(-10)
+            .setRho(0.99)
+            .setR(1.)
+            .setX(4.)
+            .setG(0.5)
+            .setB(1.5)
+            .endStep()
+            .add();
     }
 }

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/tck/ThreeWindingsTransformerTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/tck/ThreeWindingsTransformerTest.java
@@ -64,7 +64,7 @@ class ThreeWindingsTransformerTest extends AbstractThreeWindingsTransformerTest 
         assertEquals(0, ratioTapChangers.size());
         assertEquals(twt.getLeg2().getRatioTapChanger(), twt.getLeg2().getRatioTapChanger());
         assertNull(twt.getLeg1().getRatioTapChanger());
-        assertNotEquals(null, twt.getLeg2().getRatioTapChanger());
+        assertNotNull(twt.getLeg2().getRatioTapChanger());
         assertNotEquals(twt.getLeg2().getRatioTapChanger(), twt.getLeg3().getRatioTapChanger());
         assertNotEquals(twt2.getRatioTapChanger(), twt.getLeg2().getRatioTapChanger());
         assertNotEquals(twt.getLeg2().getRatioTapChanger(), twt2.getRatioTapChanger());

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/tck/ThreeWindingsTransformerTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/tck/ThreeWindingsTransformerTest.java
@@ -6,16 +6,15 @@
  */
 package com.powsybl.network.store.iidm.impl.tck;
 
-import com.powsybl.iidm.network.Network;
-import com.powsybl.iidm.network.Terminal;
-import com.powsybl.iidm.network.ThreeSides;
-import com.powsybl.iidm.network.ThreeWindingsTransformer;
+import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.tck.AbstractThreeWindingsTransformerTest;
 import com.powsybl.iidm.network.test.ThreeWindingsTransformerNetworkFactory;
 import com.powsybl.network.store.iidm.impl.ThreeWindingsTransformerImpl;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -43,5 +42,25 @@ class ThreeWindingsTransformerTest extends AbstractThreeWindingsTransformerTest 
         assertEquals(List.of(terminal1), ((ThreeWindingsTransformerImpl) twt).getTerminals(ThreeSides.ONE));
         assertEquals(List.of(terminal2), ((ThreeWindingsTransformerImpl) twt).getTerminals(ThreeSides.TWO));
         assertEquals(List.of(terminal3), ((ThreeWindingsTransformerImpl) twt).getTerminals(ThreeSides.THREE));
+    }
+
+    @Test
+    void testPhaseTapChangerEqualsAndHashCode() {
+        Network network = ThreeWindingsTransformerNetworkFactory.create();
+        ThreeWindingsTransformer twt = network.getThreeWindingsTransformer("3WT");
+        Set<RatioTapChanger> ratioTapChangers = new HashSet<>();
+        ratioTapChangers.add(twt.getLeg2().getRatioTapChanger());
+        ratioTapChangers.add(twt.getLeg2().getRatioTapChanger());
+        ratioTapChangers.remove(twt.getLeg3().getRatioTapChanger());
+
+        assertEquals(1, ratioTapChangers.size());
+
+        // use the equals and the hashcode of PhaseTapChangerImpl
+        ratioTapChangers.remove(twt.getLeg2().getRatioTapChanger());
+
+        assertEquals(0, ratioTapChangers.size());
+        assertTrue(twt.getLeg2().getRatioTapChanger().equals(twt.getLeg2().getRatioTapChanger()));
+        assertFalse(twt.getLeg2().getRatioTapChanger().equals(null));
+        assertFalse(twt.getLeg2().getRatioTapChanger().equals(twt.getLeg3().getRatioTapChanger()));
     }
 }

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/tck/ThreeWindingsTransformerTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/tck/ThreeWindingsTransformerTest.java
@@ -74,6 +74,7 @@ class ThreeWindingsTransformerTest extends AbstractThreeWindingsTransformerTest 
         assertTrue(twt.getLeg1().getPhaseTapChanger().equals(twt.getLeg1().getPhaseTapChanger()));
         assertNull(twt.getLeg3().getPhaseTapChanger());
         assertFalse(twt.getLeg2().getPhaseTapChanger().equals(twt.getLeg1().getPhaseTapChanger()));
+        assertFalse(twt2.getPhaseTapChanger().equals(twt.getLeg1().getPhaseTapChanger()));
     }
 
     private void createPhaseTapChangers(ThreeWindingsTransformer twt) {

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/tck/ThreeWindingsTransformerTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/tck/ThreeWindingsTransformerTest.java
@@ -58,7 +58,7 @@ class ThreeWindingsTransformerTest extends AbstractThreeWindingsTransformerTest 
 
         assertEquals(1, ratioTapChangers.size());
 
-        // use the equals and the hashcode of PhaseTapChangerImpl
+        // use the equals and the hashcode of RatioTapChangerImpl
         ratioTapChangers.remove(twt.getLeg2().getRatioTapChanger());
 
         assertEquals(0, ratioTapChangers.size());


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
no


**What kind of change does this PR introduce?**
it fixes abug when setting regulating on tap changers


**What is the current behavior?**
removing a tapChanger from a collection set (set.remove(tapChanger)) does not work


**What is the new behavior (if this is a feature change)?**
it is fixed with adding equals and hashcode to tapChangers


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No