### PR TITLE
Fix unexpected fetch on server after network is created

### DIFF
--- a/network-store-client/src/test/java/com/powsybl/network/store/client/CachedNetworkStoreClientTest.java
+++ b/network-store-client/src/test/java/com/powsybl/network/store/client/CachedNetworkStoreClientTest.java
@@ -1260,4 +1260,35 @@ public class CachedNetworkStoreClientTest {
         server.reset();
         assertTrue(operationalLimitsGroupAttributes.isPresent());
     }
+
+    @Test
+    public void testGetNetworkAfterCreateAvoidServerCall() {
+        CachedNetworkStoreClient cachedClient = new CachedNetworkStoreClient(new BufferedNetworkStoreClient(restStoreClient, ForkJoinPool.commonPool()));
+        UUID networkUuid1 = UUID.fromString("7928181c-7977-4592-ba19-88027e4254e4");
+        UUID networkUuid2 = UUID.fromString("9028181c-7977-4592-ba19-88027e4254e4");
+
+        Resource<NetworkAttributes> network1 = Resource.networkBuilder()
+                .id("n1")
+                .attributes(NetworkAttributes.builder()
+                        .uuid(networkUuid1)
+                        .variantId(VariantManagerConstants.INITIAL_VARIANT_ID)
+                        .caseDate(ZonedDateTime.parse("2015-01-01T00:00:00.000Z"))
+                        .build())
+                .build();
+        Resource<NetworkAttributes> network2 = Resource.networkBuilder()
+                .id("n2")
+                .attributes(NetworkAttributes.builder()
+                        .uuid(networkUuid2)
+                        .variantId(VariantManagerConstants.INITIAL_VARIANT_ID)
+                        .caseDate(ZonedDateTime.parse("2015-01-01T00:00:00.000Z"))
+                        .build())
+                .build();
+        cachedClient.createNetworks(List.of(network1, network2));
+
+        cachedClient.getNetwork(networkUuid1, 0);
+        cachedClient.getNetwork(networkUuid2, 0);
+
+        server.verify();
+        server.reset();
+    }
 }

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/CachedNetworkStoreClient.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/CachedNetworkStoreClient.java
@@ -237,6 +237,8 @@ public class CachedNetworkStoreClient extends AbstractForwardingNetworkStoreClie
         for (Resource<NetworkAttributes> networkResource : networkResources) {
             UUID networkUuid = networkResource.getAttributes().getUuid();
             int variantNum = networkResource.getVariantNum();
+            // initialize network collection cache to set to fully loaded
+            networksCache.getCollection(networkUuid, variantNum).init();
             networksCache.getCollection(networkUuid, variantNum).createResource(networkResource);
             addIdentifiableId(networkUuid, networkResource);
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
When you create a network and just after get something from this same network, instead of hitting the cache, you hit the server.


**What is the new behavior (if this is a feature change)?**
When you create a network and just after get this same network, you hit the cache as expected. The network collection is correctly initialized as every other collections.