### PR TITLE
Fix id before removal when switching variant

### DIFF
--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractIdentifiableImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractIdentifiableImpl.java
@@ -111,8 +111,12 @@ public abstract class AbstractIdentifiableImpl<I extends Identifiable<I>, D exte
     }
 
     public void setResource(Resource<D> resource) {
-        idBeforeRemoval = resource == null ? this.resource.getId() : null;
         this.resource = resource;
+    }
+
+    public void removeResource() {
+        idBeforeRemoval = resource.getId();
+        this.resource = null;
     }
 
     public Resource<D> getResource() {

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkObjectIndex.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkObjectIndex.java
@@ -232,7 +232,7 @@ public class NetworkObjectIndex {
             if (obj != null) {
                 // to reuse the object from one variant to another one just set the resource to null
                 // and keep the object in the cache
-                obj.setResource(null);
+                obj.removeResource();
             }
         }
 

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/GeneratorTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/GeneratorTest.java
@@ -6,12 +6,11 @@
  */
 package com.powsybl.network.store.iidm.impl;
 
-import com.powsybl.iidm.network.Generator;
-import com.powsybl.iidm.network.Load;
-import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.test.FourSubstationsNodeBreakerFactory;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Etienne Lesot <etienne.lesot at rte-france.com>
@@ -25,21 +24,21 @@ class GeneratorTest {
         // initialization
         Generator generator = network.getGenerator("GH3");
         Load load = network.getLoad("LD1");
-        Assertions.assertTrue(generator.isVoltageRegulatorOn());
-        Assertions.assertEquals(generator.getTerminal(), generator.getRegulatingTerminal());
-        Assertions.assertEquals(400, generator.getTargetV());
+        assertTrue(generator.isVoltageRegulatorOn());
+        assertEquals(generator.getTerminal(), generator.getRegulatingTerminal());
+        assertEquals(400, generator.getTargetV());
 
         // set the generator's regulation on the load terminal (both equipments are not on the same voltage level/bus)
         generator.setRegulatingTerminal(load.getTerminal());
         generator.setTargetV(225);
-        Assertions.assertTrue(generator.isVoltageRegulatorOn());
-        Assertions.assertEquals(load.getTerminal(), generator.getRegulatingTerminal());
-        Assertions.assertEquals(225, generator.getTargetV());
+        assertTrue(generator.isVoltageRegulatorOn());
+        assertEquals(load.getTerminal(), generator.getRegulatingTerminal());
+        assertEquals(225, generator.getTargetV());
 
         // remove the load
         network.getLoad("LD1").remove();
-        Assertions.assertEquals(generator.getTerminal(), generator.getRegulatingTerminal());
-        Assertions.assertFalse(generator.isVoltageRegulatorOn());
+        assertEquals(generator.getTerminal(), generator.getRegulatingTerminal());
+        assertFalse(generator.isVoltageRegulatorOn());
     }
 
     @Test
@@ -49,17 +48,32 @@ class GeneratorTest {
         // initialization
         Generator generator = network.getGenerator("GH3");
         Load load = network.getLoad("LD2");
-        Assertions.assertTrue(generator.isVoltageRegulatorOn());
-        Assertions.assertEquals(generator.getTerminal(), generator.getRegulatingTerminal());
+        assertTrue(generator.isVoltageRegulatorOn());
+        assertEquals(generator.getTerminal(), generator.getRegulatingTerminal());
 
         // set the generator's regulation on the load terminal (both equipments are on the same voltage level/bus)
         generator.setRegulatingTerminal(load.getTerminal());
-        Assertions.assertTrue(generator.isVoltageRegulatorOn());
-        Assertions.assertEquals(load.getTerminal(), generator.getRegulatingTerminal());
+        assertTrue(generator.isVoltageRegulatorOn());
+        assertEquals(load.getTerminal(), generator.getRegulatingTerminal());
 
         // remove the load
         network.getLoad("LD2").remove();
-        Assertions.assertEquals(generator.getTerminal(), generator.getRegulatingTerminal());
-        Assertions.assertTrue(generator.isVoltageRegulatorOn());
+        assertEquals(generator.getTerminal(), generator.getRegulatingTerminal());
+        assertTrue(generator.isVoltageRegulatorOn());
+    }
+
+    @Test
+    void testIdBeforeRemovalMultipleVariants() {
+        Network network = FourSubstationsNodeBreakerFactory.create();
+
+        Generator generator = network.getGenerator("GH3");
+        assertNotNull(generator);
+        generator.remove();
+        assertEquals("GH3", generator.getId());
+
+        VariantManager variantManager = network.getVariantManager();
+        variantManager.cloneVariant(VariantManagerConstants.INITIAL_VARIANT_ID, "variant1");
+        variantManager.setWorkingVariant("variant1");
+        assertEquals("GH3", generator.getId());
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Code throws on the following (see UT):
1. remove a resource
2. clone network
3. set working variant to the new variant

That's because we use the same setResource() method for removing and switching variant (and other usages). When removing a resource we want to save the id of the removed resource and set the resource to null so we need a separate method. 
We also want to keep the id of the removed resource when switching variant.


**What is the new behavior (if this is a feature change)?**
1. No throw when switching variant after remove
2. id of the removed resource is available when switching variant