### PR TITLE
dirty fix for remove extension for vl

### DIFF
--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/VoltageLevelImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/VoltageLevelImpl.java
@@ -613,8 +613,7 @@ public class VoltageLevelImpl extends AbstractIdentifiableImpl<VoltageLevel, Vol
 
     @Override
     public <E extends Extension<VoltageLevel>> boolean removeExtension(Class<E> type) {
-        // as buffer is not implemented yet for remove extensions, if an extension is removed
-        // when network is imported it crash as the network is still in the buffer and not yet in the database.
+        // FIXME : as buffer is not implemented yet for remove extensions, if an extension is removed when network is imported it crash as the network is still in the buffer and not yet in the database.
         // super.removeExtension(type);
         if (type == SlackTerminal.class) {
             var resource = getResource();

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/VoltageLevelImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/VoltageLevelImpl.java
@@ -613,7 +613,9 @@ public class VoltageLevelImpl extends AbstractIdentifiableImpl<VoltageLevel, Vol
 
     @Override
     public <E extends Extension<VoltageLevel>> boolean removeExtension(Class<E> type) {
-        super.removeExtension(type);
+        // as buffer is not implemented yet for remove extensions, if an extension is removed
+        // when network is imported it crash as the network is still in the buffer and not yet in the database.
+        // super.removeExtension(type);
         if (type == SlackTerminal.class) {
             var resource = getResource();
             if (resource.getAttributes().getSlackTerminal() != null) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
no



**What kind of change does this PR introduce?**
Bug fix



**What is the current behavior?**
when importing a network if an extension is removed  it crashes as buffer is not implemented yet for remove extensions and the network is still in the buffer and not yet in the database. 


**What is the new behavior (if this is a feature change)?**
does not remove the extension if present at import


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
