### PR TITLE
Set default voltage regulator state to false for EQUIPMENT validation level in adder implementations

### DIFF
--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/GeneratorAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/GeneratorAdderImpl.java
@@ -117,6 +117,10 @@ class GeneratorAdderImpl extends AbstractInjectionAdder<GeneratorAdderImpl> impl
 
     @Override
     public Generator add() {
+        NetworkImpl network = getNetwork();
+        if (network.getMinValidationLevel() == ValidationLevel.EQUIPMENT && voltageRegulatorOn == null) {
+            voltageRegulatorOn = false;
+        }
         String id = checkAndGetUniqueId();
         checkNodeBus();
         ValidationUtil.checkEnergySource(this, energySource);

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/StaticVarCompensatorAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/StaticVarCompensatorAdderImpl.java
@@ -22,7 +22,7 @@ public class StaticVarCompensatorAdderImpl extends AbstractInjectionAdder<Static
 
     private double reactivePowerSetPoint = Double.NaN;
 
-    private boolean regulating = false;
+    private Boolean regulating;
 
     StaticVarCompensator.RegulationMode regulationMode = StaticVarCompensator.RegulationMode.VOLTAGE;
 
@@ -76,6 +76,10 @@ public class StaticVarCompensatorAdderImpl extends AbstractInjectionAdder<Static
 
     @Override
     public StaticVarCompensator add() {
+        NetworkImpl network = getNetwork();
+        if (network.getMinValidationLevel() == ValidationLevel.EQUIPMENT && regulating == null) {
+            regulating = false;
+        }
         String id = checkAndGetUniqueId();
         checkNodeBus();
         ValidationUtil.checkBmin(this, bMin);

--- a/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/VscConverterStationAdderImpl.java
+++ b/network-store-iidm-impl/src/main/java/com/powsybl/network/store/iidm/impl/VscConverterStationAdderImpl.java
@@ -52,6 +52,10 @@ public class VscConverterStationAdderImpl extends AbstractHvdcConverterStationAd
 
     @Override
     public VscConverterStation add() {
+        NetworkImpl network = getNetwork();
+        if (network.getMinValidationLevel() == ValidationLevel.EQUIPMENT && voltageRegulatorOn == null) {
+            voltageRegulatorOn = false;
+        }
         String id = checkAndGetUniqueId();
         checkNodeBus();
         validate();

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/CreateNetworksUtil.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/CreateNetworksUtil.java
@@ -261,6 +261,7 @@ public final class CreateNetworksUtil {
                 .setBmax(0.0008)
                 .setReactivePowerSetpoint(200)
                 .setRegulationMode(StaticVarCompensator.RegulationMode.VOLTAGE)
+                .setRegulating(false)
                 .setVoltageSetpoint(390)
                 .add();
         svc.getTerminal().setP(435);

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/GeneratorTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/GeneratorTest.java
@@ -147,4 +147,31 @@ class GeneratorTest {
         network.setMinimumAcceptableValidationLevel(ValidationLevel.EQUIPMENT);
         generator.setTargetQ(Double.NaN);
     }
+
+    @Test
+    void undefinedVoltageRegulatorOnWithEquipmentValidationLevel() {
+        Network network = Network.create("test", "test");
+        network.setMinimumAcceptableValidationLevel(ValidationLevel.EQUIPMENT);
+        VoltageLevel voltageLevel = network.newSubstation()
+                .setId("S1")
+                .setCountry(Country.FR)
+                .add()
+                .newVoltageLevel()
+                .setId("VL1")
+                .setNominalV(400.0)
+                .setTopologyKind(TopologyKind.NODE_BREAKER)
+                .add();
+
+        Generator generator = voltageLevel.newGenerator()
+                .setId("GEN")
+                .setMaxP(Double.MAX_VALUE)
+                .setMinP(-Double.MAX_VALUE)
+                .setTargetP(30.0)
+                .setTargetQ(40.0)
+                .setNode(0)
+                .add();
+
+        assertFalse(generator.isVoltageRegulatorOn());
+        assertEquals(ValidationLevel.STEADY_STATE_HYPOTHESIS, network.getValidationLevel());
+    }
 }

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/RegulatingTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/RegulatingTest.java
@@ -87,6 +87,7 @@ class RegulatingTest {
                 .setReactivePowerSetpoint(200)
                 .setRegulationMode(StaticVarCompensator.RegulationMode.VOLTAGE)
                 .setVoltageSetpoint(390)
+                .setRegulating(false)
                 .add();
         vl1.newStaticVarCompensator().setId("SVC1").setEnsureIdUnicity(true).setNode(1)
                 .setBmin(0.0002)
@@ -94,6 +95,7 @@ class RegulatingTest {
                 .setReactivePowerSetpoint(200)
                 .setRegulationMode(StaticVarCompensator.RegulationMode.VOLTAGE)
                 .setVoltageSetpoint(390)
+                .setRegulating(false)
                 .add();
 
         Assertions.assertEquals("SVC1", network.getStaticVarCompensator("SVC1").getRegulatingTerminal().getConnectable().getId());

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/StaticVarCompensatorTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/StaticVarCompensatorTest.java
@@ -108,13 +108,13 @@ class StaticVarCompensatorTest {
                 .setTopologyKind(TopologyKind.NODE_BREAKER)
                 .add();
 
-        ValidationException e = assertThrows(ValidationException.class, () -> voltageLevel.newStaticVarCompensator()
+        StaticVarCompensatorAdder svc3 = voltageLevel.newStaticVarCompensator()
                 .setId("SVC3")
                 .setNode(0)
                 .setBmin(0.0002)
                 .setBmax(0.0008)
-                .setReactivePowerSetpoint(1.0)
-                .add());
+                .setReactivePowerSetpoint(1.0);
+        ValidationException e = assertThrows(ValidationException.class, svc3::add);
 
         assertEquals("Static var compensator 'SVC3': regulating is not set", e.getMessage());
     }

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/StaticVarCompensatorTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/StaticVarCompensatorTest.java
@@ -6,10 +6,7 @@
  */
 package com.powsybl.network.store.iidm.impl;
 
-import com.powsybl.iidm.network.Network;
-import com.powsybl.iidm.network.StaticVarCompensator;
-import com.powsybl.iidm.network.ValidationException;
-import com.powsybl.iidm.network.ValidationLevel;
+import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.extensions.*;
 import com.powsybl.iidm.network.test.FourSubstationsNodeBreakerFactory;
 import org.junit.jupiter.api.Test;
@@ -70,5 +67,31 @@ class StaticVarCompensatorTest {
                 assertThrows(ValidationException.class, () -> svc.setReactivePowerSetpoint(Double.NaN)).getMessage());
         network.setMinimumAcceptableValidationLevel(ValidationLevel.EQUIPMENT);
         svc.setReactivePowerSetpoint(Double.NaN);
+    }
+
+    @Test
+    void undefinedRegulatingWithEquipmentValidationLevel() {
+        Network network = Network.create("test", "test");
+        network.setMinimumAcceptableValidationLevel(ValidationLevel.EQUIPMENT);
+        VoltageLevel voltageLevel = network.newSubstation()
+                .setId("S1")
+                .setCountry(Country.FR)
+                .add()
+                .newVoltageLevel()
+                .setId("VL1")
+                .setNominalV(400.0)
+                .setTopologyKind(TopologyKind.NODE_BREAKER)
+                .add();
+
+        StaticVarCompensator svc = voltageLevel.newStaticVarCompensator()
+                .setId("SVC3")
+                .setNode(0)
+                .setBmin(0.0002)
+                .setBmax(0.0008)
+                .setReactivePowerSetpoint(1.0)
+                .add();
+
+        assertFalse(svc.isRegulating());
+        assertEquals(ValidationLevel.STEADY_STATE_HYPOTHESIS, network.getValidationLevel());
     }
 }

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/StaticVarCompensatorTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/StaticVarCompensatorTest.java
@@ -94,4 +94,28 @@ class StaticVarCompensatorTest {
         assertFalse(svc.isRegulating());
         assertEquals(ValidationLevel.STEADY_STATE_HYPOTHESIS, network.getValidationLevel());
     }
+
+    @Test
+    void undefinedRegulating() {
+        Network network = Network.create("test", "test");
+        VoltageLevel voltageLevel = network.newSubstation()
+                .setId("S1")
+                .setCountry(Country.FR)
+                .add()
+                .newVoltageLevel()
+                .setId("VL1")
+                .setNominalV(400.0)
+                .setTopologyKind(TopologyKind.NODE_BREAKER)
+                .add();
+
+        ValidationException e = assertThrows(ValidationException.class, () -> voltageLevel.newStaticVarCompensator()
+                .setId("SVC3")
+                .setNode(0)
+                .setBmin(0.0002)
+                .setBmax(0.0008)
+                .setReactivePowerSetpoint(1.0)
+                .add());
+
+        assertEquals("Static var compensator 'SVC3': regulating is not set", e.getMessage());
+    }
 }

--- a/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/VscConverterStationTest.java
+++ b/network-store-iidm-impl/src/test/java/com/powsybl/network/store/iidm/impl/VscConverterStationTest.java
@@ -6,10 +6,7 @@
  */
 package com.powsybl.network.store.iidm.impl;
 
-import com.powsybl.iidm.network.Network;
-import com.powsybl.iidm.network.ValidationException;
-import com.powsybl.iidm.network.ValidationLevel;
-import com.powsybl.iidm.network.VscConverterStation;
+import com.powsybl.iidm.network.*;
 import com.powsybl.iidm.network.extensions.ConnectablePosition;
 import com.powsybl.iidm.network.extensions.ConnectablePositionAdder;
 import com.powsybl.iidm.network.test.FourSubstationsNodeBreakerFactory;
@@ -65,5 +62,30 @@ class VscConverterStationTest {
                 assertThrows(ValidationException.class, () -> vscConverterStation.setReactivePowerSetpoint(Double.NaN)).getMessage());
         network.setMinimumAcceptableValidationLevel(ValidationLevel.EQUIPMENT);
         vscConverterStation.setReactivePowerSetpoint(Double.NaN);
+    }
+
+    @Test
+    void testVscConverterStationAdderWithoutVoltageRegulatorOnWithEquipmentValidationLevel() {
+        Network network = Network.create("test", "test");
+        network.setMinimumAcceptableValidationLevel(ValidationLevel.EQUIPMENT);
+        VoltageLevel voltageLevel = network.newSubstation()
+                .setId("S1")
+                .setCountry(Country.FR)
+                .add()
+                .newVoltageLevel()
+                .setId("VL1")
+                .setNominalV(400.0)
+                .setTopologyKind(TopologyKind.NODE_BREAKER)
+                .add();
+
+        VscConverterStation converterStation = voltageLevel.newVscConverterStation()
+                .setId("C4")
+                .setNode(0)
+                .setReactivePowerSetpoint(123)
+                .setLossFactor(1.1f)
+                .add();
+
+        assertFalse(converterStation.isVoltageRegulatorOn());
+        assertEquals(ValidationLevel.STEADY_STATE_HYPOTHESIS, network.getValidationLevel());
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Since [powsybl-core#3264](https://github.com/powsybl/powsybl-core/pull/3264), some regulating equipments can be created first without voltage regulation / regulating explicitly set, and then updated later during import.

In powsybl-core this is handled at `ValidationLevel.EQUIPMENT` by defaulting the missing flag to `false` (introduced in https://github.com/powsybl/powsybl-core/pull/1819), for example:

```java
if (network.getMinValidationLevel() == ValidationLevel.EQUIPMENT && regulating == null) {
    regulating = false;
}
```

This behavior was missing in network-store, which caused some CGMES files to fail during import with errors like: 
```
Generator 'GEN': voltage regulator status is not set
```

I also opened [powsybl-core#3967](https://github.com/powsybl/powsybl-core/pull/3967) to add the matching TCK coverage on the core side.

