### PR TITLE
Fix initialization of collection cache for extensions

### DIFF
--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/CollectionCache.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/CollectionCache.java
@@ -120,6 +120,7 @@ public class CollectionCache<T extends IdentifiableAttributes> {
      */
     public void init() {
         fullyLoaded = true;
+        fullyLoadedExtensions = true;
     }
 
     public boolean isFullyLoaded() {

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/CollectionCacheTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/CollectionCacheTest.java
@@ -335,6 +335,24 @@ public class CollectionCacheTest {
     }
 
     @Test
+    public void initExtensionsTest() {
+        assertEquals(Arrays.asList(l1, l2, l3), collectionCache.getResources(NETWORK_UUID, Resource.INITIAL_VARIANT_NUM));
+        assertFalse(mockNetworkStoreClient.isExtensionAttributeLoaderCalled());
+        assertFalse(mockNetworkStoreClient.isExtensionAttributesLoaderByResourceTypeAndNameCalled());
+        assertFalse(mockNetworkStoreClient.isExtensionAttributesLoaderByIdCalled());
+        assertFalse(mockNetworkStoreClient.isExtensionAttributesLoaderByResourceTypeCalled());
+        collectionCache.init(); // it means we trust cache content and no more server loading
+        collectionCache.getExtensionAttributes(NETWORK_UUID, Resource.INITIAL_VARIANT_NUM, ResourceType.LOAD, "l1", "activePowerControl");
+        collectionCache.getAllExtensionsAttributesByResourceTypeAndExtensionName(NETWORK_UUID, Resource.INITIAL_VARIANT_NUM, ResourceType.LOAD, "activePowerControl");
+        collectionCache.getAllExtensionsAttributesByIdentifiableId(NETWORK_UUID, Resource.INITIAL_VARIANT_NUM, ResourceType.LOAD, "l1");
+        collectionCache.getAllExtensionsAttributesByResourceType(NETWORK_UUID, Resource.INITIAL_VARIANT_NUM, ResourceType.LOAD);
+        assertFalse(mockNetworkStoreClient.isExtensionAttributeLoaderCalled());
+        assertFalse(mockNetworkStoreClient.isExtensionAttributesLoaderByResourceTypeAndNameCalled());
+        assertFalse(mockNetworkStoreClient.isExtensionAttributesLoaderByIdCalled());
+        assertFalse(mockNetworkStoreClient.isExtensionAttributesLoaderByResourceTypeCalled());
+    }
+
+    @Test
     public void getExtensionAttributesWithResourceNotCachedMustThrow() {
         PowsyblException exception = assertThrows(PowsyblException.class, () -> collectionCache.getExtensionAttributes(NETWORK_UUID, Resource.INITIAL_VARIANT_NUM, ResourceType.LOAD, "l1", "activePowerControl"));
         assertTrue(exception.getMessage().startsWith("Cannot manipulate extensions for identifiable"));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
It fixes an issue when trying to access extensions when they are not flushed/persisted yet. In the current behavior, a fetch on the server is done while it should not because everything is in memory.

**What is the current behavior?**
<!-- You can also link to an open issue here -->
In this network-store-server example test:
```java
        try (NetworkStoreService service = createNetworkStoreService(randomServerPort)) {
            Network network = EurostagTutorialExample1Factory.create(service.getNetworkFactory());
            TwoWindingsTransformer twt = network.getTwoWindingsTransformer("NGEN_NHV1");
            assertTrue(twt.getExtensions().isEmpty());
            service.flush(network);
        }
```
Even if the network is created in memory, extensions are fetched on the server when calling `twt.getExtensions()`.
This can be seen in the logs for examples:
```
18:28:02.333 [main] INFO  com.powsybl.network.store.client.RestNetworkStoreClient - 0 extension attributes loaded in 117 ms
```
That's because when we call the init() method of CollectionCache when the network is created, we do not set extensions to fully loaded, so despite the network is not yet persisted (and completely in memory), we try to access the extensions in the server. The server answer with an empty map/optional for now. 

**What is the new behavior (if this is a feature change)?**
In the new behavior, there will be no fetch in this case as the network is completely in memory and the boolean fullyLoadedExtensions is set to true which prevents any extension fetch on the server.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
