### PR TITLE
Update setResource method to handle idBeforeRemoval

### DIFF
--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractIdentifiableImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractIdentifiableImpl.java
@@ -111,12 +111,15 @@ public abstract class AbstractIdentifiableImpl<I extends Identifiable<I>, D exte
     }
 
     public void setResource(Resource<D> resource) {
-        this.resource = resource;
-    }
+        if (resource == null && this.resource != null) {
+            // Save idBeforeRemoval when switching from non-null to null resource
+            idBeforeRemoval = this.resource.getId();
+        } else if (resource != null) {
+            // Clear idBeforeRemoval when setting a non-null resource
+            idBeforeRemoval = null;
+        }
 
-    public void removeResource() {
-        idBeforeRemoval = resource.getId();
-        this.resource = null;
+        this.resource = resource;
     }
 
     public Resource<D> getResource() {

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkObjectIndex.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkObjectIndex.java
@@ -232,7 +232,7 @@ public class NetworkObjectIndex {
             if (obj != null) {
                 // to reuse the object from one variant to another one just set the resource to null
                 // and keep the object in the cache
-                obj.removeResource();
+                obj.setResource(null);
             }
         }
 

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/GeneratorTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/GeneratorTest.java
@@ -66,14 +66,31 @@ class GeneratorTest {
     void testIdBeforeRemovalMultipleVariants() {
         Network network = FourSubstationsNodeBreakerFactory.create();
 
-        Generator generator = network.getGenerator("GH3");
-        assertNotNull(generator);
-        generator.remove();
-        assertEquals("GH3", generator.getId());
-
         VariantManager variantManager = network.getVariantManager();
         variantManager.cloneVariant(VariantManagerConstants.INITIAL_VARIANT_ID, "variant1");
         variantManager.setWorkingVariant("variant1");
+
+        // Remove generator in variant1
+        Generator generator = network.getGenerator("GH3");
+        assertNotNull(generator);
+        generator.remove();
+        assertNull(network.getGenerator("GH3"));
+        assertEquals("GH3", generator.getId());
+
+        // Clone variant1 and switch to variant2 with removed generator
+        variantManager.cloneVariant("variant1", "variant2");
+        variantManager.setWorkingVariant("variant2");
+        assertNull(network.getGenerator("GH3"));
+        assertEquals("GH3", generator.getId());
+
+        // Switch to initial variant with existing generator
+        variantManager.setWorkingVariant(VariantManagerConstants.INITIAL_VARIANT_ID);
+        assertNotNull(network.getGenerator("GH3"));
+        assertEquals("GH3", generator.getId());
+
+        // Switch again to variant1 with removed generator
+        variantManager.setWorkingVariant("variant1");
+        assertNull(network.getGenerator("GH3"));
         assertEquals("GH3", generator.getId());
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Refacto after https://github.com/powsybl/powsybl-network-store/pull/524


**What is the current behavior?**
<!-- You can also link to an open issue here -->
idBeforeRemoval is handled in a separate method


**What is the new behavior (if this is a feature change)?**
idBeforeRemoval is handled in setResource.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No