### PR TITLE
optimize: cache computed nodes in calculated buses

### DIFF
--- a/network-store-client/src/main/java/com/powsybl/network/store/client/NetworkStoreConfig.java
+++ b/network-store-client/src/main/java/com/powsybl/network/store/client/NetworkStoreConfig.java
@@ -8,7 +8,6 @@ package com.powsybl.network.store.client;
 
 import com.powsybl.commons.config.ModuleConfig;
 import com.powsybl.commons.config.PlatformConfig;
-import com.powsybl.network.store.iidm.impl.NetworkFactoryServiceImpl;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -26,11 +25,6 @@ public final class NetworkStoreConfig {
 
     private PreloadingStrategy preloadingStrategy = DEFAULT_PRELOADING_STRATEGY;
 
-    // For now this one is
-    // probably only temporary until we fix the underlying
-    // performance issue that forces us to have it
-    private boolean useCalculatedBusFictitiousP0Q0 = NetworkFactoryServiceImpl.DEFAULT_USE_CALCULATEDBUS_FICTITIOUSP0Q0;
-
     public NetworkStoreConfig(String baseUrl) {
         this.baseUrl = Objects.requireNonNull(baseUrl);
     }
@@ -40,21 +34,14 @@ public final class NetworkStoreConfig {
     }
 
     public static NetworkStoreConfig load() {
-        PlatformConfig platformConfig = PlatformConfig.defaultConfig();
-        // Configs for the client-server interactions
-        Optional<ModuleConfig> moduleConfig = platformConfig
+        Optional<ModuleConfig> moduleConfig = PlatformConfig.defaultConfig()
                 .getOptionalModuleConfig("network-store");
         String baseUrl = moduleConfig.flatMap(mc -> mc.getOptionalStringProperty("base-url"))
                 .orElse(DEFAULT_BASE_URL);
         PreloadingStrategy preloadingStrategy = moduleConfig.flatMap(mc -> mc.getOptionalEnumProperty("preloading-strategy", PreloadingStrategy.class))
                 .orElse(DEFAULT_PRELOADING_STRATEGY);
-
-        // Configs independent of the server
-        boolean useCalculatedBusFictitiousP0Q0 = NetworkFactoryServiceImpl.loadConfigUseCalculatedBusFictitiousP0Q0(platformConfig);
-
         return new NetworkStoreConfig(baseUrl)
-                .setPreloadingStrategy(preloadingStrategy)
-                .setUseCalculatedBusFictitiousP0Q0(useCalculatedBusFictitiousP0Q0);
+                .setPreloadingStrategy(preloadingStrategy);
     }
 
     public String getBaseUrl() {
@@ -72,15 +59,6 @@ public final class NetworkStoreConfig {
 
     public NetworkStoreConfig setPreloadingStrategy(PreloadingStrategy preloadingStrategy) {
         this.preloadingStrategy = Objects.requireNonNull(preloadingStrategy);
-        return this;
-    }
-
-    public boolean isUseCalculatedBusFictitiousP0Q0() {
-        return useCalculatedBusFictitiousP0Q0;
-    }
-
-    public NetworkStoreConfig setUseCalculatedBusFictitiousP0Q0(boolean useCalculatedBusFictitiousP0Q0) {
-        this.useCalculatedBusFictitiousP0Q0 = useCalculatedBusFictitiousP0Q0;
         return this;
     }
 }

--- a/network-store-client/src/main/java/com/powsybl/network/store/client/NetworkStoreService.java
+++ b/network-store-client/src/main/java/com/powsybl/network/store/client/NetworkStoreService.java
@@ -18,7 +18,6 @@ import com.powsybl.iidm.network.NetworkFactory;
 import com.powsybl.network.store.client.util.ExecutorUtil;
 import com.powsybl.network.store.iidm.impl.CachedNetworkStoreClient;
 import com.powsybl.network.store.iidm.impl.NetworkFactoryImpl;
-import com.powsybl.network.store.iidm.impl.NetworkFactoryServiceImpl;
 import com.powsybl.network.store.iidm.impl.NetworkImpl;
 import com.powsybl.network.store.iidm.impl.NetworkStoreClient;
 import com.powsybl.network.store.iidm.impl.util.TriFunction;
@@ -63,16 +62,6 @@ public class NetworkStoreService implements AutoCloseable {
         Executors.newFixedThreadPool(ResourceType.values().length),
         contextSnapshotFactory::captureAll);
 
-    // if we start to have more things like this, we should
-    // group them in a separate class. For now this one is
-    // probably only temporary until we fix the underlying
-    // performance issue that forces us to have it
-    // NOTE: in this class we don't allow to pass this param
-    // at every method level, it is fixed in the constructor because
-    // we just need a static configuration, so either from spring's application.yaml
-    // or from powsybl itools config.yaml (NetworkStoreConfig)
-    private final boolean useCalculatedBusFictitiousP0Q0;
-
     public NetworkStoreService(String baseUri) {
         this(baseUri, PreloadingStrategy.NONE);
     }
@@ -81,44 +70,27 @@ public class NetworkStoreService implements AutoCloseable {
         this(new RestClientImpl(baseUri), defaultPreloadingStrategy);
     }
 
-    public NetworkStoreService(RestClient restClient, PreloadingStrategy defaultPreloadingStrategy) {
-        this(restClient, defaultPreloadingStrategy, NetworkFactoryServiceImpl.DEFAULT_USE_CALCULATEDBUS_FICTITIOUSP0Q0);
-    }
-
     @Autowired
     public NetworkStoreService(RestClient restClient,
-                               @Value("${powsybl.services.network-store-server.preloading-strategy:NONE}") PreloadingStrategy defaultPreloadingStrategy,
-                               @Value("${powsybl.services.network-store-server.useCalculatedBusFictitiousP0Q0:true}") boolean useCalculatedBusFictitiousP0Q0) {
-        this(restClient, defaultPreloadingStrategy, NetworkStoreService::createStoreClient, useCalculatedBusFictitiousP0Q0);
-    }
-
-    public NetworkStoreService(RestClient restClient,
-            PreloadingStrategy defaultPreloadingStrategy,
-            TriFunction<RestClient, PreloadingStrategy, ExecutorService, NetworkStoreClient> decorator) {
-        this(restClient, defaultPreloadingStrategy, decorator, NetworkFactoryServiceImpl.DEFAULT_USE_CALCULATEDBUS_FICTITIOUSP0Q0);
+                               @Value("${powsybl.services.network-store-server.preloading-strategy:NONE}") PreloadingStrategy defaultPreloadingStrategy) {
+        this(restClient, defaultPreloadingStrategy, NetworkStoreService::createStoreClient);
     }
 
     NetworkStoreService(RestClient restClient, PreloadingStrategy defaultPreloadingStrategy,
-                        TriFunction<RestClient, PreloadingStrategy, ExecutorService, NetworkStoreClient> decorator,
-                        boolean useCalculatedBusFictitiousP0Q0) {
+                        TriFunction<RestClient, PreloadingStrategy, ExecutorService, NetworkStoreClient> decorator) {
         this.restClient = Objects.requireNonNull(restClient);
         this.defaultPreloadingStrategy = Objects.requireNonNull(defaultPreloadingStrategy);
         this.decorator = Objects.requireNonNull(decorator);
-        this.useCalculatedBusFictitiousP0Q0 = useCalculatedBusFictitiousP0Q0;
     }
 
     public NetworkStoreService(String baseUri, PreloadingStrategy defaultPreloadingStrategy,
                                TriFunction<RestClient, PreloadingStrategy, ExecutorService, NetworkStoreClient> decorator) {
-        this(new RestClientImpl(baseUri), defaultPreloadingStrategy, decorator, NetworkFactoryServiceImpl.DEFAULT_USE_CALCULATEDBUS_FICTITIOUSP0Q0);
-    }
-
-    public NetworkStoreService(String baseUri, PreloadingStrategy defaultPreloadingStrategy, boolean useCalculatedBusFictitiousP0Q0) {
-        this(new RestClientImpl(baseUri), defaultPreloadingStrategy, NetworkStoreService::createStoreClient, useCalculatedBusFictitiousP0Q0);
+        this(new RestClientImpl(baseUri), defaultPreloadingStrategy, decorator);
     }
 
     public static NetworkStoreService create(NetworkStoreConfig config) {
         Objects.requireNonNull(config);
-        return new NetworkStoreService(config.getBaseUrl(), config.getPreloadingStrategy(), config.isUseCalculatedBusFictitiousP0Q0());
+        return new NetworkStoreService(config.getBaseUrl(), config.getPreloadingStrategy());
     }
 
     private PreloadingStrategy getNonNullPreloadingStrategy(PreloadingStrategy preloadingStrategy) {
@@ -143,8 +115,7 @@ public class NetworkStoreService implements AutoCloseable {
     }
 
     public NetworkFactory getNetworkFactory(PreloadingStrategy preloadingStrategy) {
-        return new NetworkFactoryImpl(() -> decorator.apply(restClient, getNonNullPreloadingStrategy(preloadingStrategy), executorService),
-                useCalculatedBusFictitiousP0Q0);
+        return new NetworkFactoryImpl(() -> decorator.apply(restClient, getNonNullPreloadingStrategy(preloadingStrategy), executorService));
     }
 
     public Network createNetwork(String id, String sourceFormat) {
@@ -241,7 +212,7 @@ public class NetworkStoreService implements AutoCloseable {
         Objects.requireNonNull(uuid);
         NetworkStoreClient storeClient = decorator.apply(restClient, getNonNullPreloadingStrategy(preloadingStrategy), executorService);
         return NetworkImpl.create(storeClient, storeClient.getNetwork(uuid, Resource.INITIAL_VARIANT_NUM)
-                .orElseThrow(() -> new PowsyblException("Network '" + uuid + "' not found")), useCalculatedBusFictitiousP0Q0);
+                .orElseThrow(() -> new PowsyblException("Network '" + uuid + "' not found")));
     }
 
     public void deleteNetwork(UUID uuid) {

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/CalculatedBus.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/CalculatedBus.java
@@ -50,22 +50,14 @@ public final class CalculatedBus implements BaseBus {
 
     private final List<Integer> nodes;
 
-    CalculatedBus(NetworkObjectIndex index, String voltageLevelId, String id, String name, Resource<VoltageLevelAttributes> voltageLevelResource,
-                  int calculatedBusNum, boolean isBusView) {
-        this.index = Objects.requireNonNull(index);
-        this.voltageLevelId = Objects.requireNonNull(voltageLevelId);
-        this.id = Objects.requireNonNull(id);
-        this.name = name;
-        this.voltageLevelResource = Objects.requireNonNull(voltageLevelResource);
-        this.calculatedBusNum = calculatedBusNum;
-        this.isBusView = isBusView;
-        connectedComponent = new ComponentImpl(this, ComponentType.CONNECTED);
-        synchronousComponent = new ComponentImpl(this, ComponentType.SYNCHRONOUS);
-        this.nodes = new ArrayList<>();
+    CalculatedBus(NetworkObjectIndex index, String voltageLevelId, String id, String name,
+                  Resource<VoltageLevelAttributes> voltageLevelResource, int calculatedBusNum, boolean isBusView) {
+        this(index, voltageLevelId, id, name, voltageLevelResource, calculatedBusNum, isBusView, Collections.emptyList());
     }
 
-    CalculatedBus(NetworkObjectIndex index, String voltageLevelId, String id, String name, Resource<VoltageLevelAttributes> voltageLevelResource,
-                  int calculatedBusNum, boolean isBusView, List<Integer> nodes) {
+    CalculatedBus(NetworkObjectIndex index, String voltageLevelId, String id, String name,
+                  Resource<VoltageLevelAttributes> voltageLevelResource, int calculatedBusNum, boolean isBusView,
+                  List<Integer> nodes) {
         this.index = Objects.requireNonNull(index);
         this.voltageLevelId = Objects.requireNonNull(voltageLevelId);
         this.id = Objects.requireNonNull(id);

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/CalculatedBus.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/CalculatedBus.java
@@ -50,6 +50,7 @@ public final class CalculatedBus implements BaseBus {
 
     private final List<Integer> nodes;
 
+    // Used in bus-breaker view as nodes are not defined and won't be used in calculations
     CalculatedBus(NetworkObjectIndex index, String voltageLevelId, String id, String name,
                   Resource<VoltageLevelAttributes> voltageLevelResource, int calculatedBusNum, boolean isBusView) {
         this(index, voltageLevelId, id, name, voltageLevelResource, calculatedBusNum, isBusView, Collections.emptyList());

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/CalculatedBus.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/CalculatedBus.java
@@ -12,7 +12,6 @@ import com.powsybl.commons.extensions.ExtensionAdder;
 import com.powsybl.commons.extensions.ExtensionAdderProvider;
 import com.powsybl.commons.extensions.ExtensionAdderProviders;
 import com.powsybl.iidm.network.*;
-import com.powsybl.iidm.network.util.Networks;
 import com.powsybl.network.store.model.*;
 import lombok.EqualsAndHashCode;
 import org.apache.commons.collections4.CollectionUtils;
@@ -20,7 +19,6 @@ import org.apache.commons.collections4.MapUtils;
 
 import java.util.*;
 import java.util.Map.Entry;
-import java.util.function.Function;
 import java.util.function.ObjDoubleConsumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -50,7 +48,7 @@ public final class CalculatedBus implements BaseBus {
 
     private final ComponentImpl synchronousComponent;
 
-    private final Function<Terminal, Bus> getBusFromTerminal;
+    private final List<Integer> nodes;
 
     CalculatedBus(NetworkObjectIndex index, String voltageLevelId, String id, String name, Resource<VoltageLevelAttributes> voltageLevelResource,
                   int calculatedBusNum, boolean isBusView) {
@@ -63,7 +61,21 @@ public final class CalculatedBus implements BaseBus {
         this.isBusView = isBusView;
         connectedComponent = new ComponentImpl(this, ComponentType.CONNECTED);
         synchronousComponent = new ComponentImpl(this, ComponentType.SYNCHRONOUS);
-        getBusFromTerminal = isBusView ? t -> t.getBusView().getBus() : t -> t.getBusBreakerView().getBus();
+        this.nodes = new ArrayList<>();
+    }
+
+    CalculatedBus(NetworkObjectIndex index, String voltageLevelId, String id, String name, Resource<VoltageLevelAttributes> voltageLevelResource,
+                  int calculatedBusNum, boolean isBusView, List<Integer> nodes) {
+        this.index = Objects.requireNonNull(index);
+        this.voltageLevelId = Objects.requireNonNull(voltageLevelId);
+        this.id = Objects.requireNonNull(id);
+        this.name = name;
+        this.voltageLevelResource = Objects.requireNonNull(voltageLevelResource);
+        this.calculatedBusNum = calculatedBusNum;
+        this.isBusView = isBusView;
+        connectedComponent = new ComponentImpl(this, ComponentType.CONNECTED);
+        synchronousComponent = new ComponentImpl(this, ComponentType.SYNCHRONOUS);
+        this.nodes = new ArrayList<>(nodes);
     }
 
     boolean isBusView() {
@@ -201,20 +213,8 @@ public final class CalculatedBus implements BaseBus {
 
     @Override
     public double getFictitiousP0() {
-        if (!getNetwork().isUseCalculatedBusFictitiousP0Q0()) {
-            // [performance.hack] TODO: this should absolutely not stay like this
-            /*
-            For now this method is not used in any service, and it is not filled (value is set to 0 in any bus) because
-            it will be filled later on by estimation computation. At this time we will have to fix this.
-            We introduce this hack because it causes serious performance regressions in loadflow computation
-            due to unpersisted bus graph. So, we will have to fix this issue before restablishing the original code.
-            Search [performance.hack] tag to see where it should be fixed in the code
-             */
-            return 0;
-        }
-
         return TopologyKind.NODE_BREAKER == getVoltageLevel().getTopologyKind() ?
-            Networks.getNodes(id, getVoltageLevel(), getBusFromTerminal)
+            nodes.stream()
                 .mapToDouble(n -> getVoltageLevel().getNodeBreakerView().getFictitiousP0(n))
                 .reduce(0.0, Double::sum) :
             getAllTerminalsStream().map(t -> t.getBusBreakerView().getBus()).distinct()
@@ -225,11 +225,11 @@ public final class CalculatedBus implements BaseBus {
     @Override
     public Bus setFictitiousP0(double p0) {
         if (TopologyKind.NODE_BREAKER == getVoltageLevel().getTopologyKind()) {
-            Networks.getNodes(id, getVoltageLevel(), getBusFromTerminal).forEach(n -> getVoltageLevel().getNodeBreakerView().setFictitiousP0(n, 0.0));
-            getVoltageLevel().getNodeBreakerView().setFictitiousP0(Networks.getNodes(id, getVoltageLevel(), getBusFromTerminal)
-                    .findFirst()
-                    .orElseThrow(() -> new PowsyblException("Bus " + id + " should contain at least one node")),
-                p0);
+            if (nodes.isEmpty()) {
+                throw new PowsyblException("Bus " + id + " should contain at least one node");
+            }
+            nodes.forEach(n -> getVoltageLevel().getNodeBreakerView().setFictitiousP0(n, 0.0));
+            getVoltageLevel().getNodeBreakerView().setFictitiousP0(nodes.getFirst(), p0);
         } else {
             getAllTerminalsStream().map(t -> t.getBusBreakerView().getBus()).distinct().forEach(b -> b.setFictitiousP0(p0));
         }
@@ -238,34 +238,23 @@ public final class CalculatedBus implements BaseBus {
 
     @Override
     public double getFictitiousQ0() {
-        if (!getNetwork().isUseCalculatedBusFictitiousP0Q0()) {
-            // [performance.hack] TODO: this should absolutely not stay like this
-            /*
-            For now this method is not used in any service, and it is not filled (value is set to 0 in any bus) because
-            it will be filled later on by estimation computation. At this time we will have to fix this.
-            We introduce this hack because it causes serious performance regressions in loadflow computation
-            due to unpersisted bus graph. So, we will have to fix this issue before restablishing the original code.
-            Search [performance.hack] tag to see where it should be fixed in the code
-             */
-            return 0;
-        }
         return TopologyKind.NODE_BREAKER == getVoltageLevel().getTopologyKind() ?
-            Networks.getNodes(id, getVoltageLevel(), getBusFromTerminal)
-                .mapToDouble(n -> getVoltageLevel().getNodeBreakerView().getFictitiousQ0(n))
-                .reduce(0.0, Double::sum) :
-            getAllTerminalsStream().map(t -> t.getBusBreakerView().getBus()).distinct()
-                .map(Bus::getFictitiousQ0)
-                .reduce(0.0, Double::sum);
+                nodes.stream()
+                    .mapToDouble(n -> getVoltageLevel().getNodeBreakerView().getFictitiousQ0(n))
+                    .reduce(0.0, Double::sum) :
+                getAllTerminalsStream().map(t -> t.getBusBreakerView().getBus()).distinct()
+                    .map(Bus::getFictitiousQ0)
+                    .reduce(0.0, Double::sum);
     }
 
     @Override
     public Bus setFictitiousQ0(double q0) {
         if (TopologyKind.NODE_BREAKER == getVoltageLevel().getTopologyKind()) {
-            Networks.getNodes(id, getVoltageLevel(), getBusFromTerminal).forEach(n -> getVoltageLevel().getNodeBreakerView().setFictitiousQ0(n, 0.0));
-            getVoltageLevel().getNodeBreakerView().setFictitiousQ0(Networks.getNodes(id, getVoltageLevel(), getBusFromTerminal)
-                    .findFirst()
-                    .orElseThrow(() -> new PowsyblException("Bus " + id + " should contain at least one node")),
-                q0);
+            if (nodes.isEmpty()) {
+                throw new PowsyblException("Bus " + id + " should contain at least one node");
+            }
+            nodes.forEach(n -> getVoltageLevel().getNodeBreakerView().setFictitiousQ0(n, 0.0));
+            getVoltageLevel().getNodeBreakerView().setFictitiousQ0(nodes.getFirst(), q0);
         } else {
             getAllTerminalsStream().map(t -> t.getBusBreakerView().getBus()).distinct().forEach(b -> b.setFictitiousQ0(q0));
         }

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkFactoryImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkFactoryImpl.java
@@ -25,27 +25,12 @@ public class NetworkFactoryImpl implements NetworkFactory {
 
     private final Supplier<NetworkStoreClient> storeClientSupplier;
 
-    // if we start to have more things like this, we should
-    // group them in a separate class. For now this one is
-    // probably only temporary until we fix the underlying
-    // performance issue that forces us to have it
-    private final boolean useCalculatedBusFictitiousP0Q0;
-
     public NetworkFactoryImpl() {
         this(() -> new CachedNetworkStoreClient(new OfflineNetworkStoreClient()));
     }
 
-    public NetworkFactoryImpl(boolean useCalculatedBusFictitiousP0Q0) {
-        this(() -> new CachedNetworkStoreClient(new OfflineNetworkStoreClient()), useCalculatedBusFictitiousP0Q0);
-    }
-
     public NetworkFactoryImpl(Supplier<NetworkStoreClient> storeClientSupplier) {
-        this(storeClientSupplier, NetworkFactoryServiceImpl.DEFAULT_USE_CALCULATEDBUS_FICTITIOUSP0Q0);
-    }
-
-    public NetworkFactoryImpl(Supplier<NetworkStoreClient> storeClientSupplier, boolean useCalculatedBusFictitiousP0Q0) {
         this.storeClientSupplier = Objects.requireNonNull(storeClientSupplier);
-        this.useCalculatedBusFictitiousP0Q0 = useCalculatedBusFictitiousP0Q0;
     }
 
     @Override
@@ -64,7 +49,7 @@ public class NetworkFactoryImpl implements NetworkFactory {
                                              .build())
                 .build();
         storeClient.createNetworks(Collections.singletonList(resource));
-        return NetworkImpl.create(storeClient, resource, useCalculatedBusFictitiousP0Q0);
+        return NetworkImpl.create(storeClient, resource);
     }
 
     @Override

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkFactoryServiceImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkFactoryServiceImpl.java
@@ -6,11 +6,7 @@
  */
 package com.powsybl.network.store.iidm.impl;
 
-import java.util.Optional;
-
 import com.google.auto.service.AutoService;
-import com.powsybl.commons.config.ModuleConfig;
-import com.powsybl.commons.config.PlatformConfig;
 import com.powsybl.iidm.network.NetworkFactory;
 import com.powsybl.iidm.network.NetworkFactoryService;
 
@@ -21,8 +17,6 @@ import com.powsybl.iidm.network.NetworkFactoryService;
 @AutoService(NetworkFactoryService.class)
 public class NetworkFactoryServiceImpl implements NetworkFactoryService {
 
-    public static final boolean DEFAULT_USE_CALCULATEDBUS_FICTITIOUSP0Q0 = true;
-
     @Override
     public String getName() {
         return "NetworkStore";
@@ -30,24 +24,6 @@ public class NetworkFactoryServiceImpl implements NetworkFactoryService {
 
     @Override
     public NetworkFactory createNetworkFactory() {
-        boolean useCalculatedBusFictitiousP0Q0 = loadConfigUseCalculatedBusFictitiousP0Q0();
-        return new NetworkFactoryImpl(useCalculatedBusFictitiousP0Q0);
-    }
-
-    // if we start to have more things like this, we should
-    // group them in a separate class of parameters independant
-    // of the server. For now this one is
-    // probably only temporary until we fix the underlying
-    // performance issue that forces us to have it
-    public static boolean loadConfigUseCalculatedBusFictitiousP0Q0() {
-        return loadConfigUseCalculatedBusFictitiousP0Q0(PlatformConfig.defaultConfig());
-    }
-
-    public static boolean loadConfigUseCalculatedBusFictitiousP0Q0(PlatformConfig platformConfig) {
-        Optional<ModuleConfig> moduleConfig = platformConfig
-                .getOptionalModuleConfig("network-store-iidm");
-        boolean useCalculatedBusFictitiousP0Q0 = moduleConfig.flatMap(mc -> mc.getOptionalBooleanProperty("use-calculatedbus-fictitiousP0Q0"))
-                .orElse(DEFAULT_USE_CALCULATEDBUS_FICTITIOUSP0Q0);
-        return useCalculatedBusFictitiousP0Q0;
+        return new NetworkFactoryImpl();
     }
 }

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NetworkImpl.java
@@ -51,25 +51,10 @@ public class NetworkImpl extends AbstractIdentifiableImpl<Network, NetworkAttrib
 
     private AbstractReportNodeContext reporterContext;
 
-    // if we start to have more things like this, we should
-    // group them in a separate class. For now this one is
-    // probably only temporary until we fix the underlying
-    // performance issue that forces us to have it
-    private final boolean useCalculatedBusFictitiousP0Q0;
-
-    public NetworkImpl(NetworkStoreClient storeClient, Resource<NetworkAttributes> resource, boolean useCalculatedBusFictitiousP0Q0) {
+    public NetworkImpl(NetworkStoreClient storeClient, Resource<NetworkAttributes> resource) {
         super(new NetworkObjectIndex(storeClient), resource);
         this.reporterContext = new SimpleReportNodeContext();
-        this.useCalculatedBusFictitiousP0Q0 = useCalculatedBusFictitiousP0Q0;
         index.setNetwork(this);
-    }
-
-    public NetworkImpl(NetworkStoreClient storeClient, Resource<NetworkAttributes> resource) {
-        this(storeClient, resource, NetworkFactoryServiceImpl.DEFAULT_USE_CALCULATEDBUS_FICTITIOUSP0Q0);
-    }
-
-    public static NetworkImpl create(NetworkStoreClient storeClient, Resource<NetworkAttributes> resource, boolean useCalculatedBusFictitiousP0Q0) {
-        return new NetworkImpl(storeClient, resource, useCalculatedBusFictitiousP0Q0);
     }
 
     public static NetworkImpl create(NetworkStoreClient storeClient, Resource<NetworkAttributes> resource) {
@@ -1339,10 +1324,6 @@ public class NetworkImpl extends AbstractIdentifiableImpl<Network, NetworkAttrib
         // FIXME: if needed implement detailed dc model
         // needed for cgmes export in https://github.com/powsybl/powsybl-core/blob/main/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/export/CgmesExportContext.java#L362
         return Collections.emptyList();
-    }
-
-    public boolean isUseCalculatedBusFictitiousP0Q0() {
-        return useCalculatedBusFictitiousP0Q0;
     }
 
     @Override

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NodeBreakerTopology.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/NodeBreakerTopology.java
@@ -129,9 +129,10 @@ public class NodeBreakerTopology extends AbstractTopology<Integer> {
     protected CalculatedBus createCalculatedBus(NetworkObjectIndex index, Resource<VoltageLevelAttributes> voltageLevelResource, int calculatedBusNum, boolean isBusView) {
         // to have a unique and stable calculated bus id, we use voltage level id as a base id plus the minimum node
         Map<Integer, Integer> nodeToCalculatedBus = isBusView ? voltageLevelResource.getAttributes().getNodeToCalculatedBusForBusView() : voltageLevelResource.getAttributes().getNodeToCalculatedBusForBusBreakerView();
-        int firstNode = nodeToCalculatedBus.entrySet().stream().filter(e -> e.getValue() == calculatedBusNum).map(Map.Entry::getKey).min(Integer::compare).orElseThrow(IllegalStateException::new);
+        List<Integer> nodes = nodeToCalculatedBus.entrySet().stream().filter(e -> e.getValue() == calculatedBusNum).map(Map.Entry::getKey).toList();
+        int firstNode = nodes.stream().min(Integer::compare).orElseThrow(IllegalStateException::new);
         String busId = voltageLevelResource.getId() + calculatedBusSeparator + firstNode;
         String busName = voltageLevelResource.getAttributes().getName() != null ? voltageLevelResource.getAttributes().getName() + calculatedBusSeparator + firstNode : null;
-        return new CalculatedBus(index, voltageLevelResource.getId(), busId, busName, voltageLevelResource, calculatedBusNum, isBusView);
+        return new CalculatedBus(index, voltageLevelResource.getId(), busId, busName, voltageLevelResource, calculatedBusNum, isBusView, nodes);
     }
 }

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/VoltageLevelTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/VoltageLevelTest.java
@@ -23,6 +23,10 @@ import static org.junit.Assert.*;
  */
 public class VoltageLevelTest {
 
+    private static final double EPSILON = 0.0001;
+    private static final double FICTITIOUS_P0 = 10.;
+    private static final double FICTITIOUS_Q0 = 15.;
+
     @Test
     // For busbreaker topology,
     // set in busbreakerview when busview cache exists
@@ -221,5 +225,150 @@ public class VoltageLevelTest {
         assertNotNull(vl1.getExtension(IdentifiableShortCircuit.class));
         assertTrue(vl1.removeExtension(IdentifiableShortCircuit.class));
         assertNull(vl1.getExtension(IdentifiableShortCircuit.class));
+    }
+
+    @Test
+    public void testFictitiousInjectionsInNodeBreaker() {
+        Network network = CreateNetworksUtil.createNodeBreakerNetworkWithLine();
+        VoltageLevel vl1 = network.getVoltageLevel("VL1");
+
+        assertEquals(0., vl1.getNodeBreakerView().getFictitiousP0(0), EPSILON);
+        assertEquals(0., vl1.getNodeBreakerView().getFictitiousQ0(0), EPSILON);
+
+        assertEquals(0., vl1.getBusBreakerView().getBus("VL1_0").getFictitiousP0(), EPSILON);
+        assertEquals(0., vl1.getBusBreakerView().getBus("VL1_0").getFictitiousQ0(), EPSILON);
+
+        assertEquals(0., vl1.getBusView().getBus("VL1_0").getFictitiousP0(), EPSILON);
+        assertEquals(0., vl1.getBusView().getBus("VL1_0").getFictitiousQ0(), EPSILON);
+
+        vl1.getNodeBreakerView().setFictitiousP0(0, FICTITIOUS_P0);
+        vl1.getNodeBreakerView().setFictitiousQ0(0, FICTITIOUS_Q0);
+
+        assertEquals(FICTITIOUS_P0, vl1.getNodeBreakerView().getFictitiousP0(0), EPSILON);
+        assertEquals(FICTITIOUS_Q0, vl1.getNodeBreakerView().getFictitiousQ0(0), EPSILON);
+
+        assertEquals(FICTITIOUS_P0, vl1.getBusBreakerView().getBus("VL1_0").getFictitiousP0(), EPSILON);
+        assertEquals(FICTITIOUS_Q0, vl1.getBusBreakerView().getBus("VL1_0").getFictitiousQ0(), EPSILON);
+
+        assertEquals(FICTITIOUS_P0, vl1.getBusView().getBus("VL1_0").getFictitiousP0(), EPSILON);
+        assertEquals(FICTITIOUS_Q0, vl1.getBusView().getBus("VL1_0").getFictitiousQ0(), EPSILON);
+    }
+
+    @Test
+    public void testFictitiousInjectionsInNodeBreakerWithSeveralBBSAreRecomputedAfterDisconnection() {
+        Network network = CreateNetworksUtil.createNodeBreakerNetworkWithLine();
+        VoltageLevel vl1 = network.getVoltageLevel("VL1");
+        addBusBarSection(vl1);
+        vl1.getNodeBreakerView().setFictitiousP0(0, FICTITIOUS_P0);
+        vl1.getNodeBreakerView().setFictitiousQ0(0, FICTITIOUS_Q0);
+        vl1.getNodeBreakerView().setFictitiousP0(7, FICTITIOUS_P0);
+        vl1.getNodeBreakerView().setFictitiousQ0(7, FICTITIOUS_Q0);
+
+        assertEquals(FICTITIOUS_P0, vl1.getNodeBreakerView().getFictitiousP0(0), EPSILON);
+        assertEquals(FICTITIOUS_Q0, vl1.getNodeBreakerView().getFictitiousQ0(0), EPSILON);
+
+        assertEquals(2 * FICTITIOUS_P0, vl1.getBusBreakerView().getBus("VL1_0").getFictitiousP0(), EPSILON);
+        assertEquals(2 * FICTITIOUS_Q0, vl1.getBusBreakerView().getBus("VL1_0").getFictitiousQ0(), EPSILON);
+
+        assertEquals(2 * FICTITIOUS_P0, vl1.getBusView().getBus("VL1_0").getFictitiousP0(), EPSILON);
+        assertEquals(2 * FICTITIOUS_Q0, vl1.getBusView().getBus("VL1_0").getFictitiousQ0(), EPSILON);
+
+        vl1.getNodeBreakerView().getSwitch("D3").setOpen(true);
+        assertEquals(FICTITIOUS_P0, vl1.getNodeBreakerView().getFictitiousP0(0), EPSILON);
+        assertEquals(FICTITIOUS_Q0, vl1.getNodeBreakerView().getFictitiousQ0(0), EPSILON);
+        assertEquals(FICTITIOUS_P0, vl1.getNodeBreakerView().getFictitiousP0(7), EPSILON);
+        assertEquals(FICTITIOUS_Q0, vl1.getNodeBreakerView().getFictitiousQ0(7), EPSILON);
+
+        assertEquals(FICTITIOUS_P0, vl1.getBusBreakerView().getBus("VL1_0").getFictitiousP0(), EPSILON);
+        assertEquals(FICTITIOUS_Q0, vl1.getBusBreakerView().getBus("VL1_0").getFictitiousQ0(), EPSILON);
+        assertEquals(FICTITIOUS_P0, vl1.getBusBreakerView().getBus("VL1_7").getFictitiousP0(), EPSILON);
+        assertEquals(FICTITIOUS_Q0, vl1.getBusBreakerView().getBus("VL1_7").getFictitiousQ0(), EPSILON);
+
+        assertEquals(FICTITIOUS_P0, vl1.getBusView().getBus("VL1_0").getFictitiousP0(), EPSILON);
+        assertEquals(FICTITIOUS_Q0, vl1.getBusView().getBus("VL1_0").getFictitiousQ0(), EPSILON);
+        assertEquals(FICTITIOUS_P0, vl1.getBusView().getBus("VL1_7").getFictitiousP0(), EPSILON);
+        assertEquals(FICTITIOUS_Q0, vl1.getBusView().getBus("VL1_7").getFictitiousQ0(), EPSILON);
+    }
+
+    @Test
+    public void testFictitiousInjectionsInBusBreaker() {
+        Network network = CreateNetworksUtil.createBusBreakerNetworkWithTwoBuses();
+        VoltageLevel vl1 = network.getVoltageLevel("VL1");
+
+        assertEquals(0., vl1.getBusBreakerView().getBus("B1").getFictitiousP0(), EPSILON);
+        assertEquals(0., vl1.getBusBreakerView().getBus("B1").getFictitiousQ0(), EPSILON);
+        assertEquals(0., vl1.getBusBreakerView().getBus("B2").getFictitiousP0(), EPSILON);
+        assertEquals(0., vl1.getBusBreakerView().getBus("B2").getFictitiousQ0(), EPSILON);
+
+        assertEquals(0., vl1.getBusView().getBus("VL1_0").getFictitiousP0(), EPSILON);
+        assertEquals(0., vl1.getBusView().getBus("VL1_0").getFictitiousQ0(), EPSILON);
+
+        vl1.getBusBreakerView().getBus("B2").setFictitiousP0(FICTITIOUS_P0);
+        vl1.getBusBreakerView().getBus("B2").setFictitiousQ0(FICTITIOUS_Q0);
+
+        assertEquals(0., vl1.getBusBreakerView().getBus("B1").getFictitiousP0(), EPSILON);
+        assertEquals(0., vl1.getBusBreakerView().getBus("B1").getFictitiousQ0(), EPSILON);
+        assertEquals(FICTITIOUS_P0, vl1.getBusBreakerView().getBus("B2").getFictitiousP0(), EPSILON);
+        assertEquals(FICTITIOUS_Q0, vl1.getBusBreakerView().getBus("B2").getFictitiousQ0(), EPSILON);
+
+        assertEquals(FICTITIOUS_P0, vl1.getBusView().getBus("VL1_0").getFictitiousP0(), EPSILON);
+        assertEquals(FICTITIOUS_Q0, vl1.getBusView().getBus("VL1_0").getFictitiousQ0(), EPSILON);
+    }
+
+    @Test
+    public void testFictitiousInjectionsInBusBreakerWithSeveralBusesAreReComputedAfterDisconnection() {
+        Network network = CreateNetworksUtil.createBusBreakerNetworkWithTwoBuses();
+        VoltageLevel vl1 = network.getVoltageLevel("VL1");
+        vl1.getBusBreakerView().getBus("B1").setFictitiousP0(FICTITIOUS_P0);
+        vl1.getBusBreakerView().getBus("B1").setFictitiousQ0(FICTITIOUS_Q0);
+        vl1.getBusBreakerView().getBus("B2").setFictitiousP0(FICTITIOUS_P0);
+        vl1.getBusBreakerView().getBus("B2").setFictitiousQ0(FICTITIOUS_Q0);
+
+        assertEquals(FICTITIOUS_P0, vl1.getBusBreakerView().getBus("B1").getFictitiousP0(), EPSILON);
+        assertEquals(FICTITIOUS_Q0, vl1.getBusBreakerView().getBus("B1").getFictitiousQ0(), EPSILON);
+        assertEquals(FICTITIOUS_P0, vl1.getBusBreakerView().getBus("B2").getFictitiousP0(), EPSILON);
+        assertEquals(FICTITIOUS_Q0, vl1.getBusBreakerView().getBus("B2").getFictitiousQ0(), EPSILON);
+
+        assertEquals(2 * FICTITIOUS_P0, vl1.getBusView().getBus("VL1_0").getFictitiousP0(), EPSILON);
+        assertEquals(2 * FICTITIOUS_Q0, vl1.getBusView().getBus("VL1_0").getFictitiousQ0(), EPSILON);
+
+        vl1.getBusBreakerView().getSwitch("BR1").setOpen(true);
+        assertEquals(FICTITIOUS_P0, vl1.getBusBreakerView().getBus("B1").getFictitiousP0(), EPSILON);
+        assertEquals(FICTITIOUS_Q0, vl1.getBusBreakerView().getBus("B1").getFictitiousQ0(), EPSILON);
+        assertEquals(FICTITIOUS_P0, vl1.getBusBreakerView().getBus("B2").getFictitiousP0(), EPSILON);
+        assertEquals(FICTITIOUS_Q0, vl1.getBusBreakerView().getBus("B2").getFictitiousQ0(), EPSILON);
+
+        assertEquals(FICTITIOUS_P0, vl1.getBusView().getBus("VL1_0").getFictitiousP0(), EPSILON);
+        assertEquals(FICTITIOUS_Q0, vl1.getBusView().getBus("VL1_0").getFictitiousQ0(), EPSILON);
+        assertEquals(FICTITIOUS_P0, vl1.getBusView().getBus("VL1_1").getFictitiousP0(), EPSILON);
+        assertEquals(FICTITIOUS_Q0, vl1.getBusView().getBus("VL1_1").getFictitiousQ0(), EPSILON);
+    }
+
+    private void addBusBarSection(VoltageLevel vl1) {
+        vl1.getNodeBreakerView().newBusbarSection()
+                .setId("BBS3")
+                .setNode(7)
+                .add();
+        vl1.getNodeBreakerView().newDisconnector()
+                .setId("D4")
+                .setNode1(7)
+                .setNode2(8)
+                .setOpen(false)
+                .add();
+        vl1.newGenerator()
+                .setId("G3")
+                .setNode(8)
+                .setMaxP(100.0)
+                .setMinP(50.0)
+                .setTargetP(100.0)
+                .setTargetV(400.0)
+                .setVoltageRegulatorOn(true)
+                .add();
+        vl1.getNodeBreakerView().newDisconnector()
+                .setId("D3")
+                .setNode1(0)
+                .setNode2(7)
+                .setOpen(false)
+                .add();
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Remove a hack that was setup due to performance issue. 

**What is the current behavior?**
<!-- You can also link to an open issue here -->

Now if an option is activated we don't compute fictitious bus P0 and Q0 and we just retuen 0. Otherwise it is computed correctly but it is not satisfying performance-wise.

**What is the new behavior (if this is a feature change)?**

We remove the option and compute everytime the proper fictitious P0 and Q0 for buses in reasonible computation time.

**Does this PR introduce a breaking change or deprecate an API?**
- [x] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [x] The *Breaking Change* or *Deprecated* label has been added
- [x] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->
.
Remove the use of useCalculatedBusFictitiousP0Q0 parameter

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
