### PR TITLE
Add back removeOperationalLimitsGroup

### DIFF
--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractBranchImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractBranchImpl.java
@@ -392,7 +392,17 @@ public abstract class AbstractBranchImpl<T extends Branch<T> & Connectable<T>, U
 
     @Override
     public void removeOperationalLimitsGroup1(String id) {
-        throw new UnsupportedOperationException("Remove operational limits groups from a branch not implemented");
+        var resource = getResource();
+        if (resource.getAttributes().getOperationalLimitsGroups1().get(id) == null) {
+            throw new IllegalArgumentException("Operational limits group '" + id + "' does not exist");
+        }
+        if (id.equals(resource.getAttributes().getSelectedOperationalLimitsGroupId1())) {
+            updateResource(res -> res.getAttributes().setSelectedOperationalLimitsGroupId1(null),
+                SELECTED_OPERATIONAL_LIMITS_GROUP_ID1, id, null);
+        }
+        var oldValue = getResource().getAttributes().getOperationalLimitsGroups1().get(id);
+        updateResource(res -> res.getAttributes().getOperationalLimitsGroups1().remove(id),
+            "operationalLimitsGroups1", oldValue, null);
     }
 
     @Override
@@ -463,7 +473,17 @@ public abstract class AbstractBranchImpl<T extends Branch<T> & Connectable<T>, U
 
     @Override
     public void removeOperationalLimitsGroup2(String id) {
-        throw new UnsupportedOperationException("Remove operational limits groups from a branch not implemented");
+        var resource = getResource();
+        if (resource.getAttributes().getOperationalLimitsGroups2().get(id) == null) {
+            throw new IllegalArgumentException("Operational limits group '" + id + "' does not exist");
+        }
+        if (id.equals(resource.getAttributes().getSelectedOperationalLimitsGroupId2())) {
+            updateResource(res -> res.getAttributes().setSelectedOperationalLimitsGroupId2(null),
+                SELECTED_OPERATIONAL_LIMITS_GROUP_ID2, id, null);
+        }
+        var oldValue = getResource().getAttributes().getOperationalLimitsGroups2().get(id);
+        updateResource(res -> res.getAttributes().getOperationalLimitsGroups2().remove(id),
+            "operationalLimitsGroups2", oldValue, null);
     }
 
     @Override

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/OperationalLimitsTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/OperationalLimitsTest.java
@@ -45,7 +45,6 @@ class OperationalLimitsTest {
         assertEquals(Optional.empty(), l1.getSelectedOperationalLimitsGroupId1());
         l1.setSelectedOperationalLimitsGroup1("group1");
         assertNotNull(l1.getSelectedOperationalLimitsGroup1());
-        /* FIXME: enable this when removeOperationalLimitsGroup1 is supported with lazy loading
         l1.removeOperationalLimitsGroup1("group1");
         assertEquals(Optional.empty(), l1.getOperationalLimitsGroup1("group1"));
         try {
@@ -54,7 +53,6 @@ class OperationalLimitsTest {
         } catch (IllegalArgumentException e) {
             assertEquals("Operational limits group 'group1' does not exist", e.getMessage());
         }
-        */
         l1.getOrCreateSelectedOperationalLimitsGroup1().newCurrentLimits().setPermanentLimit(9999).beginTemporaryLimit()
                 .setName("name1").setAcceptableDuration(9999).setValue(9999).endTemporaryLimit().add();
         assertEquals(9999, l1.getCurrentLimits1().get().getPermanentLimit());
@@ -88,7 +86,6 @@ class OperationalLimitsTest {
         assertEquals(Optional.empty(), l1.getSelectedOperationalLimitsGroupId2());
         l1.setSelectedOperationalLimitsGroup1("group2");
         assertNotNull(l1.getSelectedOperationalLimitsGroup2());
-        /* FIXME: enable this when removeOperationalLimitsGroup2 is supported with lazy loading
         l1.removeOperationalLimitsGroup2("group2");
         assertEquals(Optional.empty(), l1.getOperationalLimitsGroup2("group2"));
         try {
@@ -97,7 +94,6 @@ class OperationalLimitsTest {
         } catch (IllegalArgumentException e) {
             assertEquals("Operational limits group 'group2' does not exist", e.getMessage());
         }
-        */
         l1.getOrCreateSelectedOperationalLimitsGroup2().newCurrentLimits().setPermanentLimit(9999).beginTemporaryLimit()
                 .setName("name1").setAcceptableDuration(9999).setValue(9999).endTemporaryLimit().add();
         assertEquals(9999, l1.getCurrentLimits2().get().getPermanentLimit());

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/tck/OperationalLimitsGroupsTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/tck/OperationalLimitsGroupsTest.java
@@ -6,42 +6,10 @@
  */
 package com.powsybl.network.store.iidm.impl.tck;
 
-import com.powsybl.iidm.network.Line;
-import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.tck.AbstractOperationalLimitsGroupsTest;
-import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
-import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
  */
 public class OperationalLimitsGroupsTest extends AbstractOperationalLimitsGroupsTest {
-
-    @Override
-    public void testForOperationalLimitsGroupsOnLine() {
-        // Remove operational limit group not implemented yet for branches with lazy loading
-    }
-
-    @Test
-    void testRemoveOperationalLimitsGroup() {
-        Network network = EurostagTutorialExample1Factory.create();
-        Line line = network.getLine("NHV1_NHV2_1");
-
-        UnsupportedOperationException exception = assertThrows(
-                UnsupportedOperationException.class,
-                () -> line.removeOperationalLimitsGroup1("testGroup")
-        );
-        assertEquals("Remove operational limits groups from a branch not implemented", exception.getMessage());
-
-        exception = assertThrows(
-                UnsupportedOperationException.class,
-                () -> line.removeOperationalLimitsGroup2("testGroup")
-        );
-
-        assertEquals("Remove operational limits groups from a branch not implemented", exception.getMessage());
-    }
-
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Add again removeOperationalLimitsGroup method.


**What is the current behavior?**
<!-- You can also link to an open issue here -->
removeOperationalLimitsGroup throws an unsupported operation exception but it's used in some context to remove some operational limits group from memory before insertion in DB. 


**What is the new behavior (if this is a feature change)?**
removeOperationalLimitsGroup remove operational limits group from memory but it's still not implemented with the server.
