### PR TITLE
lazy loading fixes on branches

### DIFF
--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractBranchImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/AbstractBranchImpl.java
@@ -150,6 +150,8 @@ public abstract class AbstractBranchImpl<T extends Branch<T> & Connectable<T>, U
     public void setApparentPowerLimits(TwoSides side, LimitsAttributes apparentPowerLimitsAttributes, String operationalLimitsGroupId) {
         var attributes = getResource().getAttributes();
         if (side == TwoSides.ONE) {
+            // load operational limits group to cache
+            index.loadOperationalLimitsGroupAttributesForBranchSide(ResourceType.convert(getType()), getId(), 1);
             var operationalLimitsGroup = attributes.getOperationalLimitsGroup1(operationalLimitsGroupId);
             var oldApparentPowerLimits = operationalLimitsGroup != null ? operationalLimitsGroup.getApparentPowerLimits() : null;
             if (apparentPowerLimitsAttributes != oldApparentPowerLimits) {
@@ -157,6 +159,8 @@ public abstract class AbstractBranchImpl<T extends Branch<T> & Connectable<T>, U
                     "apparentPowerLimits1", oldApparentPowerLimits, apparentPowerLimitsAttributes);
             }
         } else if (side == TwoSides.TWO) {
+            // load operational limits group to cache
+            index.loadOperationalLimitsGroupAttributesForBranchSide(ResourceType.convert(getType()), getId(), 2);
             var operationalLimitsGroup = attributes.getOperationalLimitsGroup2(operationalLimitsGroupId);
             var oldApparentPowerLimits = operationalLimitsGroup != null ? operationalLimitsGroup.getApparentPowerLimits() : null;
             if (apparentPowerLimitsAttributes != oldApparentPowerLimits) {
@@ -226,6 +230,8 @@ public abstract class AbstractBranchImpl<T extends Branch<T> & Connectable<T>, U
     public void setActivePowerLimits(TwoSides side, LimitsAttributes activePowerLimitsAttributes, String operationalLimitsGroupId) {
         var attributes = getResource().getAttributes();
         if (side == TwoSides.ONE) {
+            // load operational limits group to cache
+            index.loadOperationalLimitsGroupAttributesForBranchSide(ResourceType.convert(getType()), getId(), 1);
             var operationalLimitsGroup = attributes.getOperationalLimitsGroup1(operationalLimitsGroupId);
             var oldActivePowerLimits = operationalLimitsGroup != null ? operationalLimitsGroup.getActivePowerLimits() : null;
             if (activePowerLimitsAttributes != oldActivePowerLimits) {
@@ -233,6 +239,8 @@ public abstract class AbstractBranchImpl<T extends Branch<T> & Connectable<T>, U
                     "activePowerLimits1", oldActivePowerLimits, activePowerLimitsAttributes);
             }
         } else if (side == TwoSides.TWO) {
+            // load operational limits group to cache
+            index.loadOperationalLimitsGroupAttributesForBranchSide(ResourceType.convert(getType()), getId(), 2);
             var operationalLimitsGroup = attributes.getOperationalLimitsGroup2(operationalLimitsGroupId);
             var oldActivePowerLimits = operationalLimitsGroup != null ? operationalLimitsGroup.getActivePowerLimits() : null;
             if (activePowerLimitsAttributes != oldActivePowerLimits) {
@@ -261,6 +269,8 @@ public abstract class AbstractBranchImpl<T extends Branch<T> & Connectable<T>, U
     public void setCurrentLimits(TwoSides side, LimitsAttributes currentLimits, String operationalLimitsGroupId) {
         var attributes = getResource().getAttributes();
         if (side == TwoSides.ONE) {
+            // load operational limits group to cache
+            index.loadOperationalLimitsGroupAttributesForBranchSide(ResourceType.convert(getType()), getId(), 1);
             var operationalLimitsGroup = attributes.getOperationalLimitsGroup1(operationalLimitsGroupId);
             var oldCurrentLimits = operationalLimitsGroup != null ? operationalLimitsGroup.getCurrentLimits() : null;
             if (currentLimits != oldCurrentLimits) {
@@ -268,6 +278,8 @@ public abstract class AbstractBranchImpl<T extends Branch<T> & Connectable<T>, U
                     "currentLimits1", oldCurrentLimits, currentLimits);
             }
         } else if (side == TwoSides.TWO) {
+            // load operational limits group to cache
+            index.loadOperationalLimitsGroupAttributesForBranchSide(ResourceType.convert(getType()), getId(), 2);
             var operationalLimitsGroup = attributes.getOperationalLimitsGroup2(operationalLimitsGroupId);
             var oldCurrentLimits = operationalLimitsGroup != null ? operationalLimitsGroup.getCurrentLimits() : null;
             if (currentLimits != oldCurrentLimits) {
@@ -375,9 +387,12 @@ public abstract class AbstractBranchImpl<T extends Branch<T> & Connectable<T>, U
     @Override
     public OperationalLimitsGroup newOperationalLimitsGroup1(String id) {
         var resource = getResource();
-        var group = OperationalLimitsGroupAttributes.builder().id(id).build();
-        resource.getAttributes().getOperationalLimitsGroups1().put(id, group);
-        return new OperationalLimitsGroupImpl<>(this, TwoSides.ONE, group);
+        var newGroup = OperationalLimitsGroupAttributes.builder().id(id).build();
+        index.loadOperationalLimitsGroupAttributesForBranchSide(ResourceType.convert(getType()), getId(), 1);
+        OperationalLimitsGroupAttributes oldValue = resource.getAttributes().getOperationalLimitsGroups1().get(id); // can be null
+        updateResource(res -> resource.getAttributes().getOperationalLimitsGroups1().put(id, newGroup),
+                "operationalLimitsGroup1", oldValue, newGroup);
+        return new OperationalLimitsGroupImpl<>(this, TwoSides.ONE, newGroup);
     }
 
     @Override
@@ -455,7 +470,11 @@ public abstract class AbstractBranchImpl<T extends Branch<T> & Connectable<T>, U
     public OperationalLimitsGroup newOperationalLimitsGroup2(String id) {
         var resource = getResource();
         var group = OperationalLimitsGroupAttributes.builder().id(id).build();
-        resource.getAttributes().getOperationalLimitsGroups2().put(id, group);
+        // load operational limits group to cache
+        index.loadOperationalLimitsGroupAttributesForBranchSide(ResourceType.convert(getType()), getId(), 2);
+        OperationalLimitsGroupAttributes oldValue = resource.getAttributes().getOperationalLimitsGroups2().get(id);
+        updateResource(res -> resource.getAttributes().getOperationalLimitsGroups2().put(id, group),
+                "operationalLimitsGroup2", oldValue, group);
         return new OperationalLimitsGroupImpl<>(this, TwoSides.TWO, group);
     }
 

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/OperationalLimitsTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/OperationalLimitsTest.java
@@ -66,7 +66,7 @@ class OperationalLimitsTest {
     }
 
     @Test
-        void lineOperationalLimits2Test() {
+    void lineOperationalLimits2Test() {
         Network network = CreateNetworksUtil.createBusBreakerNetwokWithMultipleEquipments();
         LineImpl l1 = (LineImpl) network.getLine("LINE1");
         assertEquals(Optional.empty(), l1.getOperationalLimitsGroup2("group2"));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
no


**What kind of change does this PR introduce?**
Bug fix


**What is the current behavior?**
when setting limits, the previous limits gropup is used and it is not loaded from the back if not in the cache
when creating a new operational limits group an updateResource is missing


**What is the new behavior (if this is a feature change)?**
fix it


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
