### PR TITLE
Add SV attributes contract test

### DIFF
--- a/network-store-client/src/test/java/com/powsybl/network/store/client/JsonViewTest.java
+++ b/network-store-client/src/test/java/com/powsybl/network/store/client/JsonViewTest.java
@@ -116,4 +116,31 @@ class JsonViewTest {
         assertEquals(expectedWithLimitsResult, withLimitsResult);
     }
 
+    @Test
+    void testViewSerializationWithGround() throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+        GroundAttributes groundAttributes = GroundAttributes.builder()
+                .name("ground1")
+                .voltageLevelId("vl1")
+                .node(1)
+                .bus("bus1")
+                .connectableBus("cb1")
+                .p(1)
+                .q(2)
+                .build();
+
+        String primaryResultExpected = "{\"name\":\"ground1\",\"fictitious\":false,\"extensionAttributes\":{}," +
+                "\"voltageLevelId\":\"vl1\",\"node\":1,\"bus\":\"bus1\",\"connectableBus\":\"cb1\",\"p\":1.0,\"q\":2.0," +
+                "\"regulatingEquipments\":[]}";
+        String primaryResult = mapper
+                .writerWithView(AttributeFilter.JsonViews.Primary.class)
+                .writeValueAsString(groundAttributes);
+        assertEquals(primaryResultExpected, primaryResult);
+
+        String svResult = mapper
+                .writerWithView(AttributeFilter.JsonViews.OnlySv.class)
+                .writeValueAsString(groundAttributes);
+        assertEquals("{\"p\":1.0,\"q\":2.0}", svResult);
+    }
+
 }

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/ResourceDeserializer.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/ResourceDeserializer.java
@@ -57,7 +57,8 @@ public class ResourceDeserializer extends StdDeserializer<Resource> {
                     case NETWORK -> NetworkAttributes.class;
                     case SUBSTATION -> SubstationAttributes.class;
                     case VOLTAGE_LEVEL -> VoltageLevelSvAttributes.class;
-                    case LOAD, GENERATOR, BATTERY, VSC_CONVERTER_STATION, LCC_CONVERTER_STATION, SHUNT_COMPENSATOR, STATIC_VAR_COMPENSATOR, BOUNDARY_LINE ->
+                    case LOAD, GENERATOR, BATTERY, VSC_CONVERTER_STATION, LCC_CONVERTER_STATION, SHUNT_COMPENSATOR, STATIC_VAR_COMPENSATOR, BOUNDARY_LINE,
+                         GROUND ->
                         InjectionSvAttributes.class;
                     case BUSBAR_SECTION -> BusbarSectionAttributes.class;
                     case SWITCH -> SwitchAttributes.class;
@@ -65,7 +66,6 @@ public class ResourceDeserializer extends StdDeserializer<Resource> {
                     case THREE_WINDINGS_TRANSFORMER -> ThreeWindingsTransformerSvAttributes.class;
                     case HVDC_LINE -> HvdcLineAttributes.class;
                     case CONFIGURED_BUS -> ConfiguredBusAttributes.class;
-                    case GROUND -> GroundAttributes.class;
                     case TIE_LINE -> TieLineAttributes.class;
                     case AREA -> AreaAttributes.class;
                 };

--- a/network-store-model/src/main/java/com/powsybl/network/store/model/ResourceDeserializer.java
+++ b/network-store-model/src/main/java/com/powsybl/network/store/model/ResourceDeserializer.java
@@ -23,7 +23,7 @@ public class ResourceDeserializer extends StdDeserializer<Resource> {
         super(Resource.class);
     }
 
-    private static Class<? extends Attributes> getTypeClass(ResourceType type, AttributeFilter filter) {
+    static Class<? extends Attributes> getTypeClass(ResourceType type, AttributeFilter filter) {
         Objects.requireNonNull(type);
         // The client currently doesn't send AttributeFilter.LIMITS or AttributeFilter.FULL, but if it did
         // we don't want to reject it, we know we should deserialize to normal DTOs
@@ -65,7 +65,9 @@ public class ResourceDeserializer extends StdDeserializer<Resource> {
                     case THREE_WINDINGS_TRANSFORMER -> ThreeWindingsTransformerSvAttributes.class;
                     case HVDC_LINE -> HvdcLineAttributes.class;
                     case CONFIGURED_BUS -> ConfiguredBusAttributes.class;
-                    default -> throw new IllegalStateException("Unknown resource type: " + type);
+                    case GROUND -> GroundAttributes.class;
+                    case TIE_LINE -> TieLineAttributes.class;
+                    case AREA -> AreaAttributes.class;
                 };
             } else {
                 throw new IllegalStateException("Unknown attribute filter: " + filter);

--- a/network-store-model/src/test/java/com/powsybl/network/store/model/SvAttributesContractTest.java
+++ b/network-store-model/src/test/java/com/powsybl/network/store/model/SvAttributesContractTest.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2026, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.network.store.model;
+
+import com.fasterxml.jackson.annotation.JsonView;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author Antoine Bouhours <antoine.bouhours at rte-france.com>
+ */
+class SvAttributesContractTest {
+
+    @Test
+    void jsonViewSvFieldsShouldMatchDedicatedSvAttributes() {
+        for (ResourceType resourceType : ResourceType.values()) {
+            // Get SV attributes for resource type
+            Class<? extends Attributes> svAttributesType = ResourceDeserializer.getTypeClass(resourceType, AttributeFilter.SV);
+
+            // Get FULL attributes for resource type
+            Class<? extends Attributes> fullAttributesType = ResourceDeserializer.getTypeClass(resourceType, AttributeFilter.FULL);
+            if (fullAttributesType == svAttributesType) {
+                continue;
+            }
+
+            // Check that all annotated @JsonView(AttributeFilter.JsonViews.OnlySv.class) fields in the FULL view are present in the SV attributes and reciprocally
+            assertEquals(
+                    getJsonViewSvAnnotatedFieldNames(fullAttributesType),
+                    getFieldNames(svAttributesType),
+                    () -> resourceType + " should map " + fullAttributesType.getSimpleName()
+                            + " OnlySv fields to " + svAttributesType.getSimpleName()
+            );
+        }
+    }
+
+    private static Set<String> getJsonViewSvAnnotatedFieldNames(Class<?> attributesType) {
+        return Arrays.stream(attributesType.getDeclaredFields())
+                .filter(SvAttributesContractTest::isJsonViewSvAnnotatedField)
+                .map(Field::getName)
+                .collect(Collectors.toSet());
+    }
+
+    private static boolean isJsonViewSvAnnotatedField(Field field) {
+        JsonView jsonView = field.getAnnotation(JsonView.class);
+        return jsonView != null && Arrays.asList(jsonView.value()).contains(AttributeFilter.JsonViews.OnlySv.class);
+    }
+
+    private static Set<String> getFieldNames(Class<?> attributesType) {
+        return Arrays.stream(attributesType.getDeclaredFields())
+                .map(Field::getName)
+                .collect(Collectors.toSet());
+    }
+}

--- a/network-store-model/src/test/java/com/powsybl/network/store/model/SvAttributesContractTest.java
+++ b/network-store-model/src/test/java/com/powsybl/network/store/model/SvAttributesContractTest.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 /**
  * @author Antoine Bouhours <antoine.bouhours at rte-france.com>
@@ -29,13 +30,24 @@ class SvAttributesContractTest {
 
             // Get FULL attributes for resource type
             Class<? extends Attributes> fullAttributesType = ResourceDeserializer.getTypeClass(resourceType, AttributeFilter.FULL);
-            if (fullAttributesType == svAttributesType) {
+
+            // Continue if there is no @JsonView(AttributeFilter.JsonViews.OnlySv.class) in the FULL attribute
+            Set<String> jsonViewSvAnnotatedFieldNames = getJsonViewSvAnnotatedFieldNames(fullAttributesType);
+            if (jsonViewSvAnnotatedFieldNames.isEmpty()) {
                 continue;
             }
 
+            // Check that an attribute with @JsonView(AttributeFilter.JsonViews.OnlySv.class) fields has an SV attributes class
+            assertNotEquals(
+                    fullAttributesType,
+                    svAttributesType,
+                    () -> resourceType + " declares OnlySv fields in " + fullAttributesType.getSimpleName()
+                            + " but has no dedicated SV attributes class"
+            );
+
             // Check that all annotated @JsonView(AttributeFilter.JsonViews.OnlySv.class) fields in the FULL view are present in the SV attributes and reciprocally
             assertEquals(
-                    getJsonViewSvAnnotatedFieldNames(fullAttributesType),
+                    jsonViewSvAnnotatedFieldNames,
                     getFieldNames(svAttributesType),
                     () -> resourceType + " should map " + fullAttributesType.getSimpleName()
                             + " OnlySv fields to " + svAttributesType.getSimpleName()


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)

**Does this PR already have an issue describing the problem?**

No.

**What kind of change does this PR introduce?**

Test improvement.

**What is the current behavior?**

There is no automated contract test ensuring that fields annotated with `@JsonView(AttributeFilter.JsonViews.OnlySv.class)` stay aligned with the dedicated SV DTOs.

**What is the new behavior (if this is a feature change)?**

This PR adds a test which iterates over `ResourceType` values and uses `ResourceDeserializer.getTypeClass(...)` to derive the primary and SV DTOs. It verifies that `OnlySv` fields declared on the
full attributes class match the fields exposed by the corresponding dedicated SV DTO, without manually relisting all supported classes.
If we have JsonView annotations in a nested object, we would need another more complicated way of testing that.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
