### PR TITLE
Fix deserialization error on getExtensions() when loader does not exist in classpath

### DIFF
--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractIdentifiableImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractIdentifiableImpl.java
@@ -331,6 +331,7 @@ public abstract class AbstractIdentifiableImpl<I extends Identifiable<I>, D exte
     public <E extends Extension<I>> Collection<E> getExtensions() {
         index.loadAllExtensionsAttributesByIdentifiableId(resource.getType(), resource.getId());
         return resource.getAttributes().getExtensionAttributes().keySet().stream()
+                .filter(ExtensionLoaders::loaderExists)
                 .map(name -> (E) ExtensionLoaders.findLoaderByName(name).load(this))
                 .collect(Collectors.toList());
     }

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/AttributesTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/AttributesTest.java
@@ -46,11 +46,19 @@ public class AttributesTest {
     @Test
     public void testDeserializeExtensionWithNotExistingLoader() throws JsonProcessingException {
         ObjectMapper mapper = new ObjectMapper();
-        String json = "{\"extensionName\":\"unknownName\",\"unknownAttribute1\":0.5,\"unknownAttribute2\":10.0,\"unknownAttribute3\":5.0,\"unknownAttribute4\":3.0,\"unknownAttribute5\":5.0}";
+        String json = "{\"extensionName\":\"unknownName\",\"unknownAttribute1\":0.5,\"unknownAttribute2\":10.0,\"unknownAttribute3\": {\"unknownAttribute4\":3.0,\"unknownAttribute5\":5.0}}";
 
         ExtensionAttributes unknownExtensionAttributes = mapper.readValue(json, ExtensionAttributes.class);
         assertEquals(RawExtensionAttributes.class, unknownExtensionAttributes.getClass());
-        assertEquals("{\"unknownAttribute1\":0.5,\"unknownAttribute2\":10.0,\"unknownAttribute3\":5.0,\"unknownAttribute4\":3.0,\"unknownAttribute5\":5.0}", ((RawExtensionAttributes) unknownExtensionAttributes).getRawJson());
+        Map<String, Object> expectedMap = Map.of(
+                "unknownAttribute1", 0.5,
+                "unknownAttribute2", 10.0,
+                "unknownAttribute3", Map.of(
+                        "unknownAttribute4", 3.0,
+                        "unknownAttribute5", 5.0
+                )
+        );
+        assertEquals(expectedMap, ((RawExtensionAttributes) unknownExtensionAttributes).getAttributes());
     }
 
     @Test
@@ -61,7 +69,15 @@ public class AttributesTest {
         Resource<LineAttributes> lineResource = line.getResource();
         assertNotNull(lineResource);
         // Update line with RawExtensionAttributes
-        lineResource.getAttributes().setExtensionAttributes(Map.of("unknownName", new RawExtensionAttributes("{\"unknownAttribute1\":0.5,\"unknownAttribute2\":10.0,\"unknownAttribute3\":5.0,\"unknownAttribute4\":3.0,\"unknownAttribute5\":5.0}")));
+        Map<String, Object> unknownAttributes = Map.of(
+                "unknownAttribute1", 0.5,
+                "unknownAttribute2", 10.0,
+                "unknownAttribute3", Map.of(
+                        "unknownAttribute4", 3.0,
+                        "unknownAttribute5", 5.0
+                )
+        );
+        lineResource.getAttributes().setExtensionAttributes(Map.of("unknownName", new RawExtensionAttributes(unknownAttributes)));
         line.getIndex().updateLineResource(line.getResource(), null);
         Assertions.assertEquals(0, line.getExtensions().size());
         Assertions.assertDoesNotThrow(() -> line.getExtensionByName("unknownName"));

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/ExtensionAttributesIdResolver.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/ExtensionAttributesIdResolver.java
@@ -39,6 +39,9 @@ public class ExtensionAttributesIdResolver extends TypeIdResolverBase {
 
     @Override
     public JavaType typeFromId(DatabindContext context, String id) {
+        if (!ExtensionLoaders.loaderExists(id)) {
+            return context.constructSpecializedType(superType, RawExtensionAttributes.class);
+        }
         Class<? extends ExtensionAttributes> subType = ExtensionLoaders.findLoaderByName(id).getAttributesType();
         return context.constructSpecializedType(superType, subType);
     }

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/RawExtensionAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/RawExtensionAttributes.java
@@ -11,6 +11,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.Map;
+
 /**
  * @author Antoine Bouhours <antoine.bouhours at rte-france.com>
  */
@@ -19,5 +21,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @JsonDeserialize(using = RawExtensionAttributesDeserializer.class)
 public class RawExtensionAttributes implements ExtensionAttributes {
-    private String rawJson;
+    private Map<String, Object> attributes;
 }

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/RawExtensionAttributes.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/RawExtensionAttributes.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.network.store.model;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * @author Antoine Bouhours <antoine.bouhours at rte-france.com>
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonDeserialize(using = RawExtensionAttributesDeserializer.class)
+public class RawExtensionAttributes implements ExtensionAttributes {
+    private String rawJson;
+}

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/RawExtensionAttributesDeserializer.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/RawExtensionAttributesDeserializer.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.network.store.model;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+
+/**
+ * @author Antoine Bouhours <antoine.bouhours at rte-france.com>
+ */
+public class RawExtensionAttributesDeserializer extends JsonDeserializer<RawExtensionAttributes> {
+
+    @Override
+    public RawExtensionAttributes deserialize(JsonParser p, DeserializationContext context) throws IOException {
+        String rawJson = p.readValueAsTree().toString();
+        return new RawExtensionAttributes(rawJson);
+    }
+}

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/RawExtensionAttributesDeserializer.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/RawExtensionAttributesDeserializer.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 
+import java.io.IOException;
 import java.util.Map;
 
 /**
@@ -18,13 +19,8 @@ import java.util.Map;
 public class RawExtensionAttributesDeserializer extends JsonDeserializer<RawExtensionAttributes> {
 
     @Override
-    public RawExtensionAttributes deserialize(JsonParser p, DeserializationContext context) {
-        Map<String, Object> attributes;
-        try {
-            attributes = p.readValueAs(Map.class);
-        } catch (Exception e) {
-            attributes = Map.of();
-        }
+    public RawExtensionAttributes deserialize(JsonParser p, DeserializationContext context) throws IOException {
+        Map<String, Object> attributes = p.readValueAs(Map.class);
         return new RawExtensionAttributes(attributes);
     }
 }

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/RawExtensionAttributesDeserializer.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/RawExtensionAttributesDeserializer.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 
-import java.io.IOException;
+import java.util.Map;
 
 /**
  * @author Antoine Bouhours <antoine.bouhours at rte-france.com>
@@ -18,8 +18,13 @@ import java.io.IOException;
 public class RawExtensionAttributesDeserializer extends JsonDeserializer<RawExtensionAttributes> {
 
     @Override
-    public RawExtensionAttributes deserialize(JsonParser p, DeserializationContext context) throws IOException {
-        String rawJson = p.readValueAsTree().toString();
-        return new RawExtensionAttributes(rawJson);
+    public RawExtensionAttributes deserialize(JsonParser p, DeserializationContext context) {
+        Map<String, Object> attributes;
+        try {
+            attributes = p.readValueAs(Map.class);
+        } catch (Exception e) {
+            attributes = Map.of();
+        }
+        return new RawExtensionAttributes(attributes);
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Extensions are lazily loaded from the server to identifiable when needed. On the first getIdentifiable(), extensions are not loaded in the identifiable. When we use getExtensionByName/getExtension(Extension.class) or getExtensions(), corresponding extensions are loaded in the identifiable if they exist on the server. 

We change the behavior of loading extensions when the loader of the extension to deserialize it is not present in the classpath (currently, it throws on getExtensions()).

**Does this PR introduce a new Powsybl Action implying to be implemented in simulators or pypowsybl?**
- [ ] Yes, the corresponding issue is [here](link)
- [x] No

**What is the current behavior?**
<!-- You can also link to an open issue here -->
In getExtension()/getExtensionByName(), when the extension exists on the server and the loader is not present in the classpath of the client, we do not fetch the extension on the server and return null (silently). In the future, we may want to throw an exception or an error in this case. In order to throw an error, I think that all extensions should use lazy loading not a part of them as now.
In getExtensions(), all extensions are loaded from the server. Among these extensions, there can be extensions with loader not present in the classpath. In this case, the client is not able to deserialize the extension and the error "Extension loader not found" is thrown. 

**What is the new behavior (if this is a feature change)?**
In getExtension()/getExtensionByName(), no change.
In getExtensions(), all extensions are fetched from the server. Extensions without loader are deserialized as a Map in the resources index. They are ignored in getExtensions() when building the collection that is returned (it means that the extensions filtered are not present in the collection).


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No