### PR TITLE
Filter RawExtensionAttributes to avoid adding them to the cache

### DIFF
--- a/network-store-client/src/main/java/com/powsybl/network/store/client/RestNetworkStoreClient.java
+++ b/network-store-client/src/main/java/com/powsybl/network/store/client/RestNetworkStoreClient.java
@@ -119,48 +119,52 @@ public class RestNetworkStoreClient implements NetworkStoreClient {
     private Optional<ExtensionAttributes> getExtensionAttributes(String urlTemplate, Object... uriVariables) {
         logGetExtensionAttributesUrl(urlTemplate, uriVariables);
         Stopwatch stopwatch = Stopwatch.createStarted();
-        Optional<ExtensionAttributes> extensionAttributes = restClient.getOneExtensionAttributes(urlTemplate, uriVariables)
-                .filter(attr -> !(attr instanceof RawExtensionAttributes));
+        Optional<ExtensionAttributes> rawExtensionAttributes = restClient.getOneExtensionAttributes(urlTemplate, uriVariables);
+        boolean wasFiltered = rawExtensionAttributes.filter(RawExtensionAttributes.class::isInstance).isPresent();
+        Optional<ExtensionAttributes> filteredExtensionAttributes = rawExtensionAttributes.filter(attr -> !(attr instanceof RawExtensionAttributes));
         stopwatch.stop();
-        logGetExtensionAttributesTime(extensionAttributes.isPresent() ? 1 : 0, stopwatch.elapsed(TimeUnit.MILLISECONDS));
+        logGetExtensionAttributesTime(filteredExtensionAttributes.isPresent() ? 1 : 0, stopwatch.elapsed(TimeUnit.MILLISECONDS), wasFiltered ? 1 : 0);
 
-        return extensionAttributes;
+        return filteredExtensionAttributes;
     }
 
     private Map<String, ExtensionAttributes> getExtensionAttributesMap(String urlTemplate, Object... uriVariables) {
         logGetExtensionAttributesUrl(urlTemplate, uriVariables);
         Stopwatch stopwatch = Stopwatch.createStarted();
-        Map<String, ExtensionAttributes> extensionAttributes = restClient.get(urlTemplate, new ParameterizedTypeReference<Map<String, ExtensionAttributes>>() { }, uriVariables)
-                .entrySet().stream()
-                .filter(entry -> !(entry.getValue() instanceof RawExtensionAttributes))
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-        stopwatch.stop();
-        logGetExtensionAttributesTime(extensionAttributes.size(), stopwatch.elapsed(TimeUnit.MILLISECONDS));
+        Map<String, ExtensionAttributes> rawExtensionAttributes = restClient.get(urlTemplate, new ParameterizedTypeReference<>() { }, uriVariables);
+        Map<String, ExtensionAttributes> filteredExtensionAttributes = filterRawExtensionAttributes(rawExtensionAttributes);
+        int filteredCount = rawExtensionAttributes.size() - filteredExtensionAttributes.size();
 
-        return extensionAttributes;
+        stopwatch.stop();
+        logGetExtensionAttributesTime(filteredExtensionAttributes.size(), stopwatch.elapsed(TimeUnit.MILLISECONDS), filteredCount);
+
+        return filteredExtensionAttributes;
     }
 
     private Map<String, Map<String, ExtensionAttributes>> getExtensionAttributesNestedMap(String urlTemplate, Object... uriVariables) {
         logGetExtensionAttributesUrl(urlTemplate, uriVariables);
         Stopwatch stopwatch = Stopwatch.createStarted();
-        Map<String, Map<String, ExtensionAttributes>> extensionAttributes = restClient.get(urlTemplate, new ParameterizedTypeReference<Map<String, Map<String, ExtensionAttributes>>>() { }, uriVariables)
-                .entrySet().stream()
-                .map(entry -> {
-                    Map<String, ExtensionAttributes> innerMap = entry.getValue();
-                    Map<String, ExtensionAttributes> filteredInnerMap = innerMap.entrySet().stream()
-                            .filter(innerEntry -> !(innerEntry.getValue() instanceof RawExtensionAttributes))
-                            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-                    return Map.entry(entry.getKey(), filteredInnerMap);
-                })
-                .filter(entry -> !entry.getValue().isEmpty())
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        Map<String, Map<String, ExtensionAttributes>> rawExtensionAttributes = restClient.get(urlTemplate, new ParameterizedTypeReference<>() { }, uriVariables);
+        Map<String, Map<String, ExtensionAttributes>> filteredExtensionAttributes = new HashMap<>();
+        long filteredAttributesCount = 0;
+        for (Map.Entry<String, Map<String, ExtensionAttributes>> entry : rawExtensionAttributes.entrySet()) {
+            Map<String, ExtensionAttributes> filteredInnerMap = filterRawExtensionAttributes(entry.getValue());
+            if (!filteredInnerMap.isEmpty()) {
+                filteredExtensionAttributes.put(entry.getKey(), filteredInnerMap);
+            }
+            filteredAttributesCount += entry.getValue().size() - filteredInnerMap.size();
+        }
         stopwatch.stop();
-        long loadedAttributesCount = extensionAttributes.values().stream()
-                .mapToLong(innerMap -> innerMap.values().size())
-                .sum();
-        logGetExtensionAttributesTime(loadedAttributesCount, stopwatch.elapsed(TimeUnit.MILLISECONDS));
+        long loadedAttributesCount = filteredExtensionAttributes.values().stream().mapToLong(Map::size).sum();
+        logGetExtensionAttributesTime(loadedAttributesCount, stopwatch.elapsed(TimeUnit.MILLISECONDS), filteredAttributesCount);
 
-        return extensionAttributes;
+        return filteredExtensionAttributes;
+    }
+
+    private static Map<String, ExtensionAttributes> filterRawExtensionAttributes(Map<String, ExtensionAttributes> extensionAttributes) {
+        return extensionAttributes.entrySet().stream()
+                .filter(entry -> !(entry.getValue() instanceof RawExtensionAttributes))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     private static void logGetExtensionAttributesUrl(String urlTemplate, Object... uriVariables) {
@@ -169,8 +173,12 @@ public class RestNetworkStoreClient implements NetworkStoreClient {
         }
     }
 
-    private static void logGetExtensionAttributesTime(long loadedAttributesCount, long timeElapsed) {
-        LOGGER.info("{} extension attributes loaded in {} ms", loadedAttributesCount, timeElapsed);
+    private static void logGetExtensionAttributesTime(long loadedAttributesCount, long timeElapsed, long filteredAttributesCount) {
+        if (filteredAttributesCount > 0) {
+            LOGGER.info("{} extension attributes loaded in {} ms ({} ignored due to missing deserializer in classpath)", loadedAttributesCount, timeElapsed, filteredAttributesCount);
+        } else {
+            LOGGER.info("{} extension attributes loaded in {} ms", loadedAttributesCount, timeElapsed);
+        }
     }
 
     private <T extends IdentifiableAttributes> void updatePartition(String target, String url, AttributeFilter attributeFilter, List<Resource<T>> resources, Object[] uriVariables) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
When extensions without deserializer associated to them in the classpath are handled by the client, they're deserialized as RawExtensionAttributes. In the current implementation, these RawExtensionAttributes are loaded to the collection cache. 
This means that if one:
* load extension without deserializer in the classpath (they're cached)
* update the resource (the resource contains RawExtensionAttributes)
* flush the network
The client save the resource with RawExtensionAttributes but can't serialize it. 

```
Caused by: com.fasterxml.jackson.databind.JsonMappingException: ExtensionLoader not found (through reference chain: java.util.ArrayList$SubList[0]->com.powsybl.network.store.model.Resource["attributes"]->com.powsybl.network.store.model.VoltageLevelAttributes["extensionAttributes"]->java.util.LinkedHashMap["unknownExtension"])
```


**What is the current behavior?**
<!-- You can also link to an open issue here -->
When extensions are fetched from the server, if they're not in the classpath they are added to the cache.


**What is the new behavior (if this is a feature change)?**
When extensions are fetched from the server, if they're not in the classpath they are NOT added to the cache but filtered by the client.
