### PR TITLE
Fix removeAll log when deleting partitions

### DIFF
--- a/network-store-client/src/main/java/com/powsybl/network/store/client/RestNetworkStoreClient.java
+++ b/network-store-client/src/main/java/com/powsybl/network/store/client/RestNetworkStoreClient.java
@@ -202,7 +202,7 @@ public class RestNetworkStoreClient implements NetworkStoreClient {
     private void removeAll(String target, String url, UUID networkUuid, int variantNum, List<String> ids) {
         for (List<String> idsPartition : Lists.partition(ids, RESOURCES_CREATION_CHUNK_SIZE)) {
             if (LOGGER.isInfoEnabled()) {
-                LOGGER.info("Deleting {} {} resources ({})...", ids.size(), target, UriComponentsBuilder.fromUriString(url).buildAndExpand(networkUuid, variantNum));
+                LOGGER.info("Deleting {} {} resources ({})...", idsPartition.size(), target, UriComponentsBuilder.fromUriString(url).buildAndExpand(networkUuid, variantNum));
             }
             Stopwatch stopwatch = Stopwatch.createStarted();
             try {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines

**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Changes the log which was:
```
Deleting 73862 switch resources (/networks/d7e68a41-f711-4ef9-825a-71e175e7e839/1/switches)...
1000 switch resources deleted in 19 ms
```
to 
```
Deleting 1000 switch resources (/networks/d7e68a41-f711-4ef9-825a-71e175e7e839/1/switches)...
1000 switch resources deleted in 19 ms
```